### PR TITLE
✨ Add remote server auth token and TLS endpoint support

### DIFF
--- a/OrbitDock/OrbitDock/Services/Server/ServerConnection.swift
+++ b/OrbitDock/OrbitDock/Services/Server/ServerConnection.swift
@@ -366,6 +366,7 @@ class ServerConnection: ObservableObject {
 
   let endpointId: UUID
   let endpointName: String
+  private let authToken: String?
 
   @Published private(set) var status: ConnectionStatus = .disconnected
   @Published private(set) var lastError: String?
@@ -472,6 +473,7 @@ class ServerConnection: ObservableObject {
   init(endpoint: ServerEndpoint) {
     endpointId = endpoint.id
     endpointName = endpoint.name
+    authToken = endpoint.authToken
     serverURL = endpoint.wsURL
     queuedConversationMessagesDefaultsKey = "orbitdock.queued-conversation-messages.\(endpoint.id.uuidString)"
     restoreQueuedConversationMessages()
@@ -540,7 +542,19 @@ class ServerConnection: ObservableObject {
     configuration.timeoutIntervalForResource = 0 // No resource timeout (WebSocket is long-lived)
     session = URLSession(configuration: configuration)
 
-    webSocket = session?.webSocketTask(with: serverURL)
+    let wsURL: URL = {
+      guard let authToken, !authToken.isEmpty,
+            var components = URLComponents(url: serverURL, resolvingAgainstBaseURL: false)
+      else {
+        return serverURL
+      }
+      var items = components.queryItems ?? []
+      items.append(URLQueryItem(name: "token", value: authToken))
+      components.queryItems = items
+      return components.url ?? serverURL
+    }()
+
+    webSocket = session?.webSocketTask(with: wsURL)
     webSocket?.maximumMessageSize = Self.maxInboundWebSocketMessageBytes
     webSocket?.resume()
     startReceiving()
@@ -1986,6 +2000,12 @@ class ServerConnection: ObservableObject {
     }
   }
 
+  private func applyAuth(to request: inout URLRequest) {
+    if let authToken, !authToken.isEmpty {
+      request.setValue("Bearer \(authToken)", forHTTPHeaderField: "Authorization")
+    }
+  }
+
   private func requestAPIJSON<Response: Decodable>(
     path: String,
     method: String,
@@ -1998,6 +2018,7 @@ class ServerConnection: ObservableObject {
     var request = URLRequest(url: url)
     request.httpMethod = method
     request.timeoutInterval = 15
+    applyAuth(to: &request)
 
     let (data, response) = try await URLSession.shared.data(for: request)
     guard let http = response as? HTTPURLResponse else {
@@ -2028,6 +2049,7 @@ class ServerConnection: ObservableObject {
     request.httpMethod = method
     request.timeoutInterval = 15
     request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+    applyAuth(to: &request)
 
     let encoder = JSONEncoder()
     encoder.keyEncodingStrategy = .convertToSnakeCase
@@ -2062,6 +2084,7 @@ class ServerConnection: ObservableObject {
     request.httpMethod = method
     request.timeoutInterval = 15
     request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+    applyAuth(to: &request)
 
     let encoder = JSONEncoder()
     encoder.keyEncodingStrategy = .convertToSnakeCase
@@ -2095,6 +2118,7 @@ class ServerConnection: ObservableObject {
     request.httpMethod = method
     request.timeoutInterval = 15
     request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+    applyAuth(to: &request)
     request.httpBody = bodyData
 
     let (data, response) = try await URLSession.shared.data(for: request)

--- a/OrbitDock/OrbitDock/Services/Server/ServerEndpoint.swift
+++ b/OrbitDock/OrbitDock/Services/Server/ServerEndpoint.swift
@@ -7,6 +7,7 @@ struct ServerEndpoint: Codable, Equatable, Hashable, Identifiable {
   var isLocalManaged: Bool
   var isEnabled: Bool
   var isDefault: Bool
+  var authToken: String?
 
   init(
     id: UUID = UUID(),
@@ -14,7 +15,8 @@ struct ServerEndpoint: Codable, Equatable, Hashable, Identifiable {
     wsURL: URL,
     isLocalManaged: Bool,
     isEnabled: Bool = true,
-    isDefault: Bool = false
+    isDefault: Bool = false,
+    authToken: String? = nil
   ) {
     self.id = id
     self.name = name
@@ -22,6 +24,7 @@ struct ServerEndpoint: Codable, Equatable, Hashable, Identifiable {
     self.isLocalManaged = isLocalManaged
     self.isEnabled = isEnabled
     self.isDefault = isDefault
+    self.authToken = authToken
   }
 
   var isRemote: Bool {

--- a/OrbitDock/OrbitDock/Services/Server/ServerEndpointStore.swift
+++ b/OrbitDock/OrbitDock/Services/Server/ServerEndpointStore.swift
@@ -165,25 +165,48 @@ struct ServerEndpointStore {
     let trimmed = input.trimmingCharacters(in: .whitespacesAndNewlines)
     guard !trimmed.isEmpty else { return nil }
 
-    let hostPort: String = if trimmed.hasPrefix("ws://") {
-      String(trimmed.dropFirst(5))
-    } else if trimmed.hasPrefix("wss://") {
-      String(trimmed.dropFirst(6))
+    let forceSecure: Bool
+    let hostPort: String
+
+    if trimmed.hasPrefix("wss://") {
+      forceSecure = true
+      hostPort = String(trimmed.dropFirst(6))
+    } else if trimmed.hasPrefix("https://") {
+      forceSecure = true
+      hostPort = String(trimmed.dropFirst(8))
+    } else if trimmed.hasPrefix("ws://") {
+      forceSecure = false
+      hostPort = String(trimmed.dropFirst(5))
     } else if trimmed.hasPrefix("http://") {
-      String(trimmed.dropFirst(7))
+      forceSecure = false
+      hostPort = String(trimmed.dropFirst(7))
     } else {
-      trimmed
+      forceSecure = false
+      hostPort = trimmed
     }
 
     let clean = hostPort.split(separator: "/").first.map(String.init) ?? hostPort
     guard !clean.isEmpty else { return nil }
 
-    let withPort = clean.contains(":") ? clean : "\(clean):\(defaultPort)"
-    return URL(string: "ws://\(withPort)/ws")
+    if forceSecure {
+      // TLS — use wss://, no default port (443 is implicit)
+      return URL(string: "wss://\(clean)/ws")
+    } else {
+      // Plain — use ws:// with default port fallback
+      let withPort = clean.contains(":") ? clean : "\(clean):\(defaultPort)"
+      return URL(string: "ws://\(withPort)/ws")
+    }
   }
 
   static func hostInput(from url: URL, defaultPort: Int) -> String? {
     guard let host = url.host else { return nil }
+    let isSecure = url.scheme == "wss"
+    if isSecure {
+      if let port = url.port {
+        return "https://\(host):\(port)"
+      }
+      return "https://\(host)"
+    }
     if let port = url.port, port != defaultPort {
       return "\(host):\(port)"
     }

--- a/OrbitDock/OrbitDock/Views/ServerSettingsSheet.swift
+++ b/OrbitDock/OrbitDock/Views/ServerSettingsSheet.swift
@@ -26,6 +26,7 @@ struct ServerSettingsSheet: View {
   @State private var draftIsEnabled = true
   @State private var draftIsDefault = false
   @State private var draftIsLocalManaged = false
+  @State private var draftAuthToken = ""
   @State private var editorError: String?
   @State private var endpointPendingDelete: ServerEndpoint?
 
@@ -362,7 +363,7 @@ struct ServerSettingsSheet: View {
 
             // Host field
             editorField(label: "Host") {
-              TextField("10.0.0.5 or 10.0.0.5:4100", text: $draftHostInput)
+              TextField("10.0.0.5:4000 or https://host.example", text: $draftHostInput)
                 .textFieldStyle(.plain)
                 .font(.system(size: TypeScale.body, design: .monospaced))
               #if os(iOS)
@@ -379,6 +380,22 @@ struct ServerSettingsSheet: View {
                 .padding(.horizontal, Spacing.lg)
                 .padding(.bottom, Spacing.md)
                 .padding(.top, -Spacing.xs)
+            }
+
+            if !draftIsLocalManaged {
+              Divider()
+                .overlay(Color.panelBorder)
+
+              // Auth token field
+              editorField(label: "Auth Token") {
+                SecureField("Paste token", text: $draftAuthToken)
+                  .textFieldStyle(.plain)
+                  .font(.system(size: TypeScale.body, design: .monospaced))
+                #if os(iOS)
+                  .textInputAutocapitalization(.never)
+                #endif
+                  .autocorrectionDisabled()
+              }
             }
 
             Divider()
@@ -587,6 +604,7 @@ struct ServerSettingsSheet: View {
     editingEndpointId = nil
     draftName = ""
     draftHostInput = ""
+    draftAuthToken = ""
     draftIsEnabled = true
     draftIsDefault = endpoints.first(where: \.isDefault) == nil
     draftIsLocalManaged = false
@@ -598,6 +616,7 @@ struct ServerSettingsSheet: View {
     editingEndpointId = endpoint.id
     draftName = endpoint.name
     draftHostInput = ServerEndpointSettings.hostInput(from: endpoint.wsURL) ?? endpoint.wsURL.host ?? ""
+    draftAuthToken = endpoint.authToken ?? ""
     draftIsEnabled = endpoint.isEnabled
     draftIsDefault = endpoint.isDefault
     draftIsLocalManaged = endpoint.isLocalManaged
@@ -608,6 +627,7 @@ struct ServerSettingsSheet: View {
   private func closeEditor() {
     showEditor = false
     editorError = nil
+    draftAuthToken = ""
   }
 
   private func saveEditor() {
@@ -627,20 +647,22 @@ struct ServerSettingsSheet: View {
         .localDefault(defaultPort: ServerEndpointSettings.defaultPort).wsURL
     } else {
       guard let built = ServerEndpointSettings.buildURL(from: draftHostInput) else {
-        editorError = "Enter a valid host (for example 10.0.0.5 or 10.0.0.5:4100)."
+        editorError = "Enter a valid host (e.g. 10.0.0.5:4000 or https://host.example)."
         return
       }
       resolvedURL = built
     }
 
     var updated = endpoints
+    let trimmedToken = draftAuthToken.trimmingCharacters(in: .whitespacesAndNewlines)
     let endpoint = ServerEndpoint(
       id: endpointId,
       name: trimmedName,
       wsURL: resolvedURL,
       isLocalManaged: isLocalManaged,
       isEnabled: draftIsEnabled,
-      isDefault: draftIsEnabled && draftIsDefault
+      isDefault: draftIsEnabled && draftIsDefault,
+      authToken: trimmedToken.isEmpty ? nil : trimmedToken
     )
 
     if let index = updated.firstIndex(where: { $0.id == endpointId }) {


### PR DESCRIPTION
## Summary
- Add `authToken` property to `ServerEndpoint` for optional Bearer token authentication
- Support `wss://` and `https://` URL prefixes for TLS endpoint connections
- Apply auth token to REST requests (Authorization header) and WebSocket connections (?token query param)
- Add Auth Token field to endpoint editor UI (SecureField, hidden for local-managed endpoints)
- Fix `hostInput` round-trip to preserve TLS scheme on edit-save cycles

## Commits
- `3335946` ✨ Add remote server auth token and TLS endpoint support

## Validation
- `make lint` (swiftformat clean, no Rust changes in this PR)

## Notes
- Auth token is stored in UserDefaults alongside other endpoint data. Keychain storage is a future improvement.
- WebSocket uses query param for auth because `URLSessionWebSocketTask` does not support custom headers on the upgrade request.