### PR TITLE
💄 Normalize provider pill sizing in composer status row

### DIFF
--- a/OrbitDock/OrbitDock/Views/Claude/ClaudePermissionPicker.swift
+++ b/OrbitDock/OrbitDock/Views/Claude/ClaudePermissionPicker.swift
@@ -69,7 +69,55 @@ enum ClaudePermissionMode: String, CaseIterable, Identifiable {
 // MARK: - Compact Permission Pill
 
 struct ClaudePermissionPill: View {
+  enum PillSize {
+    case regular
+    case statusBar
+
+    var iconFontSize: CGFloat {
+      switch self {
+        case .regular: TypeScale.body
+        case .statusBar: 9
+      }
+    }
+
+    var textFontSize: CGFloat {
+      switch self {
+        case .regular: TypeScale.body
+        case .statusBar: 10
+      }
+    }
+
+    var horizontalPadding: CGFloat {
+      switch self {
+        case .regular: CGFloat(Spacing.md)
+        case .statusBar: 6
+      }
+    }
+
+    var verticalPadding: CGFloat {
+      switch self {
+        case .regular: CGFloat(Spacing.sm)
+        case .statusBar: 3
+      }
+    }
+
+    var spacing: CGFloat {
+      switch self {
+        case .regular: CGFloat(Spacing.xs)
+        case .statusBar: 3
+      }
+    }
+
+    var height: CGFloat? {
+      switch self {
+        case .regular: nil
+        case .statusBar: 20
+      }
+    }
+  }
+
   let sessionId: String
+  var size: PillSize = .regular
   @Environment(ServerAppState.self) private var serverState
   @State private var showPopover = false
 
@@ -81,15 +129,16 @@ struct ClaudePermissionPill: View {
     Button {
       showPopover.toggle()
     } label: {
-      HStack(spacing: Spacing.xs) {
+      HStack(spacing: size.spacing) {
         Image(systemName: currentMode.icon)
-          .font(.system(size: TypeScale.body, weight: .semibold))
+          .font(.system(size: size.iconFontSize, weight: .semibold))
         Text(currentMode.displayName)
-          .font(.system(size: TypeScale.body, weight: .semibold))
+          .font(.system(size: size.textFontSize, weight: .semibold))
       }
       .foregroundStyle(currentMode.color)
-      .padding(.horizontal, Spacing.md)
-      .padding(.vertical, Spacing.sm)
+      .padding(.horizontal, size.horizontalPadding)
+      .padding(.vertical, size.verticalPadding)
+      .frame(height: size.height)
       .background(currentMode.color.opacity(OpacityTier.light), in: Capsule())
     }
     .buttonStyle(.plain)

--- a/OrbitDock/OrbitDock/Views/Codex/AutonomyPicker.swift
+++ b/OrbitDock/OrbitDock/Views/Codex/AutonomyPicker.swift
@@ -142,7 +142,55 @@ enum AutonomyLevel: String, CaseIterable, Identifiable {
 // MARK: - Compact Autonomy Pill
 
 struct AutonomyPill: View {
+  enum PillSize {
+    case regular
+    case statusBar
+
+    var iconFontSize: CGFloat {
+      switch self {
+        case .regular: TypeScale.body
+        case .statusBar: 9
+      }
+    }
+
+    var textFontSize: CGFloat {
+      switch self {
+        case .regular: TypeScale.body
+        case .statusBar: 10
+      }
+    }
+
+    var horizontalPadding: CGFloat {
+      switch self {
+        case .regular: CGFloat(Spacing.md)
+        case .statusBar: 6
+      }
+    }
+
+    var verticalPadding: CGFloat {
+      switch self {
+        case .regular: CGFloat(Spacing.sm)
+        case .statusBar: 3
+      }
+    }
+
+    var spacing: CGFloat {
+      switch self {
+        case .regular: CGFloat(Spacing.xs)
+        case .statusBar: 3
+      }
+    }
+
+    var height: CGFloat? {
+      switch self {
+        case .regular: nil
+        case .statusBar: 20
+      }
+    }
+  }
+
   let sessionId: String
+  var size: PillSize = .regular
   @Environment(ServerAppState.self) private var serverState
   @State private var showPopover = false
 
@@ -158,19 +206,20 @@ struct AutonomyPill: View {
     Button {
       showPopover.toggle()
     } label: {
-      HStack(spacing: Spacing.xs) {
+      HStack(spacing: size.spacing) {
         Image(systemName: currentLevel.icon)
-          .font(.system(size: TypeScale.body, weight: .semibold))
+          .font(.system(size: size.iconFontSize, weight: .semibold))
         Text(currentLevel.displayName)
-          .font(.system(size: TypeScale.body, weight: .semibold))
+          .font(.system(size: size.textFontSize, weight: .semibold))
         if !isConfiguredOnServer {
           Image(systemName: "exclamationmark.circle.fill")
             .font(.system(size: TypeScale.caption, weight: .semibold))
         }
       }
       .foregroundStyle(currentLevel.color)
-      .padding(.horizontal, Spacing.md)
-      .padding(.vertical, Spacing.sm)
+      .padding(.horizontal, size.horizontalPadding)
+      .padding(.vertical, size.verticalPadding)
+      .frame(height: size.height)
       .background(currentLevel.color.opacity(OpacityTier.light), in: Capsule())
     }
     .buttonStyle(.plain)

--- a/OrbitDock/OrbitDock/Views/Codex/DirectSessionComposer.swift
+++ b/OrbitDock/OrbitDock/Views/Codex/DirectSessionComposer.swift
@@ -1022,9 +1022,9 @@ struct DirectSessionComposer: View {
       }
 
       if obs.isDirectCodex {
-        AutonomyPill(sessionId: sessionId)
+        AutonomyPill(sessionId: sessionId, size: .statusBar)
       } else if obs.isDirectClaude {
-        ClaudePermissionPill(sessionId: sessionId)
+        ClaudePermissionPill(sessionId: sessionId, size: .statusBar)
       }
 
       if isSessionWorking {
@@ -1047,8 +1047,8 @@ struct DirectSessionComposer: View {
     }
     .frame(maxWidth: .infinity, alignment: .leading)
     .padding(.horizontal, Spacing.lg + 10)
-    .padding(.top, -2)
-    .padding(.bottom, 6)
+    .padding(.top, 1)
+    .padding(.bottom, 9)
   }
 
   private var compactStatusBar: some View {
@@ -1059,9 +1059,9 @@ struct DirectSessionComposer: View {
         }
 
         if obs.isDirectCodex {
-          AutonomyPill(sessionId: sessionId)
+          AutonomyPill(sessionId: sessionId, size: .statusBar)
         } else if obs.isDirectClaude {
-          ClaudePermissionPill(sessionId: sessionId)
+          ClaudePermissionPill(sessionId: sessionId, size: .statusBar)
         }
 
         if isSessionWorking {


### PR DESCRIPTION
## Summary
- add compact status-row sizing variants for Codex autonomy and Claude permission pills
- apply compact provider-pill sizing only in the composer metadata row below the input
- add a bit more desktop-only status-row vertical padding for breathing room

## Validation
- make build (Build Succeeded)
- make fmt
- make lint
- verified in a fresh Xcode run that the first provider pill now matches neighboring chip height in the bottom status row

## Screenshots
<img width="285" height="137" alt="image" src="https://github.com/user-attachments/assets/b8b5016b-53a0-461d-8bc3-cf0c115d91a6" />