### PR TITLE
♻️ Unify PATH setup via server CLI

### DIFF
--- a/OrbitDock/OrbitDock/Services/Server/ServerManager.swift
+++ b/OrbitDock/OrbitDock/Services/Server/ServerManager.swift
@@ -152,11 +152,12 @@ enum ServerInstallState: Equatable {
     /// Full setup sequence:
     /// 1. Find binary
     /// 2. Copy to ~/.orbitdock/bin/ (if from bundle)
-    /// 3. Run `orbitdock-server init`
-    /// 4. Run `orbitdock-server install-hooks`
-    /// 5. Run `orbitdock-server install-service --enable`
-    /// 6. Wait for health check
-    /// 7. Refresh state
+    /// 3. Run `orbitdock-server ensure-path`
+    /// 4. Run `orbitdock-server init`
+    /// 5. Run `orbitdock-server install-hooks`
+    /// 6. Run `orbitdock-server install-service --enable`
+    /// 7. Wait for health check
+    /// 8. Refresh state
     func install() async throws {
       isInstalling = true
       installError = nil
@@ -201,6 +202,14 @@ enum ServerInstallState: Equatable {
         }
       } else {
         binaryPath = sourcePath
+      }
+
+      // Ensure CLI binary directory is persisted on PATH (non-fatal for older binaries)
+      do {
+        try await runCLI(binaryPath, arguments: ["ensure-path"])
+        logger.info("orbitdock-server ensure-path completed")
+      } catch {
+        logger.warning("orbitdock-server ensure-path failed: \(error.localizedDescription)")
       }
 
       // Run init

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Get this running locally in a few minutes.
 curl -fsSL https://raw.githubusercontent.com/Robdel12/OrbitDock/main/orbitdock-server/install.sh | bash
 ```
 
-The installer sets up the binary, data directory, database, Claude hooks, and background service.
+The installer sets up the binary, shell `PATH`, data directory, database, Claude hooks, and background service.
 
 ### 2. Verify it started
 

--- a/orbitdock-server/README.md
+++ b/orbitdock-server/README.md
@@ -17,6 +17,7 @@ curl -fsSL https://raw.githubusercontent.com/Robdel12/OrbitDock/main/orbitdock-s
 The installer downloads a prebuilt binary for macOS, Linux x86_64, and Linux aarch64 (Raspberry Pi 64-bit). Falls back to building from source if no prebuilt is available (requires the [Rust toolchain](https://rustup.rs)).
 
 - Installs `orbitdock-server` to `~/.orbitdock/bin/`
+- Ensures `~/.orbitdock/bin` is on shell `PATH`
 - Runs `orbitdock-server init`
 - Runs `orbitdock-server install-hooks`
 - Runs `orbitdock-server install-service --enable`
@@ -140,6 +141,7 @@ orbitdock-server [--data-dir PATH] <command>
 | `start` | Start the server (also the default when you omit the subcommand) |
 | `setup` | Interactive wizard (init + hooks + token + service) |
 | `init` | Create data directory and run migrations |
+| `ensure-path` | Persist the server binary directory on your shell `PATH` |
 | `install-hooks` | Merge OrbitDock hooks into `~/.claude/settings.json` |
 | `install-service` | Generate a launchd plist (macOS) or systemd unit (Linux) |
 | `status` | Check if the server is running |

--- a/orbitdock-server/crates/server/src/cmd_ensure_path.rs
+++ b/orbitdock-server/crates/server/src/cmd_ensure_path.rs
@@ -1,0 +1,247 @@
+//! `orbitdock-server ensure-path` — ensure the server binary directory is on PATH.
+//!
+//! Adds the current binary directory to a shell profile when missing so
+//! `orbitdock-server` is easy to run from terminal sessions.
+
+use std::ffi::OsStr;
+use std::fs::OpenOptions;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+use anyhow::{anyhow, Context};
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum ShellKind {
+    Zsh,
+    Bash,
+    Fish,
+    Other,
+}
+
+pub fn run() -> anyhow::Result<()> {
+    let binary_path = std::env::current_exe().context("failed to resolve current executable")?;
+    let bin_dir = binary_path.parent().ok_or_else(|| {
+        anyhow!(
+            "failed to resolve binary directory from {}",
+            binary_path.display()
+        )
+    })?;
+    let home_dir = dirs::home_dir().ok_or_else(|| anyhow!("HOME directory not found"))?;
+    let shell_kind = detect_shell_kind(std::env::var("SHELL").ok().as_deref());
+    let profile_path = profile_path_for_shell(&home_dir, shell_kind);
+
+    if path_has_entry(std::env::var("PATH").ok().as_deref(), bin_dir) {
+        println!();
+        println!("  PATH already includes {}", bin_dir.display());
+        println!();
+        return Ok(());
+    }
+
+    if profile_contains_bin_dir(&profile_path, bin_dir)? {
+        println!();
+        println!("  PATH entry already present in {}", profile_path.display());
+        println!();
+        return Ok(());
+    }
+
+    let line = render_path_line(shell_kind, bin_dir);
+    append_profile_entry(&profile_path, &line)?;
+
+    println!();
+    println!(
+        "  Added {} to PATH in {}",
+        bin_dir.display(),
+        profile_path.display()
+    );
+    println!("  Restart your terminal, or run:");
+    match shell_kind {
+        ShellKind::Fish => println!("    fish_add_path {}", quote_for_shell(bin_dir)),
+        _ => println!(
+            "    export PATH=\"{}:$PATH\"",
+            escape_for_double_quotes(bin_dir)
+        ),
+    }
+    println!();
+
+    Ok(())
+}
+
+fn detect_shell_kind(shell_env: Option<&str>) -> ShellKind {
+    let raw = shell_env.unwrap_or("/bin/bash");
+    let name = Path::new(raw)
+        .file_name()
+        .and_then(OsStr::to_str)
+        .unwrap_or(raw)
+        .to_ascii_lowercase();
+
+    match name.as_str() {
+        "zsh" => ShellKind::Zsh,
+        "bash" => ShellKind::Bash,
+        "fish" => ShellKind::Fish,
+        _ => ShellKind::Other,
+    }
+}
+
+fn profile_path_for_shell(home_dir: &Path, shell_kind: ShellKind) -> PathBuf {
+    match shell_kind {
+        ShellKind::Zsh => home_dir.join(".zshrc"),
+        ShellKind::Bash => {
+            let bash_profile = home_dir.join(".bash_profile");
+            if bash_profile.exists() {
+                bash_profile
+            } else {
+                home_dir.join(".bashrc")
+            }
+        }
+        ShellKind::Fish => home_dir.join(".config/fish/config.fish"),
+        ShellKind::Other => home_dir.join(".profile"),
+    }
+}
+
+fn render_path_line(shell_kind: ShellKind, bin_dir: &Path) -> String {
+    match shell_kind {
+        ShellKind::Fish => format!("fish_add_path {}", quote_for_shell(bin_dir)),
+        _ => format!(
+            "export PATH=\"{}:$PATH\"",
+            escape_for_double_quotes(bin_dir)
+        ),
+    }
+}
+
+fn quote_for_shell(path: &Path) -> String {
+    format!("\"{}\"", escape_for_double_quotes(path))
+}
+
+fn escape_for_double_quotes(path: &Path) -> String {
+    path.to_string_lossy()
+        .replace('\\', "\\\\")
+        .replace('"', "\\\"")
+}
+
+fn normalize_path_component(value: &str) -> String {
+    let trimmed = value.trim();
+    if trimmed == "/" {
+        "/".to_string()
+    } else {
+        trimmed.trim_end_matches('/').to_string()
+    }
+}
+
+fn path_has_entry(path_env: Option<&str>, target_dir: &Path) -> bool {
+    let Some(path_env) = path_env else {
+        return false;
+    };
+
+    let target = normalize_path_component(&target_dir.to_string_lossy());
+    path_env.split(':').any(|entry| {
+        if entry.trim().is_empty() {
+            return false;
+        }
+        normalize_path_component(entry) == target
+    })
+}
+
+fn profile_contains_bin_dir(profile_path: &Path, bin_dir: &Path) -> anyhow::Result<bool> {
+    if !profile_path.exists() {
+        return Ok(false);
+    }
+
+    let content = std::fs::read_to_string(profile_path)
+        .with_context(|| format!("failed to read {}", profile_path.display()))?;
+    let target = bin_dir.to_string_lossy();
+    Ok(content.lines().any(|line| line.contains(target.as_ref())))
+}
+
+fn append_profile_entry(profile_path: &Path, line: &str) -> anyhow::Result<()> {
+    if let Some(parent) = profile_path.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("failed to create {}", parent.display()))?;
+    }
+
+    let mut file = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(profile_path)
+        .with_context(|| format!("failed to open {}", profile_path.display()))?;
+    writeln!(file)?;
+    writeln!(file, "# Added by OrbitDock installer")?;
+    writeln!(file, "{line}")?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+    use std::path::Path;
+
+    use tempfile::tempdir;
+
+    use super::{
+        append_profile_entry, detect_shell_kind, path_has_entry, profile_contains_bin_dir,
+        profile_path_for_shell, render_path_line, ShellKind,
+    };
+
+    #[test]
+    fn detect_shell_kind_supports_common_shells() {
+        assert_eq!(detect_shell_kind(Some("/bin/zsh")), ShellKind::Zsh);
+        assert_eq!(
+            detect_shell_kind(Some("/usr/local/bin/bash")),
+            ShellKind::Bash
+        );
+        assert_eq!(detect_shell_kind(Some("fish")), ShellKind::Fish);
+        assert_eq!(detect_shell_kind(Some("nu")), ShellKind::Other);
+        assert_eq!(detect_shell_kind(None), ShellKind::Bash);
+    }
+
+    #[test]
+    fn profile_path_for_shell_prefers_bash_profile_when_present() {
+        let temp = tempdir().expect("tempdir");
+        let home = temp.path();
+
+        assert_eq!(
+            profile_path_for_shell(home, ShellKind::Bash),
+            home.join(".bashrc")
+        );
+
+        fs::write(home.join(".bash_profile"), "# bash profile").expect("write .bash_profile");
+        assert_eq!(
+            profile_path_for_shell(home, ShellKind::Bash),
+            home.join(".bash_profile")
+        );
+    }
+
+    #[test]
+    fn path_has_entry_matches_exact_component() {
+        let target = Path::new("/Users/test/.orbitdock/bin");
+        assert!(path_has_entry(
+            Some("/usr/bin:/Users/test/.orbitdock/bin:/bin"),
+            target
+        ));
+        assert!(path_has_entry(
+            Some("/usr/bin:/Users/test/.orbitdock/bin/:/bin"),
+            target
+        ));
+        assert!(!path_has_entry(Some("/usr/bin:/opt/homebrew/bin"), target));
+    }
+
+    #[test]
+    fn render_and_append_profile_entry_for_zsh() {
+        let temp = tempdir().expect("tempdir");
+        let profile_path = temp.path().join(".zshrc");
+        let bin_dir = Path::new("/tmp/orbit dock/bin");
+        let line = render_path_line(ShellKind::Zsh, bin_dir);
+
+        append_profile_entry(&profile_path, &line).expect("append profile entry");
+
+        let content = fs::read_to_string(&profile_path).expect("read profile");
+        assert!(content.contains("# Added by OrbitDock installer"));
+        assert!(content.contains("export PATH=\"/tmp/orbit dock/bin:$PATH\""));
+        assert!(profile_contains_bin_dir(&profile_path, bin_dir).expect("profile contains path"));
+    }
+
+    #[test]
+    fn render_fish_path_line_quotes_path() {
+        let line = render_path_line(ShellKind::Fish, Path::new("/tmp/orbit dock/bin"));
+        assert_eq!(line, "fish_add_path \"/tmp/orbit dock/bin\"");
+    }
+}

--- a/orbitdock-server/crates/server/src/main.rs
+++ b/orbitdock-server/crates/server/src/main.rs
@@ -7,6 +7,7 @@ mod ai_naming;
 mod auth;
 mod claude_session;
 mod cmd_doctor;
+mod cmd_ensure_path;
 mod cmd_hook_forward;
 mod cmd_init;
 mod cmd_install_hooks;
@@ -160,6 +161,9 @@ enum Command {
         enable: bool,
     },
 
+    /// Ensure the server binary directory is persisted on your shell PATH
+    EnsurePath,
+
     /// Check if the server is running
     Status,
 
@@ -264,6 +268,9 @@ fn main() -> anyhow::Result<()> {
         }
         Some(Command::InstallService { bind, enable }) => {
             return cmd_install_service::run(&data_dir, *bind, *enable);
+        }
+        Some(Command::EnsurePath) => {
+            return cmd_ensure_path::run();
         }
         Some(Command::Status) => {
             return cmd_status::run(&data_dir);

--- a/orbitdock-server/install.sh
+++ b/orbitdock-server/install.sh
@@ -281,8 +281,9 @@ echo ""
 # ── PATH setup ────────────────────────────────────────────────────────
 BIN_DIR="$INSTALL_ROOT/bin"
 NEEDS_PATH_RELOAD=0
+USED_LEGACY_PATH_SETUP=0
 
-ensure_in_path() {
+ensure_in_path_legacy() {
   # Already on PATH — nothing to do
   if echo "$PATH" | tr ':' '\n' | grep -qx "$BIN_DIR"; then
     return
@@ -323,7 +324,17 @@ ensure_in_path() {
   NEEDS_PATH_RELOAD=1
 }
 
-ensure_in_path
+if "$SERVER_BIN" --help 2>/dev/null | grep -q "ensure-path"; then
+  if ! "$SERVER_BIN" ensure-path; then
+    warn "orbitdock-server ensure-path failed; falling back to legacy PATH setup."
+    ensure_in_path_legacy
+    USED_LEGACY_PATH_SETUP=1
+  fi
+else
+  warn "Installed server doesn't support ensure-path yet; using legacy PATH setup."
+  ensure_in_path_legacy
+  USED_LEGACY_PATH_SETUP=1
+fi
 
 # ── Setup ─────────────────────────────────────────────────────────────────
 info "Running initial setup..."
@@ -371,7 +382,7 @@ else
   echo "  Verify with: orbitdock-server status"
 fi
 
-if [[ "$NEEDS_PATH_RELOAD" == "1" ]]; then
+if [[ "$USED_LEGACY_PATH_SETUP" == "1" && "$NEEDS_PATH_RELOAD" == "1" ]]; then
   echo ""
   warn "Restart your terminal, or run:"
   echo ""


### PR DESCRIPTION
## Summary
- add a new `orbitdock-server ensure-path` subcommand that persists the binary directory on shell PATH
- call `ensure-path` from `install.sh` with a safe legacy fallback for older binaries
- call `ensure-path` from the macOS app setup flow so app installs and script installs use the same path behavior
- update top-level and server README docs for the unified CLI-first PATH flow

## Validation
- `make rust-fmt`
- `make rust-check`
- `make rust-test`
- `make test-unit` *(fails in existing unrelated test code: missing `supportsRichToolingCards` / `isDirectCodexSession` args in `OrbitDockTests`)*
