### PR TITLE
🐛 Fix conversation view layout invalidation and render churn

### DIFF
--- a/OrbitDock/OrbitDock/Views/Conversation/ConversationCollectionTypes.swift
+++ b/OrbitDock/OrbitDock/Views/Conversation/ConversationCollectionTypes.swift
@@ -184,7 +184,7 @@ nonisolated struct ToolBreakdownEntry: Hashable, Sendable {
 
 nonisolated enum TimelineRowPayload: Hashable, Sendable {
   case none
-  case message(id: String)
+  case message(id: String, showHeader: Bool)
   case turnHeader(turnID: String)
   case tool(id: String)
   case rollupSummary(

--- a/OrbitDock/OrbitDock/Views/Conversation/ConversationCollectionView+iOS.swift
+++ b/OrbitDock/OrbitDock/Views/Conversation/ConversationCollectionView+iOS.swift
@@ -157,7 +157,6 @@ import SwiftUI
     var sourceState = ConversationSourceState()
     var uiState = ConversationUIState()
     var messagesByID: [String: TranscriptMessage] = [:]
-    var messageMeta: [String: ConversationView.MessageMeta] = [:]
     var turnsByID: [String: TurnSummary] = [:]
     private var projectionResult = ProjectionResult.empty
     private var currentRows: [TimelineRow] = []
@@ -365,7 +364,7 @@ import SwiftUI
               using: self.messageCountCellReg, for: indexPath, item: ()
             )
           case .message:
-            if case let .message(id) = row.payload {
+            if case let .message(id, _) = row.payload {
               return collectionView.dequeueConfiguredReusableCell(
                 using: self.messageCellReg, for: indexPath, item: id
               )
@@ -487,7 +486,6 @@ import SwiftUI
       ConversationTimelineReducer.reduce(source: &sourceState, ui: &uiState, action: .setMessages(messages))
 
       messagesByID = Dictionary(uniqueKeysWithValues: sourceState.messages.map { ($0.id, $0) })
-      messageMeta = ConversationView.computeMessageMetadata(sourceState.messages)
 
       rebuildTurns()
       ConversationTimelineReducer.reduce(
@@ -750,7 +748,7 @@ import SwiftUI
             height = ConversationLayout.compactToolRowHeight
           }
         case .message:
-          if case let .message(id) = row.payload, let model = buildRichMessageModel(for: id) {
+          if case let .message(id, _) = row.payload, let model = buildRichMessageModel(for: id) {
             height = UIKitRichMessageCell.requiredHeight(for: width, model: model)
             logger.debug(
               "sizeForItem[\(indexPath.item)] msg[\(id.prefix(8))] \(model.messageType) "
@@ -775,10 +773,21 @@ import SwiftUI
 
     private func buildRichMessageModel(for messageId: String) -> NativeRichMessageRowModel? {
       guard let message = messagesByID[messageId] else { return nil }
+      let showHeader: Bool = {
+        guard let rowIndex = rowIndexByTimelineRowID[.message(messageId)],
+              rowIndex >= 0,
+              rowIndex < currentRows.count,
+              case let .message(_, projectedShowHeader) = currentRows[rowIndex].payload
+        else {
+          return true
+        }
+        return projectedShowHeader
+      }()
       return SharedModelBuilders.richMessageModel(
         from: message,
         messageID: messageId,
-        isThinkingExpanded: expandedThinkingIDs.contains(messageId)
+        isThinkingExpanded: expandedThinkingIDs.contains(messageId),
+        showHeader: showHeader
       )
     }
 
@@ -795,7 +804,11 @@ import SwiftUI
       heightCache.removeValue(forKey: rowID)
       var snapshot = dataSource.snapshot()
       snapshot.reconfigureItems([rowID])
-      dataSource.apply(snapshot, animatingDifferences: true)
+      dataSource.apply(snapshot, animatingDifferences: true) { [weak self] in
+        guard let self else { return }
+        self.collectionView.collectionViewLayout.invalidateLayout()
+        self.collectionView.layoutIfNeeded()
+      }
     }
 
     // MARK: - Compact Tool Model Building

--- a/OrbitDock/OrbitDock/Views/Conversation/ConversationCollectionView+macOS.swift
+++ b/OrbitDock/OrbitDock/Views/Conversation/ConversationCollectionView+macOS.swift
@@ -159,7 +159,6 @@ import SwiftUI
 
     // Derived caches for O(1) cell rendering lookups
     private var messagesByID: [String: TranscriptMessage] = [:]
-    private var messageMeta: [String: ConversationView.MessageMeta] = [:]
     private var turnsByID: [String: TurnSummary] = [:]
 
     private var programmaticScrollInProgress = false
@@ -255,6 +254,8 @@ import SwiftUI
     }
 
     private func setupTableView() {
+      UserDefaults.standard.set(false, forKey: "NSTableViewCanEstimateRowHeights")
+
       tableView = WidthClampedTableView(frame: .zero)
       tableView.delegate = self
       tableView.dataSource = self
@@ -445,9 +446,6 @@ import SwiftUI
       remainingLoadCount: Int,
       hasMoreMessages: Bool
     ) {
-      let previousMode = sourceState.metadata.chatViewMode
-      let identityChanged = messageIdentityChanged(sourceState.messages, messages)
-
       // Approval metadata is server-authoritative from session summary fields.
       let session = serverState?.sessions.first(where: { $0.id == self.sessionId })
       let resolvedApprovalId = session?.pendingApprovalId
@@ -488,9 +486,6 @@ import SwiftUI
 
       // Rebuild derived caches
       messagesByID = Dictionary(uniqueKeysWithValues: sourceState.messages.map { ($0.id, $0) })
-      if identityChanged || previousMode != chatViewMode || messageMeta.isEmpty {
-        messageMeta = ConversationView.computeMessageMetadata(sourceState.messages)
-      }
 
       if isLoadingMoreAtTop {
         if sourceState.messages.count > loadMoreBaselineMessageCount || !hasMoreMessages {
@@ -748,22 +743,11 @@ import SwiftUI
       programmaticScrollInProgress = false
     }
 
-    private func messageIdentityChanged(_ old: [TranscriptMessage], _ new: [TranscriptMessage]) -> Bool {
-      guard old.count == new.count else { return true }
-      for (lhs, rhs) in zip(old, new) where lhs.id != rhs.id {
-        return true
-      }
-      return false
-    }
-
     /// Build a NativeRichMessageRowModel for ANY .message row — no markdown filter.
     /// Returns nil only for tool rows or empty content.
-    private func nativeRichMessageRow(for row: TimelineRow, at index: Int? = nil) -> NativeRichMessageRowModel? {
-      guard case let .message(id) = row.payload else { return nil }
+    private func nativeRichMessageRow(for row: TimelineRow) -> NativeRichMessageRowModel? {
+      guard case let .message(id, showHeader) = row.payload else { return nil }
       guard let message = messagesByID[id] else { return nil }
-
-      // Determine whether to show the header by checking the previous row
-      let showHeader = shouldShowHeader(for: message, at: index)
 
       return SharedModelBuilders.richMessageModel(
         from: message,
@@ -771,37 +755,6 @@ import SwiftUI
         isThinkingExpanded: expandedThinkingIDs.contains(id),
         showHeader: showHeader
       )
-    }
-
-    /// Check if the previous row is a same-role message — if so, suppress the header.
-    private func shouldShowHeader(for message: TranscriptMessage, at index: Int?) -> Bool {
-      guard let idx = index, idx > 0, idx < currentRows.count else { return true }
-
-      // User messages always show header (bubble needs visual anchor)
-      if message.isUser || message.isShell { return true }
-      // Error messages always show header (label is informational)
-      if message.isError, message.isAssistant { return true }
-      // Steer messages always show header
-      if message.isSteer { return true }
-
-      // Look at the previous row
-      let prevRow = currentRows[idx - 1]
-      guard case let .message(prevID) = prevRow.payload,
-            let prevMessage = messagesByID[prevID]
-      else { return true }
-
-      // Same-role consecutive messages: suppress header
-      let currentRole = messageRole(message)
-      let prevRole = messageRole(prevMessage)
-      return currentRole != prevRole
-    }
-
-    private func messageRole(_ message: TranscriptMessage) -> String {
-      if message.isUser || message.isShell { return "user" }
-      if message.isThinking { return "thinking" }
-      if message.isSteer { return "steer" }
-      if message.isError, message.isAssistant { return "error" }
-      return "assistant"
     }
 
     // MARK: - Thinking Expansion
@@ -828,7 +781,7 @@ import SwiftUI
       if let cell = tableView.view(atColumn: 0, row: row, makeIfNecessary: false)
         as? NativeRichMessageCellView,
         let timelineRow = row < currentRows.count ? currentRows[row] : nil,
-        let model = nativeRichMessageRow(for: timelineRow, at: row)
+        let model = nativeRichMessageRow(for: timelineRow)
       {
         let width = max(100, tableView.bounds.width)
         cell.configure(model: model, width: width)
@@ -992,7 +945,7 @@ import SwiftUI
 
       // ── Native rich message rows (ALL markdown, zero SwiftUI) ──
 
-      if let richModel = nativeRichMessageRow(for: timelineRow, at: row) {
+      if let richModel = nativeRichMessageRow(for: timelineRow) {
         let richID = NativeRichMessageCellView.reuseIdentifier
         let richCell = (tableView.makeView(withIdentifier: richID, owner: self) as? NativeRichMessageCellView)
           ?? NativeRichMessageCellView(frame: .zero)
@@ -1137,7 +1090,7 @@ import SwiftUI
         .info("heightOfRow[\(row)] \(timelineRow.id.rawValue) cache-miss w=\(String(format: "%.0f", measurementWidth))")
 
       // Tier 2a: Native rich message rows (ALL markdown + images, zero SwiftUI)
-      if let richModel = nativeRichMessageRow(for: timelineRow, at: row) {
+      if let richModel = nativeRichMessageRow(for: timelineRow) {
         let measuredHeight = max(
           1,
           ceil(NativeRichMessageCellView.requiredHeight(for: measurementWidth, model: richModel))

--- a/OrbitDock/OrbitDock/Views/Conversation/ConversationTimelineProjector.swift
+++ b/OrbitDock/OrbitDock/Views/Conversation/ConversationTimelineProjector.swift
@@ -169,14 +169,49 @@ nonisolated enum ConversationTimelineProjector {
     }
 
     let isToolRow = toolRowsEnabled && isToolLikeMessage(message)
+    let showHeader = isToolRow ? true : shouldShowHeader(for: message, previousRow: rows.last, context: context)
     rows.append(
       makeRow(
         id: isToolRow ? .tool(message.id) : .message(message.id),
         kind: isToolRow ? .tool : .message,
-        payload: isToolRow ? .tool(id: message.id) : .message(id: message.id),
+        payload: isToolRow ? .tool(id: message.id) : .message(id: message.id, showHeader: showHeader),
         context: context
       )
     )
+  }
+
+  private static func shouldShowHeader(
+    for message: TranscriptMessage,
+    previousRow: TimelineRow?,
+    context: ProjectionContext
+  ) -> Bool {
+    if message.type == .user || message.type == .shell { return true }
+    if message.isError, message.type == .assistant { return true }
+    if message.type == .steer { return true }
+
+    guard let previousRow,
+          case let .message(prevID, _) = previousRow.payload,
+          let previousMessage = context.messagesByID[prevID]
+    else {
+      return true
+    }
+
+    return messageRole(message) != messageRole(previousMessage)
+  }
+
+  private static func messageRole(_ message: TranscriptMessage) -> String {
+    switch message.type {
+      case .user, .shell:
+        "user"
+      case .thinking:
+        "thinking"
+      case .steer:
+        "steer"
+      case .assistant where message.isError:
+        "error"
+      default:
+        "assistant"
+    }
   }
 
   private static func shouldHideRedundantApprovalPrompt(
@@ -440,7 +475,7 @@ nonisolated enum ConversationTimelineProjector {
         hasher.combine(context.source.metadata.messageCount)
 
       case .message:
-        if case let .message(id) = payload, let message = context.messagesByID[id] {
+        if case let .message(id, _) = payload, let message = context.messagesByID[id] {
           combineRenderable(message: message, into: &hasher)
           let meta = context.messageMetaByID[id]
           hasher.combine(meta?.turnsAfter)

--- a/OrbitDock/OrbitDock/Views/Conversation/Markdown/NativeMarkdownContentView.swift
+++ b/OrbitDock/OrbitDock/Views/Conversation/Markdown/NativeMarkdownContentView.swift
@@ -21,6 +21,19 @@ import SwiftUI
 final class NativeMarkdownContentView: PlatformView {
   // MARK: - Constants
 
+  private struct MeasurementCacheWidthKey: Hashable {
+    let bucket: Int
+
+    init(width: CGFloat) {
+      bucket = Int((width * 2).rounded(.toNearestOrAwayFromZero))
+    }
+  }
+
+  private static let textMeasurementCache = NSMapTable<NSAttributedString, NSMutableDictionary>(
+    keyOptions: [.weakMemory, .objectPointerPersonality],
+    valueOptions: .strongMemory
+  )
+
   private static func blockquoteBarColor(style: ContentStyle) -> PlatformColor {
     switch style {
       case .standard: PlatformColor(Color.accentMuted).withAlphaComponent(0.9)
@@ -248,6 +261,13 @@ final class NativeMarkdownContentView: PlatformView {
   /// Deterministic text height measurement using NSTextStorage + NSLayoutManager (TextKit 1).
   static func measureTextHeight(_ attrStr: NSAttributedString, width: CGFloat) -> CGFloat {
     guard attrStr.length > 0, width > 1 else { return 0 }
+    let widthKey = MeasurementCacheWidthKey(width: width)
+    let widthToken = NSNumber(value: widthKey.bucket)
+    if let cachedHeights = textMeasurementCache.object(forKey: attrStr),
+       let cachedHeight = cachedHeights.object(forKey: widthToken) as? NSNumber
+    {
+      return CGFloat(cachedHeight.doubleValue)
+    }
 
     let textStorage = NSTextStorage(attributedString: attrStr)
     let layoutManager = NSLayoutManager()
@@ -260,8 +280,13 @@ final class NativeMarkdownContentView: PlatformView {
     // Force glyph generation + layout
     layoutManager.ensureLayout(for: textContainer)
     let usedRect = layoutManager.usedRect(for: textContainer)
+    let measuredHeight = ceil(usedRect.height)
 
-    return ceil(usedRect.height)
+    let cachedHeights = textMeasurementCache.object(forKey: attrStr) ?? NSMutableDictionary()
+    cachedHeights[widthToken] = NSNumber(value: Double(measuredHeight))
+    textMeasurementCache.setObject(cachedHeights, forKey: attrStr)
+
+    return measuredHeight
   }
 
   // MARK: - View Factory

--- a/OrbitDock/OrbitDock/Views/Conversation/Markdown/NativeRichMessageCellView.swift
+++ b/OrbitDock/OrbitDock/Views/Conversation/Markdown/NativeRichMessageCellView.swift
@@ -573,8 +573,7 @@ struct NativeRichMessageRowModel {
       let vTop = Self.thinkingVPadTop
       let vBottom = Self.thinkingVPadBottom
       let innerWidth = contentWidth - hPad * 2
-      let displayBlocks = MarkdownSystemParser.parse(model.displayContent, style: .thinking)
-      let mdHeight = NativeMarkdownContentView.requiredHeight(for: displayBlocks, width: innerWidth, style: .thinking)
+      let mdHeight = NativeMarkdownContentView.requiredHeight(for: currentBlocks, width: innerWidth, style: .thinking)
 
       let hasShowMore = model.isThinkingLong
       let isCollapsed = hasShowMore && !model.isThinkingExpanded
@@ -601,7 +600,7 @@ struct NativeRichMessageRowModel {
         width: innerWidth,
         height: mdHeight
       )
-      markdownContentView.configure(blocks: displayBlocks, style: .thinking)
+      markdownContentView.configure(blocks: currentBlocks, style: .thinking)
       bodyContainer.addSubview(markdownContentView)
 
       // Gradient mask: fade text to transparent over the last lines when collapsed

--- a/OrbitDock/OrbitDock/Views/Conversation/UIKitCells/UIKitRichMessageCell.swift
+++ b/OrbitDock/OrbitDock/Views/Conversation/UIKitCells/UIKitRichMessageCell.swift
@@ -237,6 +237,13 @@
     }
 
     private func configureHeader(model: NativeRichMessageRowModel, width: CGFloat) {
+      guard model.showHeader else {
+        headerContainer.isHidden = true
+        headerContainer.frame = CGRect(x: 0, y: 0, width: width, height: 0)
+        return
+      }
+      headerContainer.isHidden = false
+
       let symbolName = model.glyphSymbol
       let isThinking = model.messageType == .thinking
       let symbolConfig = UIImage.SymbolConfiguration(
@@ -306,7 +313,7 @@
       errorAccentBar.isHidden = true
       markdownContentView.layer.mask = nil
 
-      let bodyY = Self.headerHeight + Self.headerToBodySpacing
+      let bodyY = model.showHeader ? Self.headerHeight + Self.headerToBodySpacing : 0
       let contentWidth: CGFloat
 
       if model.isUserAligned {
@@ -431,8 +438,7 @@
       let vTop = Self.thinkingVPadTop
       let vBottom = Self.thinkingVPadBottom
       let innerWidth = contentWidth - hPad * 2
-      let displayBlocks = MarkdownSystemParser.parse(model.displayContent, style: .thinking)
-      let mdHeight = NativeMarkdownContentView.requiredHeight(for: displayBlocks, width: innerWidth, style: .thinking)
+      let mdHeight = NativeMarkdownContentView.requiredHeight(for: currentBlocks, width: innerWidth, style: .thinking)
 
       let hasShowMore = model.isThinkingLong
       let isCollapsed = hasShowMore && !model.isThinkingExpanded
@@ -452,7 +458,7 @@
       // Markdown content
       let contentX = Self.laneHorizontalInset + hPad
       markdownContentView.frame = CGRect(x: contentX, y: vTop, width: innerWidth, height: mdHeight)
-      markdownContentView.configure(blocks: displayBlocks, style: .thinking)
+      markdownContentView.configure(blocks: currentBlocks, style: .thinking)
       bodyContainer.addSubview(markdownContentView)
 
       // Gradient mask: fade text to transparent over the last lines when collapsed
@@ -797,10 +803,12 @@
         style: model.messageType == .thinking ? .thinking : .standard
       )
       let body = bodyHeight(for: width, model: model, blocks: blocks)
-      let total = max(1, ceil(headerHeight + headerToBodySpacing + body + entryBottomSpacing))
+      let actualHeaderHeight = model.showHeader ? headerHeight : 0
+      let actualSpacing = model.showHeader ? headerToBodySpacing : 0
+      let total = max(1, ceil(actualHeaderHeight + actualSpacing + body + entryBottomSpacing))
       logger.debug(
         "requiredHeight-rich[\(model.messageID.prefix(8))] \(model.messageType) "
-          + "header=\(f(headerHeight)) body=\(f(body)) total=\(f(total)) "
+          + "header=\(f(actualHeaderHeight)) body=\(f(body)) total=\(f(total)) "
           + "w=\(f(width)) blocks=\(blocks.count)"
       )
       return total

--- a/OrbitDock/OrbitDock/Views/ConversationView.swift
+++ b/OrbitDock/OrbitDock/Views/ConversationView.swift
@@ -44,12 +44,6 @@ struct ConversationView: View {
     #endif
   }()
 
-  /// Pre-computed per-message metadata to avoid O(n²) in ForEach
-  struct MessageMeta {
-    let turnsAfter: Int?
-    let nthUserMessage: Int?
-  }
-
   private var effectiveDisplayedCount: Int {
     guard !messages.isEmpty else { return 0 }
     if displayedCount <= 0 { return messages.count }
@@ -270,48 +264,6 @@ struct ConversationView: View {
       lhs.isInProgress == rhs.isInProgress &&
       lhs.thinking == rhs.thinking &&
       lhs.images == rhs.images
-  }
-
-  /// Single-pass computation of per-message metadata (turnsAfter, nthUserMessage).
-  /// Replaces O(n²) inline closures that scanned the array per message in ForEach.
-  static func computeMessageMetadata(_ msgs: [TranscriptMessage]) -> [String: MessageMeta] {
-    var result: [String: MessageMeta] = [:]
-    result.reserveCapacity(msgs.count)
-
-    // First pass: assign nthUserMessage indices
-    var userCount = 0
-    var userIndices: [Int] = [] // indices of user messages in msgs
-    for (i, msg) in msgs.enumerated() {
-      if msg.isUser {
-        result[msg.id] = MessageMeta(turnsAfter: 0, nthUserMessage: userCount)
-        userCount += 1
-        userIndices.append(i)
-      } else {
-        result[msg.id] = MessageMeta(turnsAfter: nil, nthUserMessage: nil)
-      }
-    }
-
-    // Second pass: compute turnsAfter for each user message
-    // turnsAfter = number of user messages after this one, or 1 if there's at least a response
-    for (rank, msgIndex) in userIndices.enumerated() {
-      let userMsgsAfter = userIndices.count - rank - 1
-      let turnsAfter: Int
-      if userMsgsAfter > 0 {
-        turnsAfter = userMsgsAfter
-      } else {
-        // Last user message — check if there's any response after it
-        let hasResponseAfter = msgs[(msgIndex + 1)...].contains { !$0.isUser }
-        turnsAfter = hasResponseAfter ? 1 : 0
-      }
-
-      let existing = result[msgs[msgIndex].id]
-      result[msgs[msgIndex].id] = MessageMeta(
-        turnsAfter: turnsAfter > 0 ? turnsAfter : nil,
-        nthUserMessage: existing?.nthUserMessage
-      )
-    }
-
-    return result
   }
 
   private func logDebugState(_ reason: String) {

--- a/OrbitDock/OrbitDockTests/ConversationTimelinePipelineTests.swift
+++ b/OrbitDock/OrbitDockTests/ConversationTimelinePipelineTests.swift
@@ -72,6 +72,42 @@ struct ConversationTimelinePipelineTests {
     #expect(appended.diff.deletions.isEmpty)
   }
 
+  @Test func projectorMarksMessageRowDirtyWhenHeaderVisibilityChanges() {
+    let initialSource = makeSource(messages: [makeMessage(id: "a1", type: .assistant, content: "first")])
+    let ui = ConversationUIState(widthBucket: 12)
+    let initial = ConversationTimelineProjector.project(source: initialSource, ui: ui)
+
+    let appendedSource = makeSource(messages: [
+      makeMessage(id: "a0", type: .assistant, content: "previous"),
+      makeMessage(id: "a1", type: .assistant, content: "first"),
+    ])
+    let appended = ConversationTimelineProjector.project(source: appendedSource, ui: ui, previous: initial)
+
+    #expect(appended.diff.insertions == [0])
+    #expect(appended.diff.reloads == [1])
+    #expect(appended.dirtyRowIDs.contains(.message("a0")))
+    #expect(appended.dirtyRowIDs.contains(.message("a1")))
+
+    guard appended.rows.count >= 2 else {
+      Issue.record("Expected two message rows before bottom spacer")
+      return
+    }
+
+    guard case let .message(firstID, firstShowHeader) = appended.rows[0].payload else {
+      Issue.record("Expected first projected row to be a message payload")
+      return
+    }
+    #expect(firstID == "a0")
+    #expect(firstShowHeader)
+
+    guard case let .message(secondID, secondShowHeader) = appended.rows[1].payload else {
+      Issue.record("Expected second projected row to be a message payload")
+      return
+    }
+    #expect(secondID == "a1")
+    #expect(!secondShowHeader)
+  }
+
   @Test func projectorTracksLayoutHashSeparatelyFromRenderHash() {
     let source = makeSource(
       messages: [


### PR DESCRIPTION
## Summary
- move message header visibility into projected row state so row reloads and height caches stay correct on macOS and iOS
- fix iOS rich-message header collapsing and thinking expansion layout invalidation
- reduce streaming render work by removing dead message metadata recomputation, reusing parsed thinking blocks, and caching repeated TextKit height measurements

## Validation
- make fmt
- make lint
- make build-all
- make test-unit

## Notes
- UI tests were intentionally skipped for this pass