### PR TITLE
♻️ Optimize conversation streaming updates

### DIFF
--- a/OrbitDock/OrbitDock/Services/Server/ServerAppState.swift
+++ b/OrbitDock/OrbitDock/Services/Server/ServerAppState.swift
@@ -563,7 +563,7 @@ final class ServerAppState {
           obs.messages[idx].toolDuration = Double(durationMs) / 1_000.0
           obs.messages[idx].isError = isError
           obs.messages[idx].isInProgress = false
-          obs.bumpMessagesRevision()
+          obs.bumpMessagesRevision(.upsert(obs.messages[idx]))
         }
       }
     }
@@ -1873,6 +1873,14 @@ final class ServerAppState {
     return normalized
   }
 
+  private func normalizedTranscriptMessage(
+    _ incoming: TranscriptMessage,
+    sessionId: String,
+    source: String
+  ) -> TranscriptMessage? {
+    normalizedTranscriptMessages([incoming], sessionId: sessionId, source: source).first
+  }
+
   private func normalizedTurnDiffs(
     _ incoming: [ServerTurnDiff],
     sessionId: String,
@@ -1921,13 +1929,14 @@ final class ServerAppState {
     if let idx = messages.firstIndex(where: { $0.id == transcriptMsg.id }) {
       messages[idx] = mergeMessage(messages[idx], with: transcriptMsg)
       mergeAction = "merged"
+      obs.messages = messages
+      obs.bumpMessagesRevision(.upsert(messages[idx]))
     } else {
       messages.append(transcriptMsg)
       mergeAction = "appended"
+      obs.messages = messages
+      obs.bumpMessagesRevision(.upsert(transcriptMsg))
     }
-
-    obs.messages = normalizedTranscriptMessages(messages, sessionId: sessionId, source: "append-state")
-    obs.bumpMessagesRevision()
     logger.debug(
       "Message \(mergeAction, privacy: .public) for \(sessionId): id=\(transcriptMsg.id, privacy: .public) before=\(beforeCount, privacy: .public) after=\(obs.messages.count, privacy: .public)"
     )
@@ -1943,11 +1952,17 @@ final class ServerAppState {
 
     let obs = session(sessionId)
     var messages = obs.messages
+    let normalizedMessageId = messageId.trimmingCharacters(in: .whitespacesAndNewlines)
 
-    guard let idx = messages.firstIndex(where: { $0.id == messageId }) else {
+    guard !normalizedMessageId.isEmpty else {
+      logger.warning("Message update arrived with empty id in \(sessionId)")
+      return
+    }
+
+    guard let idx = messages.firstIndex(where: { $0.id == normalizedMessageId }) else {
       guard let content = changes.content else { return }
       let fallback = TranscriptMessage(
-        id: messageId,
+        id: normalizedMessageId,
         type: .assistant,
         content: content,
         timestamp: Date(),
@@ -1961,10 +1976,15 @@ final class ServerAppState {
         isError: changes.isError ?? false,
         isInProgress: changes.isInProgress ?? false
       )
-      messages.append(fallback)
-      obs.messages = normalizedTranscriptMessages(messages, sessionId: sessionId, source: "update-fallback")
-      obs.bumpMessagesRevision()
-      logger.warning("Message update arrived before create; upserted \(messageId) in \(sessionId)")
+      guard let normalizedFallback = normalizedTranscriptMessage(
+        fallback,
+        sessionId: sessionId,
+        source: "update-fallback"
+      ) else { return }
+      messages.append(normalizedFallback)
+      obs.messages = messages
+      obs.bumpMessagesRevision(.upsert(normalizedFallback))
+      logger.warning("Message update arrived before create; upserted \(normalizedMessageId) in \(sessionId)")
       return
     }
 
@@ -2002,8 +2022,8 @@ final class ServerAppState {
       }
     }
     messages[idx] = msg
-    obs.messages = normalizedTranscriptMessages(messages, sessionId: sessionId, source: "update")
-    obs.bumpMessagesRevision()
+    obs.messages = messages
+    obs.bumpMessagesRevision(.upsert(msg))
   }
 
   private func handleApprovalRequested(

--- a/OrbitDock/OrbitDock/Services/Server/SessionObservable.swift
+++ b/OrbitDock/OrbitDock/Services/Server/SessionObservable.swift
@@ -8,6 +8,16 @@
 
 import Foundation
 
+enum ConversationMessageMutationKind {
+  case replaceAll
+  case upsert(TranscriptMessage)
+}
+
+struct ConversationMessageMutation {
+  let revision: Int
+  let kind: ConversationMessageMutationKind
+}
+
 @Observable
 @MainActor
 final class SessionObservable {
@@ -16,6 +26,7 @@ final class SessionObservable {
   // Messages
   var messages: [TranscriptMessage] = []
   private(set) var messagesRevision: Int = 0
+  private(set) var lastMessageMutation: ConversationMessageMutation?
 
   // Approval
   var pendingApproval: ServerApprovalRequest?
@@ -242,8 +253,9 @@ final class SessionObservable {
     (inputTokens ?? 0) > 0 || (outputTokens ?? 0) > 0 || (cachedTokens ?? 0) > 0
   }
 
-  func bumpMessagesRevision() {
+  func bumpMessagesRevision(_ kind: ConversationMessageMutationKind = .replaceAll) {
     messagesRevision += 1
+    lastMessageMutation = ConversationMessageMutation(revision: messagesRevision, kind: kind)
   }
 
   var hasMcpData: Bool {

--- a/OrbitDock/OrbitDock/Views/Conversation/ConversationCollectionView+iOS.swift
+++ b/OrbitDock/OrbitDock/Views/Conversation/ConversationCollectionView+iOS.swift
@@ -246,9 +246,10 @@ import SwiftUI
 
     private func setupCellRegistrations() {
       messageCellReg = UICollectionView.CellRegistration<UIKitRichMessageCell, String> {
-        [weak self] cell, _, messageId in
+        [weak self] cell, indexPath, _ in
         guard let self else { return }
-        guard let model = self.buildRichMessageModel(for: messageId) else { return }
+        guard indexPath.item < self.currentRows.count else { return }
+        guard let model = self.buildRichMessageModel(for: self.currentRows[indexPath.item]) else { return }
         let width = self.collectionView.bounds.width
         cell.configure(model: model, width: width)
         cell.onThinkingExpandToggle = { [weak self] id in
@@ -748,7 +749,7 @@ import SwiftUI
             height = ConversationLayout.compactToolRowHeight
           }
         case .message:
-          if case let .message(id, _) = row.payload, let model = buildRichMessageModel(for: id) {
+          if case let .message(id, _) = row.payload, let model = buildRichMessageModel(for: row) {
             height = UIKitRichMessageCell.requiredHeight(for: width, model: model)
             logger.debug(
               "sizeForItem[\(indexPath.item)] msg[\(id.prefix(8))] \(model.messageType) "
@@ -771,18 +772,9 @@ import SwiftUI
 
     // MARK: - Model Building
 
-    private func buildRichMessageModel(for messageId: String) -> NativeRichMessageRowModel? {
+    private func buildRichMessageModel(for row: TimelineRow) -> NativeRichMessageRowModel? {
+      guard case let .message(messageId, showHeader) = row.payload else { return nil }
       guard let message = messagesByID[messageId] else { return nil }
-      let showHeader: Bool = {
-        guard let rowIndex = rowIndexByTimelineRowID[.message(messageId)],
-              rowIndex >= 0,
-              rowIndex < currentRows.count,
-              case let .message(_, projectedShowHeader) = currentRows[rowIndex].payload
-        else {
-          return true
-        }
-        return projectedShowHeader
-      }()
       return SharedModelBuilders.richMessageModel(
         from: message,
         messageID: messageId,

--- a/OrbitDock/OrbitDock/Views/Conversation/ConversationTimelineProjector.swift
+++ b/OrbitDock/OrbitDock/Views/Conversation/ConversationTimelineProjector.swift
@@ -7,11 +7,6 @@
 
 import Foundation
 
-private struct ProjectionMessageMeta {
-  let turnsAfter: Int?
-  let nthUserMessage: Int?
-}
-
 private struct FocusedTurnSplit {
   let leading: [TranscriptMessage]
   let toolZone: [TranscriptMessage]
@@ -477,9 +472,6 @@ nonisolated enum ConversationTimelineProjector {
       case .message:
         if case let .message(id, _) = payload, let message = context.messagesByID[id] {
           combineRenderable(message: message, into: &hasher)
-          let meta = context.messageMetaByID[id]
-          hasher.combine(meta?.turnsAfter)
-          hasher.combine(meta?.nthUserMessage)
         }
 
       case .tool:
@@ -663,53 +655,12 @@ nonisolated enum ConversationTimelineProjector {
     let ui: ConversationUIState
     let messagesByID: [String: TranscriptMessage]
     let turnsByID: [String: TurnSummary]
-    let messageMetaByID: [String: ProjectionMessageMeta]
 
     init(source: ConversationSourceState, ui: ConversationUIState) {
       self.source = source
       self.ui = ui
       messagesByID = Dictionary(uniqueKeysWithValues: source.messages.map { ($0.id, $0) })
       turnsByID = Dictionary(uniqueKeysWithValues: source.turns.map { ($0.id, $0) })
-      messageMetaByID = Self.computeMessageMetadata(source.messages)
-    }
-
-    private static func computeMessageMetadata(_ messages: [TranscriptMessage]) -> [String: ProjectionMessageMeta] {
-      var result: [String: ProjectionMessageMeta] = [:]
-      result.reserveCapacity(messages.count)
-
-      var userCount = 0
-      var userIndices: [Int] = []
-      for (index, message) in messages.enumerated() {
-        if message.type == .user {
-          result[message.id] = ProjectionMessageMeta(turnsAfter: 0, nthUserMessage: userCount)
-          userCount += 1
-          userIndices.append(index)
-        } else {
-          result[message.id] = ProjectionMessageMeta(turnsAfter: nil, nthUserMessage: nil)
-        }
-      }
-
-      for (rank, messageIndex) in userIndices.enumerated() {
-        let userMessagesAfter = userIndices.count - rank - 1
-        let turnsAfter: Int
-        if userMessagesAfter > 0 {
-          turnsAfter = userMessagesAfter
-        } else if messageIndex + 1 < messages.count {
-          let hasResponseAfter = messages[(messageIndex + 1)...].contains { $0.type != .user }
-          turnsAfter = hasResponseAfter ? 1 : 0
-        } else {
-          turnsAfter = 0
-        }
-
-        let id = messages[messageIndex].id
-        let existing = result[id]
-        result[id] = ProjectionMessageMeta(
-          turnsAfter: turnsAfter > 0 ? turnsAfter : nil,
-          nthUserMessage: existing?.nthUserMessage
-        )
-      }
-
-      return result
     }
   }
 }

--- a/OrbitDock/OrbitDock/Views/Conversation/Markdown/NativeRichMessageCellView.swift
+++ b/OrbitDock/OrbitDock/Views/Conversation/Markdown/NativeRichMessageCellView.swift
@@ -345,7 +345,7 @@ struct NativeRichMessageRowModel {
       rebuildBody(model: model, width: width)
 
       // ── Diagnostic: detect body overflow ──
-      let expectedTotal = Self.requiredHeight(for: width, model: model)
+      let expectedTotal = Self.requiredHeight(for: width, model: model, blocks: currentBlocks)
       let maxBodyBottom = bodyContainer.subviews
         .map(\.frame.maxY)
         .max() ?? 0
@@ -959,6 +959,15 @@ struct NativeRichMessageRowModel {
 
       let style: ContentStyle = model.messageType == .thinking ? .thinking : .standard
       let blocks = MarkdownSystemParser.parse(model.displayContent, style: style)
+      return requiredHeight(for: width, model: model, blocks: blocks)
+    }
+
+    private static func requiredHeight(
+      for width: CGFloat,
+      model: NativeRichMessageRowModel,
+      blocks: [MarkdownBlock]
+    ) -> CGFloat {
+      let style: ContentStyle = model.messageType == .thinking ? .thinking : .standard
       let bodyHeight: CGFloat
 
       if model.isUserAligned {

--- a/OrbitDock/OrbitDock/Views/Conversation/TimelineFileLogger.swift
+++ b/OrbitDock/OrbitDock/Views/Conversation/TimelineFileLogger.swift
@@ -5,6 +5,7 @@
 //  Lightweight file logger for conversation timeline debugging.
 //  macOS: ~/.orbitdock/logs/timeline.log
 //  iOS:   ~/.orbitdock/logs/timeline-ios.log
+//  Enable with ORBITDOCK_TIMELINE_LOG=1 or UserDefaults key ORBITDOCK_TIMELINE_LOG=true.
 //
 
 import SwiftUI
@@ -12,20 +13,28 @@ import SwiftUI
 final class TimelineFileLogger: @unchecked Sendable {
   static let shared = TimelineFileLogger()
 
+  private let isEnabled: Bool
   private let fileHandle: FileHandle?
   private let queue = DispatchQueue(label: "com.orbitdock.timeline-logger", qos: .utility)
   private let dateFormatter: DateFormatter
 
   private init() {
+    isEnabled = Self.resolveEnabledFlag()
+
+    dateFormatter = DateFormatter()
+    dateFormatter.dateFormat = "HH:mm:ss.SSS"
+
+    guard isEnabled else {
+      fileHandle = nil
+      return
+    }
+
     let logDir = PlatformPaths.orbitDockLogsDirectory
     #if os(iOS)
       let logPath = logDir.appendingPathComponent("timeline-ios.log").path
     #else
       let logPath = logDir.appendingPathComponent("timeline.log").path
     #endif
-
-    dateFormatter = DateFormatter()
-    dateFormatter.dateFormat = "HH:mm:ss.SSS"
 
     try? FileManager.default.createDirectory(at: logDir, withIntermediateDirectories: true)
 
@@ -41,6 +50,7 @@ final class TimelineFileLogger: @unchecked Sendable {
   }
 
   nonisolated func debug(_ message: @autoclosure () -> String) {
+    guard isEnabled else { return }
     let msg = message()
     queue.async { [weak self] in
       self?.write(msg)
@@ -48,6 +58,7 @@ final class TimelineFileLogger: @unchecked Sendable {
   }
 
   nonisolated func info(_ message: @autoclosure () -> String) {
+    guard isEnabled else { return }
     let msg = message()
     queue.async { [weak self] in
       self?.write("ℹ️ \(msg)")
@@ -60,6 +71,28 @@ final class TimelineFileLogger: @unchecked Sendable {
     guard let data = line.data(using: .utf8) else { return }
     fileHandle?.seekToEndOfFile()
     fileHandle?.write(data)
+  }
+
+  private static func resolveEnabledFlag() -> Bool {
+    if let rawValue = ProcessInfo.processInfo.environment["ORBITDOCK_TIMELINE_LOG"] {
+      return enabledFlag(from: rawValue)
+    }
+    if let rawValue = UserDefaults.standard.object(forKey: "ORBITDOCK_TIMELINE_LOG") as? String {
+      return enabledFlag(from: rawValue)
+    }
+    if let boolValue = UserDefaults.standard.object(forKey: "ORBITDOCK_TIMELINE_LOG") as? Bool {
+      return boolValue
+    }
+    return false
+  }
+
+  private static func enabledFlag(from rawValue: String) -> Bool {
+    switch rawValue.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() {
+      case "1", "true", "yes", "on":
+        true
+      default:
+        false
+    }
   }
 }
 

--- a/OrbitDock/OrbitDock/Views/Conversation/UIKitCells/UIKitRichMessageCell.swift
+++ b/OrbitDock/OrbitDock/Views/Conversation/UIKitCells/UIKitRichMessageCell.swift
@@ -179,6 +179,8 @@
     override func prepareForReuse() {
       super.prepareForReuse()
       bodyContainer.subviews.forEach { $0.removeFromSuperview() }
+      headerContainer.isHidden = false
+      speakerLabel.isHidden = false
       bubbleBackground.isHidden = true
       accentBar.isHidden = true
       thinkingBackground.isHidden = true
@@ -239,11 +241,12 @@
     private func configureHeader(model: NativeRichMessageRowModel, width: CGFloat) {
       guard model.showHeader else {
         headerContainer.isHidden = true
+        speakerLabel.isHidden = true
         headerContainer.frame = CGRect(x: 0, y: 0, width: width, height: 0)
         return
       }
-      headerContainer.isHidden = false
 
+      headerContainer.isHidden = false
       let symbolName = model.glyphSymbol
       let isThinking = model.messageType == .thinking
       let symbolConfig = UIImage.SymbolConfiguration(
@@ -266,6 +269,7 @@
         .foregroundColor: model.speakerColor,
       ]
       speakerLabel.attributedText = NSAttributedString(string: model.speaker, attributes: attrs)
+      speakerLabel.isHidden = model.messageType != .error
 
       // Layout header
       let glyphSize: CGFloat = 20

--- a/OrbitDock/OrbitDock/Views/ConversationView.swift
+++ b/OrbitDock/OrbitDock/Views/ConversationView.swift
@@ -177,61 +177,28 @@ struct ConversationView: View {
   private func refreshFromServerStateIfNeeded() {
     guard let sid = sessionId else { return }
     let obs = serverState.session(sid)
-    let serverMessages = obs.messages
     let snapshotReceived = obs.hasReceivedSnapshot
-    let previousRefreshCount = messages.count
+    let syncResult = ConversationMessageSync.reconcile(
+      localMessages: messages,
+      serverMessages: obs.messages,
+      displayedCount: displayedCount,
+      pageSize: pageSize,
+      mutation: obs.lastMessageMutation
+    )
 
-    // Fast path: nothing changed at a render-relevant level.
-    if messages.count == serverMessages.count,
-       messages.indices.allSatisfy({ i in
-         messages[i].id == serverMessages[i].id &&
-           Self.messageRenderEquivalent(messages[i], serverMessages[i])
-       })
-    {
-      if displayedCount <= 0, !messages.isEmpty {
-        displayedCount = min(pageSize, messages.count)
+    if displayedCount != syncResult.displayedCount {
+      displayedCount = syncResult.displayedCount
+      if !syncResult.didChange, !messages.isEmpty {
         logDebugState("fast_path_repair_displayed_count")
       }
+    }
+
+    guard syncResult.didChange else {
       if snapshotReceived { isLoading = false }
       return
     }
 
-    // Append path: server has more messages and preserves ID ordering.
-    let sharesPrefixIds = !messages.isEmpty &&
-      serverMessages.count >= messages.count &&
-      messages.indices.allSatisfy { messages[$0].id == serverMessages[$0].id }
-
-    if serverMessages.count >= messages.count,
-       sharesPrefixIds
-    {
-      // Update changed existing messages (e.g., streaming content/tool output).
-      for i in messages.indices {
-        if i < serverMessages.count, !Self.messageRenderEquivalent(messages[i], serverMessages[i]) {
-          messages[i] = serverMessages[i]
-        }
-      }
-
-      // Append genuinely new messages
-      if serverMessages.count > messages.count {
-        messages.append(contentsOf: serverMessages[messages.count...])
-      }
-    } else {
-      // Structural change (undo/rollback/initial load) — full replace
-      messages = serverMessages
-    }
-
-    if !messages.isEmpty {
-      // Grow displayedCount by new message delta — don't jump to full count.
-      // This keeps the native table/collection view manageable while ensuring
-      // new streaming content is always visible.
-      let delta = max(0, messages.count - previousRefreshCount)
-      displayedCount = max(displayedCount + delta, effectiveDisplayedCount)
-      if displayedCount <= 0 {
-        displayedCount = min(pageSize, messages.count)
-      }
-    } else {
-      displayedCount = 0
-    }
+    messages = syncResult.messages
 
     if snapshotReceived { isLoading = false }
     logDebugState("refresh_messages")
@@ -249,21 +216,6 @@ struct ConversationView: View {
       }
       refreshTask = nil
     }
-  }
-
-  static func messageRenderEquivalent(_ lhs: TranscriptMessage, _ rhs: TranscriptMessage) -> Bool {
-    lhs.id == rhs.id &&
-      lhs.type == rhs.type &&
-      lhs.content == rhs.content &&
-      lhs.toolName == rhs.toolName &&
-      lhs.toolInputRenderSignature == rhs.toolInputRenderSignature &&
-      lhs.toolOutput == rhs.toolOutput &&
-      lhs.toolDuration == rhs.toolDuration &&
-      lhs.inputTokens == rhs.inputTokens &&
-      lhs.outputTokens == rhs.outputTokens &&
-      lhs.isInProgress == rhs.isInProgress &&
-      lhs.thinking == rhs.thinking &&
-      lhs.images == rhs.images
   }
 
   private func logDebugState(_ reason: String) {
@@ -299,6 +251,158 @@ struct ConversationView: View {
     #endif
   }
 
+}
+
+struct ConversationMessageSyncResult {
+  let messages: [TranscriptMessage]
+  let displayedCount: Int
+  let didChange: Bool
+}
+
+enum ConversationMessageSync {
+  static func reconcile(
+    localMessages: [TranscriptMessage],
+    serverMessages: [TranscriptMessage],
+    displayedCount: Int,
+    pageSize: Int,
+    mutation: ConversationMessageMutation?
+  ) -> ConversationMessageSyncResult {
+    if let mutation {
+      switch mutation.kind {
+        case .replaceAll:
+          return fullReplace(
+            localMessages: localMessages,
+            serverMessages: serverMessages,
+            displayedCount: displayedCount,
+            pageSize: pageSize
+          )
+        case let .upsert(message):
+          if let incremental = applyIncremental(
+            localMessages: localMessages,
+            serverMessages: serverMessages,
+            displayedCount: displayedCount,
+            pageSize: pageSize,
+            message: message
+          ) {
+            return incremental
+          }
+          return fullReplace(
+            localMessages: localMessages,
+            serverMessages: serverMessages,
+            displayedCount: displayedCount,
+            pageSize: pageSize
+          )
+      }
+    }
+
+    return fullReplace(
+      localMessages: localMessages,
+      serverMessages: serverMessages,
+      displayedCount: displayedCount,
+      pageSize: pageSize
+    )
+  }
+
+  static func messageRenderEquivalent(_ lhs: TranscriptMessage, _ rhs: TranscriptMessage) -> Bool {
+    lhs.id == rhs.id &&
+      lhs.type == rhs.type &&
+      lhs.content == rhs.content &&
+      lhs.toolName == rhs.toolName &&
+      lhs.toolInputRenderSignature == rhs.toolInputRenderSignature &&
+      lhs.toolOutput == rhs.toolOutput &&
+      lhs.toolDuration == rhs.toolDuration &&
+      lhs.inputTokens == rhs.inputTokens &&
+      lhs.outputTokens == rhs.outputTokens &&
+      lhs.isInProgress == rhs.isInProgress &&
+      lhs.thinking == rhs.thinking &&
+      lhs.images == rhs.images
+  }
+
+  private static func applyIncremental(
+    localMessages: [TranscriptMessage],
+    serverMessages: [TranscriptMessage],
+    displayedCount: Int,
+    pageSize: Int,
+    message: TranscriptMessage
+  ) -> ConversationMessageSyncResult? {
+    guard localMessages.count <= serverMessages.count else { return nil }
+
+    var nextMessages = localMessages
+    var didChange = false
+
+    if nextMessages.count < serverMessages.count {
+      nextMessages.append(contentsOf: serverMessages[nextMessages.count...])
+      didChange = true
+    }
+
+    guard let index = nextMessages.firstIndex(where: { $0.id == message.id }) else { return nil }
+
+    if !messageRenderEquivalent(nextMessages[index], message) {
+      nextMessages[index] = message
+      didChange = true
+    }
+
+    let resultMessages = didChange ? nextMessages : localMessages
+    return ConversationMessageSyncResult(
+      messages: resultMessages,
+      displayedCount: adjustedDisplayedCount(
+        currentDisplayedCount: displayedCount,
+        previousMessages: localMessages,
+        nextMessages: resultMessages,
+        pageSize: pageSize
+      ),
+      didChange: didChange
+    )
+  }
+
+  private static func fullReplace(
+    localMessages: [TranscriptMessage],
+    serverMessages: [TranscriptMessage],
+    displayedCount: Int,
+    pageSize: Int
+  ) -> ConversationMessageSyncResult {
+    let didChange = !messagesRenderEquivalent(localMessages, serverMessages)
+    let resultMessages = didChange ? serverMessages : localMessages
+    return ConversationMessageSyncResult(
+      messages: resultMessages,
+      displayedCount: adjustedDisplayedCount(
+        currentDisplayedCount: displayedCount,
+        previousMessages: localMessages,
+        nextMessages: resultMessages,
+        pageSize: pageSize
+      ),
+      didChange: didChange
+    )
+  }
+
+  private static func messagesRenderEquivalent(_ lhs: [TranscriptMessage], _ rhs: [TranscriptMessage]) -> Bool {
+    guard lhs.count == rhs.count else { return false }
+    return lhs.indices.allSatisfy { index in
+      lhs[index].id == rhs[index].id && messageRenderEquivalent(lhs[index], rhs[index])
+    }
+  }
+
+  private static func adjustedDisplayedCount(
+    currentDisplayedCount: Int,
+    previousMessages: [TranscriptMessage],
+    nextMessages: [TranscriptMessage],
+    pageSize: Int
+  ) -> Int {
+    guard !nextMessages.isEmpty else { return 0 }
+
+    let previousEffectiveDisplayedCount: Int = {
+      guard !previousMessages.isEmpty else { return 0 }
+      if currentDisplayedCount <= 0 { return previousMessages.count }
+      return min(currentDisplayedCount, previousMessages.count)
+    }()
+
+    let delta = max(0, nextMessages.count - previousMessages.count)
+    var nextDisplayedCount = max(currentDisplayedCount + delta, previousEffectiveDisplayedCount)
+    if nextDisplayedCount <= 0 {
+      nextDisplayedCount = min(pageSize, nextMessages.count)
+    }
+    return min(nextDisplayedCount, nextMessages.count)
+  }
 }
 
 // MARK: - Preview

--- a/OrbitDock/OrbitDockTests/ConversationTimelinePipelineTests.swift
+++ b/OrbitDock/OrbitDockTests/ConversationTimelinePipelineTests.swift
@@ -108,6 +108,69 @@ struct ConversationTimelinePipelineTests {
     #expect(!secondShowHeader)
   }
 
+  @Test func projectorEncodesHeaderVisibilityInMessagePayload() {
+    let source = makeSource(
+      messages: [
+        makeMessage(id: "a1", content: "first"),
+        makeMessage(id: "a2", content: "second"),
+      ]
+    )
+
+    let projected = ConversationTimelineProjector.project(source: source, ui: ConversationUIState(widthBucket: 12))
+
+    guard projected.rows.count >= 2 else {
+      Issue.record("Expected two message rows")
+      return
+    }
+
+    if case let .message(id, showHeader) = projected.rows[0].payload {
+      #expect(id == "a1")
+      #expect(showHeader)
+    } else {
+      Issue.record("Expected first row to be a message payload")
+    }
+
+    if case let .message(id, showHeader) = projected.rows[1].payload {
+      #expect(id == "a2")
+      #expect(!showHeader)
+    } else {
+      Issue.record("Expected second row to be a message payload")
+    }
+  }
+
+  @Test func projectorReloadsNeighborRowWhenHeaderVisibilityChanges() {
+    let initialSource = makeSource(
+      messages: [
+        makeMessage(id: "m1", content: "assistant"),
+        makeMessage(id: "m2", content: "follow-up"),
+      ]
+    )
+    let ui = ConversationUIState(widthBucket: 12)
+    let initial = ConversationTimelineProjector.project(source: initialSource, ui: ui)
+
+    let updatedSource = makeSource(
+      messages: [
+        makeMessage(id: "m1", type: .user, content: "user prompt"),
+        makeMessage(id: "m2", content: "follow-up"),
+      ]
+    )
+    let updated = ConversationTimelineProjector.project(source: updatedSource, ui: ui, previous: initial)
+
+    #expect(updated.diff.reloads == [0, 1])
+
+    guard updated.rows.count >= 2 else {
+      Issue.record("Expected two message rows")
+      return
+    }
+
+    if case let .message(id, showHeader) = updated.rows[1].payload {
+      #expect(id == "m2")
+      #expect(showHeader)
+    } else {
+      Issue.record("Expected second row to be a message payload")
+    }
+  }
+
   @Test func projectorTracksLayoutHashSeparatelyFromRenderHash() {
     let source = makeSource(
       messages: [
@@ -347,6 +410,47 @@ struct ConversationTimelinePipelineTests {
       viewportHeight: 300
     )
     #expect(clamped == 200)
+  }
+
+  @Test func messageSyncAppliesStreamingUpsertIncrementally() {
+    let localMessages = [makeMessage(id: "m1", content: "hello")]
+    let streamedMessage = makeMessage(id: "m2", content: "streaming reply")
+    let serverMessages = localMessages + [streamedMessage]
+    let mutation = ConversationMessageMutation(revision: 2, kind: .upsert(streamedMessage))
+
+    let result = ConversationMessageSync.reconcile(
+      localMessages: localMessages,
+      serverMessages: serverMessages,
+      displayedCount: 1,
+      pageSize: 50,
+      mutation: mutation
+    )
+
+    #expect(result.didChange)
+    #expect(result.messages.map(\.id) == ["m1", "m2"])
+    #expect(result.messages.last?.content == "streaming reply")
+    #expect(result.displayedCount == 2)
+  }
+
+  @Test func messageSyncFallsBackToReplaceAllWhenIncrementalHintCannotBeApplied() {
+    let localMessages = [makeMessage(id: "m1", content: "old")]
+    let serverMessages = [makeMessage(id: "m2", content: "new")]
+    let mutation = ConversationMessageMutation(
+      revision: 2,
+      kind: .upsert(makeMessage(id: "m2", content: "new"))
+    )
+
+    let result = ConversationMessageSync.reconcile(
+      localMessages: localMessages,
+      serverMessages: serverMessages,
+      displayedCount: 1,
+      pageSize: 50,
+      mutation: mutation
+    )
+
+    #expect(result.didChange)
+    #expect(result.messages.map(\.id) == ["m2"])
+    #expect(result.displayedCount == 1)
   }
 
   private func makeSource(


### PR DESCRIPTION
## Summary
- push transcript changes through the conversation view as incremental message upserts instead of rescanning the full transcript on every refresh
- move header visibility into projected row state so macOS and iOS invalidate rows consistently during streaming and expansion
- gate timeline file logging behind the ORBITDOCK_TIMELINE_LOG flag while keeping the debugging path available when we need it

## Testing
- make test-unit
- xcodebuild -project /Users/robertdeluca/Developer/OrbitDock/OrbitDock/OrbitDock.xcodeproj -scheme "OrbitDock iOS" -destination "generic/platform=iOS" build