### PR TITLE
🐛 Fix conversation row ordering — single-writer persistence

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -149,6 +149,7 @@ The server–client protocol uses strongly-typed Swift structs that mirror Rust 
 - The Rust server persistence layer (`infrastructure/persistence/`) is the sole SQLite writer
 - All connections use WAL mode (`journal_mode = WAL`), `busy_timeout = 5000`, `synchronous = NORMAL`
 - The migration runner sets these pragmas at startup
+- Conversation rows follow the single-writer principle — see "Row Persistence: Single-Writer Principle" under Message Storage Architecture
 
 ### Animations
 - Use `.spring(response: 0.35, dampingFraction: 0.8)` for message animations
@@ -545,9 +546,21 @@ Migrations run when: the Rust server starts through `crates/server/src/app/mod.r
 
 - Rust server receives events via HTTP hooks (CLI) or codex-core (Codex)
 - `infrastructure/persistence/` batches writes through the `PersistCommand` channel
-- Messages stored in SQLite `messages` table
+- Messages stored in SQLite `messages` table with monotonic `sequence` numbers per session
 - Swift app receives messages in real-time via WebSocket push — does NOT read SQLite directly
 - Client-initiated reads (session snapshot, approvals, etc.) use REST endpoints
+
+#### Row Persistence: Single-Writer Principle
+
+**All conversation row writes MUST flow through one of two paths:**
+
+1. **`AddRowAndBroadcast` / `UpsertRowAndBroadcast`** session commands — the handler in `session_command_handler.rs` calls `add_row()`/`upsert_row()` (which assigns the correct sequence), then sends `PersistCommand::RowAppend`/`RowUpsert` with the correctly-sequenced entry, then broadcasts to WebSocket.
+
+2. **Transition state machine** — `dispatch_transition_input()` runs the pure `transition()` function which assigns sequences before creating `PersistOp::RowAppend`/`RowUpsert` effects. Effects are processed after `apply_state()`.
+
+**Never send `PersistCommand::RowAppend`/`RowUpsert` directly from a callsite that also uses the session actor.** This causes a dual-write race where the DB gets the wrong sequence (typically 0) because the persist command is created before the actor assigns the correct sequence. The only exceptions are bootstrap paths where no actor exists yet (e.g., session fork, startup backfill).
+
+Key files: `runtime/session_command_handler.rs` (command handlers), `connector-core/src/transition.rs` (state machine), `infrastructure/persistence/writer.rs` (batched writer)
 
 ## Database Conventions
 

--- a/orbitdock-server/crates/server/src/app/mod.rs
+++ b/orbitdock-server/crates/server/src/app/mod.rs
@@ -435,8 +435,15 @@ pub async fn run_server(options: ServerRunOptions) -> anyhow::Result<()> {
                         )
                         .await
                         {
-                            Ok(rows) if !rows.is_empty() => {
+                            Ok(mut rows) if !rows.is_empty() => {
                                 let count = rows.len();
+
+                                // Normalize sequences before persisting (matching
+                                // what replace_rows() does internally) to keep
+                                // DB and in-memory state consistent.
+                                for (i, entry) in rows.iter_mut().enumerate() {
+                                    entry.sequence = i as u64;
+                                }
                                 for entry in &rows {
                                     let _ = backfill_persist_tx
                                         .send(crate::infrastructure::persistence::PersistCommand::RowAppend {

--- a/orbitdock-server/crates/server/src/connectors/codex_rollout/runtime.rs
+++ b/orbitdock-server/crates/server/src/connectors/codex_rollout/runtime.rs
@@ -699,14 +699,7 @@ impl WatcherRuntime {
         };
 
         actor
-            .send(SessionCommand::AddRowAndBroadcast {
-                entry: entry.clone(),
-            })
-            .await;
-
-        let _ = self
-            .persist_tx
-            .send(PersistCommand::RowAppend { session_id, entry })
+            .send(SessionCommand::AddRowAndBroadcast { entry })
             .await;
     }
 
@@ -817,19 +810,9 @@ impl WatcherRuntime {
 
         if let Some(actor) = self.app_state.get_session(session_id) {
             actor
-                .send(SessionCommand::AddRowAndBroadcast {
-                    entry: entry.clone(),
-                })
+                .send(SessionCommand::AddRowAndBroadcast { entry })
                 .await;
         }
-
-        let _ = self
-            .persist_tx
-            .send(PersistCommand::RowAppend {
-                session_id: session_id.to_string(),
-                entry,
-            })
-            .await;
     }
 
     async fn finish_rollout_shell_message(

--- a/orbitdock-server/crates/server/src/infrastructure/persistence/mod.rs
+++ b/orbitdock-server/crates/server/src/infrastructure/persistence/mod.rs
@@ -388,7 +388,8 @@ pub(super) fn execute_command(
                  VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)
                  ON CONFLICT(id) DO UPDATE SET
                    content = excluded.content,
-                   row_data = excluded.row_data",
+                   row_data = excluded.row_data,
+                   sequence = excluded.sequence",
                 params![
                     row_id,
                     session_id,

--- a/orbitdock-server/crates/server/src/infrastructure/persistence/tests.rs
+++ b/orbitdock-server/crates/server/src/infrastructure/persistence/tests.rs
@@ -1,1 +1,260 @@
-// Tests deleted during ConversationRowEntry migration. Will be rewritten.
+use rusqlite::Connection;
+
+use orbitdock_protocol::conversation_contracts::{
+    ConversationRow, ConversationRowEntry, MessageRowContent,
+};
+
+use super::commands::PersistCommand;
+use super::messages::load_messages_from_db;
+
+fn setup_test_db() -> (Connection, std::path::PathBuf, tempfile::TempDir) {
+    let dir = tempfile::TempDir::new().unwrap();
+    let db_path = dir.path().join("test.db");
+    let conn = Connection::open(&db_path).unwrap();
+    conn.execute_batch(
+        "PRAGMA journal_mode = WAL;
+         PRAGMA busy_timeout = 5000;
+         PRAGMA synchronous = NORMAL;
+
+         CREATE TABLE IF NOT EXISTS sessions (
+           id TEXT PRIMARY KEY,
+           project_path TEXT NOT NULL DEFAULT '',
+           project_name TEXT,
+           provider TEXT NOT NULL DEFAULT 'codex',
+           status TEXT NOT NULL DEFAULT 'active',
+           work_status TEXT NOT NULL DEFAULT 'waiting',
+           model TEXT,
+           branch TEXT,
+           last_message TEXT,
+           unread_count INTEGER NOT NULL DEFAULT 0,
+           started_at TEXT,
+           last_activity_at TEXT
+         );
+
+         CREATE TABLE IF NOT EXISTS messages (
+           id TEXT PRIMARY KEY,
+           session_id TEXT NOT NULL,
+           type TEXT NOT NULL DEFAULT '',
+           content TEXT NOT NULL DEFAULT '',
+           timestamp TEXT,
+           sequence INTEGER DEFAULT 0,
+           row_data TEXT,
+           is_in_progress INTEGER DEFAULT 0
+         );
+
+         CREATE INDEX IF NOT EXISTS idx_messages_session_sequence
+           ON messages(session_id, sequence);
+
+         INSERT INTO sessions (id, project_path, provider) VALUES ('test-session', '/tmp/test', 'codex');",
+    )
+    .unwrap();
+
+    (conn, db_path, dir)
+}
+
+fn user_entry(id: &str, sequence: u64) -> ConversationRowEntry {
+    ConversationRowEntry {
+        session_id: "test-session".to_string(),
+        sequence,
+        turn_id: None,
+        row: ConversationRow::User(MessageRowContent {
+            id: id.to_string(),
+            content: format!("message from {id}"),
+            turn_id: None,
+            timestamp: None,
+            is_streaming: false,
+            images: vec![],
+        }),
+    }
+}
+
+fn assistant_entry(id: &str, sequence: u64) -> ConversationRowEntry {
+    ConversationRowEntry {
+        session_id: "test-session".to_string(),
+        sequence,
+        turn_id: None,
+        row: ConversationRow::Assistant(MessageRowContent {
+            id: id.to_string(),
+            content: format!("response from {id}"),
+            turn_id: None,
+            timestamp: None,
+            is_streaming: false,
+            images: vec![],
+        }),
+    }
+}
+
+#[test]
+fn row_append_stores_correct_sequence() {
+    let (conn, db_path, _dir) = setup_test_db();
+    drop(conn);
+
+    let batch = vec![
+        PersistCommand::RowAppend {
+            session_id: "test-session".to_string(),
+            entry: user_entry("row-0", 0),
+        },
+        PersistCommand::RowAppend {
+            session_id: "test-session".to_string(),
+            entry: assistant_entry("row-1", 1),
+        },
+        PersistCommand::RowAppend {
+            session_id: "test-session".to_string(),
+            entry: user_entry("row-2", 2),
+        },
+    ];
+
+    super::writer::flush_batch_for_test(&db_path, batch).unwrap();
+
+    let conn = Connection::open(&db_path).unwrap();
+    let rows = load_messages_from_db(&conn, "test-session").unwrap();
+
+    assert_eq!(rows.len(), 3);
+    assert_eq!(rows[0].sequence, 0);
+    assert_eq!(rows[1].sequence, 1);
+    assert_eq!(rows[2].sequence, 2);
+}
+
+#[test]
+fn row_append_with_zero_sequence_stores_zero() {
+    // This test documents that RowAppend is a dumb write — it persists
+    // whatever sequence it receives. The caller (AddRowAndBroadcast handler)
+    // is responsible for assigning the correct sequence BEFORE sending.
+    let (conn, db_path, _dir) = setup_test_db();
+    drop(conn);
+
+    let batch = vec![
+        PersistCommand::RowAppend {
+            session_id: "test-session".to_string(),
+            entry: user_entry("row-a", 0),
+        },
+        PersistCommand::RowAppend {
+            session_id: "test-session".to_string(),
+            entry: user_entry("row-b", 0), // Bad: duplicate sequence=0
+        },
+    ];
+
+    super::writer::flush_batch_for_test(&db_path, batch).unwrap();
+
+    let conn = Connection::open(&db_path).unwrap();
+    let rows = load_messages_from_db(&conn, "test-session").unwrap();
+
+    // Both rows are stored, both with sequence=0 — this is why callers
+    // MUST go through the actor (AddRowAndBroadcast) to get correct sequences.
+    assert_eq!(rows.len(), 2);
+    assert_eq!(rows[0].sequence, 0);
+    assert_eq!(rows[1].sequence, 0);
+}
+
+#[test]
+fn row_upsert_updates_sequence_on_conflict() {
+    let (conn, db_path, _dir) = setup_test_db();
+    drop(conn);
+
+    // First: insert a row with sequence=0 (the old buggy behavior)
+    let batch = vec![PersistCommand::RowAppend {
+        session_id: "test-session".to_string(),
+        entry: user_entry("row-0", 0),
+    }];
+    super::writer::flush_batch_for_test(&db_path, batch).unwrap();
+
+    // Then: upsert the same row with the correct sequence=5
+    let batch = vec![PersistCommand::RowUpsert {
+        session_id: "test-session".to_string(),
+        entry: user_entry("row-0", 5),
+    }];
+    super::writer::flush_batch_for_test(&db_path, batch).unwrap();
+
+    let conn = Connection::open(&db_path).unwrap();
+    let rows = load_messages_from_db(&conn, "test-session").unwrap();
+
+    assert_eq!(rows.len(), 1);
+    // The sequence should be corrected from 0 to 5
+    assert_eq!(
+        rows[0].sequence, 5,
+        "RowUpsert must update the sequence column"
+    );
+}
+
+#[test]
+fn row_upsert_inserts_when_not_existing() {
+    let (conn, db_path, _dir) = setup_test_db();
+    drop(conn);
+
+    let batch = vec![PersistCommand::RowUpsert {
+        session_id: "test-session".to_string(),
+        entry: user_entry("new-row", 3),
+    }];
+    super::writer::flush_batch_for_test(&db_path, batch).unwrap();
+
+    let conn = Connection::open(&db_path).unwrap();
+    let rows = load_messages_from_db(&conn, "test-session").unwrap();
+
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].id(), "new-row");
+    assert_eq!(rows[0].sequence, 3);
+}
+
+#[test]
+fn batch_of_appends_preserves_insertion_order() {
+    let (conn, db_path, _dir) = setup_test_db();
+    drop(conn);
+
+    // Simulate a burst of 10 rapid messages with correct sequences
+    let batch: Vec<PersistCommand> = (0..10)
+        .map(|i| PersistCommand::RowAppend {
+            session_id: "test-session".to_string(),
+            entry: assistant_entry(&format!("msg-{i}"), i as u64),
+        })
+        .collect();
+
+    super::writer::flush_batch_for_test(&db_path, batch).unwrap();
+
+    let conn = Connection::open(&db_path).unwrap();
+    let rows = load_messages_from_db(&conn, "test-session").unwrap();
+
+    assert_eq!(rows.len(), 10);
+    for (i, row) in rows.iter().enumerate() {
+        assert_eq!(row.id(), format!("msg-{i}"));
+        assert_eq!(row.sequence, i as u64);
+    }
+
+    // Verify ORDER BY sequence returns them in correct order
+    let sequences: Vec<u64> = rows.iter().map(|r| r.sequence).collect();
+    let mut sorted = sequences.clone();
+    sorted.sort();
+    assert_eq!(
+        sequences, sorted,
+        "rows must be ordered by sequence from DB"
+    );
+}
+
+#[test]
+fn row_append_ignore_deduplicates_by_id() {
+    let (conn, db_path, _dir) = setup_test_db();
+    drop(conn);
+
+    // INSERT OR IGNORE means second insert with same id is silently dropped
+    let batch = vec![
+        PersistCommand::RowAppend {
+            session_id: "test-session".to_string(),
+            entry: user_entry("dup-id", 0),
+        },
+        PersistCommand::RowAppend {
+            session_id: "test-session".to_string(),
+            entry: user_entry("dup-id", 5), // Same id, different sequence
+        },
+    ];
+
+    super::writer::flush_batch_for_test(&db_path, batch).unwrap();
+
+    let conn = Connection::open(&db_path).unwrap();
+    let rows = load_messages_from_db(&conn, "test-session").unwrap();
+
+    // Only one row should exist — the first one wins with INSERT OR IGNORE
+    assert_eq!(rows.len(), 1);
+    assert_eq!(
+        rows[0].sequence, 0,
+        "first insert wins with INSERT OR IGNORE"
+    );
+}

--- a/orbitdock-server/crates/server/src/infrastructure/persistence/writer.rs
+++ b/orbitdock-server/crates/server/src/infrastructure/persistence/writer.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 
 use rusqlite::Connection;
 use tokio::sync::mpsc;
-use tracing::{debug, error, info, warn};
+use tracing::{debug, error, info};
 
 use super::PersistCommand;
 
@@ -123,7 +123,7 @@ pub(crate) fn flush_batch(
 
     for cmd in batch {
         if let Err(error) = super::execute_command(&tx, cmd) {
-            warn!(
+            error!(
                 component = "persistence",
                 event = "persistence.command.failed",
                 error = %error,

--- a/orbitdock-server/crates/server/src/runtime/message_dispatch.rs
+++ b/orbitdock-server/crates/server/src/runtime/message_dispatch.rs
@@ -166,13 +166,6 @@ pub(crate) async fn dispatch_send_message(
         persisted_images.clone(),
     );
 
-    let _ = state
-        .persist()
-        .send(PersistCommand::RowAppend {
-            session_id: session_id.clone(),
-            entry: user_entry.clone(),
-        })
-        .await;
     actor
         .send(SessionCommand::AddRowAndBroadcast {
             entry: user_entry.clone(),
@@ -262,13 +255,6 @@ pub(crate) async fn dispatch_steer_turn(
         persisted_images.clone(),
     );
 
-    let _ = state
-        .persist()
-        .send(PersistCommand::RowAppend {
-            session_id: session_id.clone(),
-            entry: steer_entry.clone(),
-        })
-        .await;
     actor
         .send(SessionCommand::AddRowAndBroadcast { entry: steer_entry })
         .await;

--- a/orbitdock-server/crates/server/src/runtime/session_actor.rs
+++ b/orbitdock-server/crates/server/src/runtime/session_actor.rs
@@ -303,6 +303,200 @@ mod tests {
         assert_eq!(snap.work_status, WorkStatus::Working);
     }
 
+    fn user_row(id: &str) -> ConversationRowEntry {
+        ConversationRowEntry {
+            session_id: "test-session".to_string(),
+            sequence: 0,
+            turn_id: None,
+            row: ConversationRow::User(MessageRowContent {
+                id: id.to_string(),
+                content: format!("msg-{id}"),
+                turn_id: None,
+                timestamp: None,
+                is_streaming: false,
+                images: vec![],
+            }),
+        }
+    }
+
+    fn assistant_row(id: &str) -> ConversationRowEntry {
+        ConversationRowEntry {
+            session_id: "test-session".to_string(),
+            sequence: 0,
+            turn_id: None,
+            row: ConversationRow::Assistant(MessageRowContent {
+                id: id.to_string(),
+                content: format!("response-{id}"),
+                turn_id: None,
+                timestamp: None,
+                is_streaming: false,
+                images: vec![],
+            }),
+        }
+    }
+
+    /// Extracts (row_id, sequence) from RowAppend persist commands on the channel.
+    fn drain_row_appends(persist_rx: &mut mpsc::Receiver<PersistCommand>) -> Vec<(String, u64)> {
+        let mut result = Vec::new();
+        while let Ok(cmd) = persist_rx.try_recv() {
+            if let PersistCommand::RowAppend { entry, .. } = cmd {
+                result.push((entry.id().to_string(), entry.sequence));
+            }
+        }
+        result
+    }
+
+    /// Extracts (row_id, sequence) from RowUpsert persist commands on the channel.
+    fn drain_row_upserts(persist_rx: &mut mpsc::Receiver<PersistCommand>) -> Vec<(String, u64)> {
+        let mut result = Vec::new();
+        while let Ok(cmd) = persist_rx.try_recv() {
+            if let PersistCommand::RowUpsert { entry, .. } = cmd {
+                result.push((entry.id().to_string(), entry.sequence));
+            }
+        }
+        result
+    }
+
+    #[tokio::test]
+    async fn add_row_and_broadcast_persists_with_correct_sequences() {
+        let (persist_tx, mut persist_rx) = mpsc::channel(64);
+        let actor = SessionActorHandle::spawn(test_handle(), persist_tx);
+
+        // Send a burst of rows all with sequence=0 (the pattern that caused the bug)
+        for i in 0..5 {
+            actor
+                .send(SessionCommand::AddRowAndBroadcast {
+                    entry: user_row(&format!("row-{i}")),
+                })
+                .await;
+        }
+
+        // Let the actor process all commands
+        tokio::task::yield_now().await;
+        tokio::task::yield_now().await;
+
+        let persisted = drain_row_appends(&mut persist_rx);
+
+        // Every row should arrive at persistence with a unique, monotonically
+        // increasing sequence — never the original 0 (except the very first row)
+        assert_eq!(persisted.len(), 5);
+        for (i, (id, seq)) in persisted.iter().enumerate() {
+            assert_eq!(id, &format!("row-{i}"));
+            assert_eq!(*seq, i as u64, "row {id} should have sequence {i}");
+        }
+    }
+
+    #[tokio::test]
+    async fn burst_of_mixed_row_types_persists_monotonic_sequences() {
+        let (persist_tx, mut persist_rx) = mpsc::channel(64);
+        let actor = SessionActorHandle::spawn(test_handle(), persist_tx);
+
+        // Simulate a realistic burst: user message, then rapid assistant + user
+        actor
+            .send(SessionCommand::AddRowAndBroadcast {
+                entry: user_row("user-1"),
+            })
+            .await;
+        for i in 0..3 {
+            actor
+                .send(SessionCommand::AddRowAndBroadcast {
+                    entry: assistant_row(&format!("assistant-{i}")),
+                })
+                .await;
+        }
+        actor
+            .send(SessionCommand::AddRowAndBroadcast {
+                entry: user_row("user-2"),
+            })
+            .await;
+
+        tokio::task::yield_now().await;
+        tokio::task::yield_now().await;
+
+        let persisted = drain_row_appends(&mut persist_rx);
+        assert_eq!(persisted.len(), 5);
+
+        // Verify strictly increasing sequences
+        let sequences: Vec<u64> = persisted.iter().map(|(_, seq)| *seq).collect();
+        for pair in sequences.windows(2) {
+            assert!(
+                pair[1] > pair[0],
+                "sequences must be strictly increasing: got {:?}",
+                sequences
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn upsert_row_and_broadcast_persists_with_correct_sequence() {
+        let (persist_tx, mut persist_rx) = mpsc::channel(64);
+        let actor = SessionActorHandle::spawn(test_handle(), persist_tx);
+
+        // First add two rows so we have something to upsert
+        actor
+            .send(SessionCommand::AddRowAndBroadcast {
+                entry: user_row("row-0"),
+            })
+            .await;
+        actor
+            .send(SessionCommand::AddRowAndBroadcast {
+                entry: assistant_row("asst-1"),
+            })
+            .await;
+
+        tokio::task::yield_now().await;
+        tokio::task::yield_now().await;
+
+        // Drain the appends
+        let _ = drain_row_appends(&mut persist_rx);
+
+        // Now upsert asst-1 with sequence=0 (simulating transcript sync)
+        let mut updated = assistant_row("asst-1");
+        updated.sequence = 0; // Callers don't know the correct sequence
+        actor
+            .send(SessionCommand::UpsertRowAndBroadcast { entry: updated })
+            .await;
+
+        tokio::task::yield_now().await;
+        tokio::task::yield_now().await;
+
+        let upserted = drain_row_upserts(&mut persist_rx);
+        assert_eq!(upserted.len(), 1);
+
+        // The upsert should preserve the original sequence (1), not persist 0
+        let (id, seq) = &upserted[0];
+        assert_eq!(id, "asst-1");
+        assert_eq!(*seq, 1, "upserted row should keep its assigned sequence");
+    }
+
+    #[tokio::test]
+    async fn in_memory_and_persisted_sequences_agree() {
+        let (persist_tx, mut persist_rx) = mpsc::channel(64);
+        let actor = SessionActorHandle::spawn(test_handle(), persist_tx);
+
+        for i in 0..3 {
+            actor
+                .send(SessionCommand::AddRowAndBroadcast {
+                    entry: user_row(&format!("row-{i}")),
+                })
+                .await;
+        }
+
+        tokio::task::yield_now().await;
+        tokio::task::yield_now().await;
+
+        let persisted = drain_row_appends(&mut persist_rx);
+        let page = actor.conversation_page(None, 100).await.unwrap();
+        let in_memory: Vec<(String, u64)> = page
+            .rows
+            .iter()
+            .map(|r| (r.id().to_string(), r.sequence))
+            .collect();
+
+        // In-memory and persisted must be identical
+        assert_eq!(in_memory, persisted);
+    }
+
     #[tokio::test]
     async fn actor_throttles_streaming_row_update_broadcasts_but_emits_final_row() {
         let (persist_tx, _persist_rx) = mpsc::channel(64);

--- a/orbitdock-server/crates/server/src/runtime/session_command_handler.rs
+++ b/orbitdock-server/crates/server/src/runtime/session_command_handler.rs
@@ -332,6 +332,15 @@ pub async fn handle_session_command(
             let previous_last_message = handle.to_snapshot().last_message.clone();
 
             let entry = handle.add_row(entry);
+
+            // Persist with the correctly-sequenced entry (single-writer principle)
+            let _ = persist_tx
+                .send(PersistCommand::RowAppend {
+                    session_id: session_id.clone(),
+                    entry: entry.clone(),
+                })
+                .await;
+
             let observability_changes = row_append_delta(
                 previous_last_message.as_deref(),
                 &entry,
@@ -362,6 +371,15 @@ pub async fn handle_session_command(
         SessionCommand::UpsertRowAndBroadcast { entry } => {
             let session_id = handle.id().to_string();
             let entry = handle.upsert_row(entry);
+
+            // Persist with the correctly-sequenced entry (single-writer principle)
+            let _ = persist_tx
+                .send(PersistCommand::RowUpsert {
+                    session_id: session_id.clone(),
+                    entry: entry.clone(),
+                })
+                .await;
+
             let rows_changed = ServerMessage::ConversationRowsChanged {
                 session_id,
                 upserted: vec![entry.to_summary()],

--- a/orbitdock-server/crates/server/src/runtime/session_runtime_helpers.rs
+++ b/orbitdock-server/crates/server/src/runtime/session_runtime_helpers.rs
@@ -367,37 +367,28 @@ pub(crate) async fn sync_transcript_messages(
     match plan.message_sync_decision {
         TranscriptMessageSyncDecision::AppendNewMessages => {
             // Upsert existing rows that got results attached by the transcript parser.
+            // UpsertRowAndBroadcast handles persistence internally.
             for entry in plan.updated_rows {
-                let _ = persist_tx
-                    .send(
-                        crate::infrastructure::persistence::PersistCommand::RowUpsert {
-                            session_id: session_id.clone(),
-                            entry: entry.clone(),
-                        },
-                    )
-                    .await;
                 actor
                     .send(SessionCommand::UpsertRowAndBroadcast { entry })
                     .await;
             }
 
+            // AddRowAndBroadcast handles persistence internally.
             for entry in plan.new_rows {
-                let _ = persist_tx
-                    .send(
-                        crate::infrastructure::persistence::PersistCommand::RowAppend {
-                            session_id: session_id.clone(),
-                            entry: entry.clone(),
-                        },
-                    )
-                    .await;
                 actor
                     .send(SessionCommand::AddRowAndBroadcast { entry })
                     .await;
             }
         }
         TranscriptMessageSyncDecision::ForceResync => {
-            // Full resync — replace all rows in-memory and broadcast
-            for entry in &plan.new_rows {
+            // Full resync — normalize sequences before persisting (matching
+            // what replace_rows() does internally), then replace in-memory.
+            let mut rows = plan.new_rows;
+            for (i, entry) in rows.iter_mut().enumerate() {
+                entry.sequence = i as u64;
+            }
+            for entry in &rows {
                 let _ = persist_tx
                     .send(
                         crate::infrastructure::persistence::PersistCommand::RowUpsert {
@@ -407,11 +398,7 @@ pub(crate) async fn sync_transcript_messages(
                     )
                     .await;
             }
-            actor
-                .send(SessionCommand::ReplaceRows {
-                    rows: plan.new_rows,
-                })
-                .await;
+            actor.send(SessionCommand::ReplaceRows { rows }).await;
         }
         TranscriptMessageSyncDecision::SkipNoNewMessages => {}
     }


### PR DESCRIPTION
## Summary

- **Root cause**: 6 callsites sent `PersistCommand::RowAppend` to the persistence channel independently of the session actor that assigns correct sequence numbers. The DB stored `sequence=0` for most rows, corrupting ordering during fast tool bursts and causing data loss via pagination cursor misses.
- **Fix**: `AddRowAndBroadcast` and `UpsertRowAndBroadcast` command handlers now own persistence internally — they call `add_row()`/`upsert_row()` (which assigns the correct sequence), then send the correctly-sequenced entry to `persist_tx`. All 6 external dual-write sites removed.
- **SQL fix**: `RowUpsert` ON CONFLICT now updates `sequence` column so existing corrupted rows can be corrected.
- **Startup backfill**: Normalizes sequences before persisting (matching what `replace_rows()` does internally).
- **Docs**: AGENTS.md updated with "Row Persistence: Single-Writer Principle" section.

## Test plan

- [x] 10 new tests (4 actor-level, 6 DB-level) verify:
  - Burst of rows with `sequence: 0` → persistence receives monotonic sequences
  - Mixed row types in burst → strictly increasing sequences
  - Upsert with `sequence: 0` → persistence gets the correct original sequence
  - In-memory rows and persisted entries have identical sequences
  - `RowUpsert` updates sequence on conflict in SQLite
  - Batch ordering preserved through the writer
- [x] All 436 existing tests pass, 0 warnings
- [ ] Manual: run a session with fast tool bursts, verify `SELECT id, sequence, type FROM messages WHERE session_id = 'xxx' ORDER BY sequence` shows monotonically increasing sequences