### PR TITLE
✨ Tool rendering overhaul — bug fixes, design upgrades, unified classification

### DIFF
--- a/OrbitDockNative/OrbitDock/Services/Server/Protocol/ServerConversationContracts.swift
+++ b/OrbitDockNative/OrbitDock/Services/Server/Protocol/ServerConversationContracts.swift
@@ -802,4 +802,11 @@ struct ServerToolDiffPreview: Codable {
 struct ServerToolTodoItem: Codable {
   let status: String
   let content: String?
+  let activeForm: String?
+
+  enum CodingKeys: String, CodingKey {
+    case status
+    case content
+    case activeForm = "active_form"
+  }
 }

--- a/OrbitDockNative/OrbitDock/Views/Conversation/Cells/ActivityGroupRowView.swift
+++ b/OrbitDockNative/OrbitDock/Views/Conversation/Cells/ActivityGroupRowView.swift
@@ -30,7 +30,7 @@ struct ActivityGroupRowView: View {
         .onTapGesture { onToggle?(group.id) }
 
       if isExpanded {
-        VStack(spacing: Spacing.xxs) {
+        VStack(spacing: Spacing.xs) {
           ForEach(group.children, id: \.id) { child in
             ToolCardView(
               toolRow: child,

--- a/OrbitDockNative/OrbitDock/Views/Conversation/Cells/ToolCardView.swift
+++ b/OrbitDockNative/OrbitDock/Views/Conversation/Cells/ToolCardView.swift
@@ -75,7 +75,7 @@ struct ToolCardView: View {
     .background(cardBackground)
     .overlay(alignment: .leading) { accentEdge }
     //  horizontal padding handled by TimelineRowContent
-    .padding(.vertical, Spacing.xxs)
+    .padding(.vertical, Spacing.xs)
     .contentShape(Rectangle())
     .onTapGesture { onToggle?() }
   }
@@ -246,29 +246,63 @@ struct ToolCardView: View {
         .font(.system(size: TypeScale.meta, design: .monospaced))
         .foregroundStyle(Color.textTertiary)
     }
+    .padding(.horizontal, Spacing.sm)
+    .padding(.vertical, Spacing.xs)
+    .background(Color.backgroundCode, in: RoundedRectangle(cornerRadius: Radius.xs))
     .padding(.horizontal, Spacing.md)
     .padding(.bottom, Spacing.sm_)
   }
 
   private func outputPreviewStrip(_ preview: String) -> some View {
     let firstLine = preview.components(separatedBy: "\n").first(where: { !$0.isEmpty }) ?? preview
-    return Text(firstLine)
-      .font(.system(size: TypeScale.meta, design: .monospaced))
-      .foregroundStyle(Color.textQuaternary)
-      .padding(.horizontal, Spacing.md)
-      .padding(.bottom, Spacing.sm_)
+    let isBash = toolType == "bash"
+
+    return HStack(spacing: Spacing.xs) {
+      if isBash {
+        Text("$")
+          .font(.system(size: TypeScale.meta, weight: .bold, design: .monospaced))
+          .foregroundStyle(Color.toolBash.opacity(0.3))
+      }
+      Text(firstLine)
+        .font(.system(size: TypeScale.meta, design: .monospaced))
+        .foregroundStyle(isBash ? Color.textTertiary : Color.textQuaternary)
+    }
+    .padding(.horizontal, Spacing.sm)
+    .padding(.vertical, Spacing.xs)
+    .background(Color.backgroundCode, in: RoundedRectangle(cornerRadius: Radius.xs))
+    .padding(.horizontal, Spacing.md)
+    .padding(.bottom, Spacing.sm_)
   }
 
   private func todoPreviewStrip(_ items: [ServerToolTodoItem]) -> some View {
     let completed = items.filter { $0.status == "completed" }.count
-    return HStack(spacing: Spacing.xs) {
+    let total = items.count
+    let fraction = total > 0 ? CGFloat(completed) / CGFloat(total) : 0
+
+    return HStack(spacing: Spacing.sm_) {
       Image(systemName: "checklist")
         .font(.system(size: 8))
         .foregroundStyle(Color.toolTodo)
-      Text("\(completed)/\(items.count) done")
+      Text("\(completed)/\(total) done")
         .font(.system(size: TypeScale.meta))
         .foregroundStyle(Color.textTertiary)
+
+      // Inline micro progress bar
+      GeometryReader { geo in
+        ZStack(alignment: .leading) {
+          RoundedRectangle(cornerRadius: Radius.xs)
+            .fill(Color.feedbackPositive.opacity(OpacityTier.subtle))
+            .frame(height: 3)
+          RoundedRectangle(cornerRadius: Radius.xs)
+            .fill(Color.feedbackPositive)
+            .frame(width: geo.size.width * fraction, height: 3)
+        }
+      }
+      .frame(width: 40, height: 3)
     }
+    .padding(.horizontal, Spacing.sm)
+    .padding(.vertical, Spacing.xs)
+    .background(Color.backgroundCode, in: RoundedRectangle(cornerRadius: Radius.xs))
     .padding(.horizontal, Spacing.md)
     .padding(.bottom, Spacing.sm_)
   }

--- a/OrbitDockNative/OrbitDock/Views/ToolCards/Components/SmartJSONView.swift
+++ b/OrbitDockNative/OrbitDock/Views/ToolCards/Components/SmartJSONView.swift
@@ -3,8 +3,9 @@
 //  OrbitDock
 //
 //  Adaptive JSON renderer that auto-selects the best display format:
-//  - Simple flat objects (<5 keys, no nesting) → key-value field list
-//  - Complex JSON (nested, arrays, >5 keys) → JSONTreeView
+//  - Simple flat objects (<10 keys, no nesting) → key-value field list
+//  - Uniform array of flat objects (<=10 items) → separated card list
+//  - Complex JSON (nested, arrays, >10 keys) → JSONTreeView
 //  - Plain text / single string → body text
 //
 
@@ -23,6 +24,9 @@ struct SmartJSONView: View {
 
       case let .keyValuePairs(pairs):
         keyValueList(pairs)
+
+      case let .uniformArray(items):
+        uniformArrayList(items)
 
       case .complexJSON:
         JSONTreeView(jsonString: jsonString)
@@ -72,10 +76,24 @@ struct SmartJSONView: View {
           .foregroundStyle(Color.accent)
       }
     } else if let string = value as? String {
-      Text(string)
-        .font(.system(size: TypeScale.code, design: .monospaced))
-        .foregroundStyle(Color.textSecondary)
-        .lineLimit(3)
+      if looksLikeURL(string) {
+        Text(string.count > 80 ? String(string.prefix(77)) + "..." : string)
+          .font(.system(size: TypeScale.code, design: .monospaced))
+          .foregroundStyle(Color.accent)
+      } else if looksLikePath(string) {
+        HStack(spacing: Spacing.xs) {
+          Image(systemName: "doc.plaintext")
+            .font(.system(size: 8))
+            .foregroundStyle(Color.toolRead)
+          Text(string.count > 80 ? String(string.prefix(77)) + "..." : string)
+            .font(.system(size: TypeScale.code, design: .monospaced))
+            .foregroundStyle(Color.textSecondary)
+        }
+      } else {
+        Text(string.count > 80 ? String(string.prefix(77)) + "..." : string)
+          .font(.system(size: TypeScale.code, design: .monospaced))
+          .foregroundStyle(Color.textSecondary)
+      }
     } else {
       Text(String(describing: value))
         .font(.system(size: TypeScale.code, design: .monospaced))
@@ -88,6 +106,7 @@ struct SmartJSONView: View {
   private enum JSONShape {
     case plainText(String)
     case keyValuePairs([(key: String, value: Any)])
+    case uniformArray([[String: Any]])
     case complexJSON
   }
 
@@ -106,10 +125,10 @@ struct SmartJSONView: View {
       return .plainText(single)
     }
 
-    // Flat object with <5 keys and no nested objects/arrays
+    // Flat object with <10 keys and no nested objects/arrays
     if let dict = parsed as? [String: Any] {
       let keys = dict.keys.sorted()
-      if keys.count > 0, keys.count < 5 {
+      if keys.count > 0, keys.count < 10 {
         let hasNesting = dict.values.contains { $0 is [String: Any] || $0 is [Any] }
         if !hasNesting {
           let pairs = keys.map { (key: $0, value: dict[$0]!) }
@@ -118,7 +137,57 @@ struct SmartJSONView: View {
       }
     }
 
+    // Array of uniform flat objects
+    if let array = parsed as? [[String: Any]] {
+      let allFlat = array.allSatisfy { dict in
+        dict.count < 10 && !dict.values.contains { $0 is [String: Any] || $0 is [Any] }
+      }
+      if allFlat, !array.isEmpty, array.count <= 10 {
+        return .uniformArray(array)
+      }
+    }
+
     // Everything else: complex JSON
     return .complexJSON
+  }
+
+  // MARK: - Uniform Array List
+
+  private func uniformArrayList(_ items: [[String: Any]]) -> some View {
+    VStack(alignment: .leading, spacing: 0) {
+      ForEach(Array(items.enumerated()), id: \.offset) { index, item in
+        let keys = item.keys.sorted()
+        VStack(alignment: .leading, spacing: Spacing.xs) {
+          ForEach(Array(keys.enumerated()), id: \.offset) { _, key in
+            HStack(alignment: .top, spacing: Spacing.sm) {
+              Text(key)
+                .font(.system(size: TypeScale.caption, weight: .semibold))
+                .foregroundStyle(Color.textTertiary)
+                .frame(width: labelWidth, alignment: .trailing)
+              valueView(item[key]!)
+            }
+          }
+        }
+        .padding(Spacing.sm)
+
+        if index < items.count - 1 {
+          Rectangle()
+            .fill(Color.textQuaternary.opacity(0.08))
+            .frame(height: 1)
+        }
+      }
+    }
+    .frame(maxWidth: .infinity, alignment: .leading)
+    .background(Color.backgroundCode, in: RoundedRectangle(cornerRadius: Radius.sm))
+  }
+
+  // MARK: - String Helpers
+
+  private func looksLikePath(_ s: String) -> Bool {
+    s.hasPrefix("/") || s.hasPrefix("./") || s.hasPrefix("~/")
+  }
+
+  private func looksLikeURL(_ s: String) -> Bool {
+    s.hasPrefix("http://") || s.hasPrefix("https://")
   }
 }

--- a/OrbitDockNative/OrbitDock/Views/ToolCards/Expanded/BashExpandedView.swift
+++ b/OrbitDockNative/OrbitDock/Views/ToolCards/Expanded/BashExpandedView.swift
@@ -2,8 +2,9 @@
 //  BashExpandedView.swift
 //  OrbitDock
 //
-//  Terminal emulator feel for bash tool output.
-//  Features: slim terminal chrome, ANSI color parsing, scrollable capped output, exit status.
+//  Unified terminal block for bash tool output.
+//  Features: single terminal chrome + command + output block, ANSI color parsing,
+//  scrollable capped output viewport, footer bar with exit status + expand/collapse.
 //
 
 import SwiftUI
@@ -28,139 +29,70 @@ struct BashExpandedView: View {
 
   var body: some View {
     VStack(alignment: .leading, spacing: 0) {
-      if let input = content.inputDisplay, !input.isEmpty {
-        let command = input.hasPrefix("$ ") ? String(input.dropFirst(2)) : input
+      // Single unified terminal block
+      VStack(alignment: .leading, spacing: 0) {
+        TerminalChrome(path: nil)
 
-        // Terminal chrome + command as a single block
-        VStack(alignment: .leading, spacing: 0) {
-          TerminalChrome(path: nil)
-
-          // Command line
+        // Command line
+        if let input = content.inputDisplay, !input.isEmpty {
+          let command = input.hasPrefix("$ ") ? String(input.dropFirst(2)) : input
           HStack(alignment: .top, spacing: Spacing.xs) {
             Text("$")
               .font(.system(size: TypeScale.code, weight: .bold, design: .monospaced))
               .foregroundStyle(Color.toolBash)
-
             let highlighted = SyntaxHighlighter.highlightLine(command, language: "bash")
             Text(highlighted)
           }
-          .padding(Spacing.sm)
+          .padding(.horizontal, Spacing.sm)
+          .padding(.vertical, Spacing.sm)
         }
-        .background(Color.backgroundCode)
-        .clipShape(RoundedRectangle(cornerRadius: Radius.sm))
-      }
 
-      if let output = content.outputDisplay, !output.isEmpty {
-        let lineCount = output.components(separatedBy: "\n").count
-        let parsed = ANSIColorParser.parse(output)
-        let useViewport = lineCount > inlineThreshold && !isFullyExpanded
+        // Output flows directly below — no gap, no header
+        if let output = content.outputDisplay, !output.isEmpty {
+          // Thin separator between command and output
+          Rectangle()
+            .fill(Color.textQuaternary.opacity(0.06))
+            .frame(height: 1)
+            .padding(.horizontal, Spacing.sm)
 
-        VStack(alignment: .leading, spacing: Spacing.xs) {
-          // Output header
-          HStack(spacing: Spacing.sm) {
-            Text("Output")
-              .font(.system(size: TypeScale.caption, weight: .semibold))
-              .foregroundStyle(Color.textTertiary)
+          outputContent(output)
 
-            Spacer()
-
-            Text("\(lineCount) lines")
-              .font(.system(size: TypeScale.mini, design: .monospaced))
-              .foregroundStyle(Color.textQuaternary)
-              .padding(.horizontal, Spacing.sm_)
-              .padding(.vertical, Spacing.xxs)
-              .background(Color.backgroundSecondary, in: Capsule())
-
-            exitCodePill(failed: isFailed)
-          }
-          .padding(.top, Spacing.sm)
-
-          // Output content — viewport or inline
-          if useViewport {
-            // Scrollable capped viewport
-            VStack(spacing: 0) {
-              ScrollView(.vertical, showsIndicators: false) {
-                Text(parsed)
-                  .padding(Spacing.sm)
-                  .frame(maxWidth: .infinity, alignment: .leading)
-              }
-              .frame(maxHeight: maxOutputHeight)
-              .mask(edgeFadeMask)
-
-              // Footer
-              HStack {
-                Text("\(lineCount) lines")
-                  .font(.system(size: TypeScale.mini, design: .monospaced))
-                  .foregroundStyle(Color.textQuaternary)
-                Spacer()
-                Button {
-                  withAnimation(Motion.standard) {
-                    isFullyExpanded = true
-                  }
-                } label: {
-                  HStack(spacing: Spacing.xs) {
-                    Image(systemName: "arrow.up.left.and.arrow.down.right")
-                      .font(.system(size: 8))
-                    Text("Expand to full")
-                      .font(.system(size: TypeScale.mini, weight: .medium))
-                  }
-                  .foregroundStyle(Color.toolBash)
-                }
-                .buttonStyle(.plain)
-              }
-              .padding(.horizontal, Spacing.sm)
-              .padding(.vertical, Spacing.sm_)
-              .overlay(alignment: .top) {
-                Rectangle()
-                  .fill(Color.textQuaternary.opacity(0.06))
-                  .frame(height: 1)
-              }
-            }
-            .background(
-              isFailed
-                ? Color.feedbackNegative.opacity(OpacityTier.tint)
-                : Color.backgroundCode,
-              in: RoundedRectangle(cornerRadius: Radius.sm)
-            )
-          } else {
-            // Inline (small output or fully expanded)
-            VStack(alignment: .leading, spacing: 0) {
-              Text(parsed)
-                .padding(Spacing.sm)
-                .frame(maxWidth: .infinity, alignment: .leading)
-
-              if lineCount > inlineThreshold {
-                // Collapse button
-                HStack {
-                  Spacer()
-                  Button {
-                    withAnimation(Motion.standard) {
-                      isFullyExpanded = false
-                    }
-                  } label: {
-                    HStack(spacing: Spacing.xs) {
-                      Image(systemName: "arrow.down.right.and.arrow.up.left")
-                        .font(.system(size: 8))
-                      Text("Collapse to viewport")
-                        .font(.system(size: TypeScale.mini, weight: .medium))
-                    }
-                    .foregroundStyle(Color.toolBash)
-                  }
-                  .buttonStyle(.plain)
-                }
-                .padding(.horizontal, Spacing.sm)
-                .padding(.bottom, Spacing.sm)
-              }
-            }
-            .background(
-              isFailed
-                ? Color.feedbackNegative.opacity(OpacityTier.tint)
-                : Color.backgroundCode,
-              in: RoundedRectangle(cornerRadius: Radius.sm)
-            )
-          }
+          // Footer bar
+          footerBar(lineCount: output.components(separatedBy: "\n").count)
         }
       }
+      .background(
+        isFailed
+          ? Color.feedbackNegative.opacity(OpacityTier.tint)
+          : Color.backgroundCode,
+        in: RoundedRectangle(cornerRadius: Radius.sm)
+      )
+    }
+  }
+
+  // MARK: - Output Content
+
+  /// Output content — viewport or inline depending on line count
+  @ViewBuilder
+  private func outputContent(_ output: String) -> some View {
+    let lineCount = output.components(separatedBy: "\n").count
+    let parsed = ANSIColorParser.parse(output)
+    let useViewport = lineCount > inlineThreshold && !isFullyExpanded
+
+    if useViewport {
+      ScrollView(.vertical, showsIndicators: false) {
+        Text(parsed)
+          .padding(.horizontal, Spacing.sm)
+          .padding(.vertical, Spacing.xs)
+          .frame(maxWidth: .infinity, alignment: .leading)
+      }
+      .frame(maxHeight: maxOutputHeight)
+      .mask(edgeFadeMask)
+    } else {
+      Text(parsed)
+        .padding(.horizontal, Spacing.sm)
+        .padding(.vertical, Spacing.xs)
+        .frame(maxWidth: .infinity, alignment: .leading)
     }
   }
 
@@ -176,7 +108,48 @@ struct BashExpandedView: View {
     }
   }
 
-  // MARK: - Exit Code
+  // MARK: - Footer Bar
+
+  /// Unified footer bar with line count, exit code pill, and expand/collapse
+  private func footerBar(lineCount: Int) -> some View {
+    HStack(spacing: Spacing.sm) {
+      Text("\(lineCount) lines")
+        .font(.system(size: TypeScale.mini, design: .monospaced))
+        .foregroundStyle(Color.textQuaternary)
+
+      exitCodePill(failed: isFailed)
+
+      Spacer()
+
+      if lineCount > inlineThreshold {
+        Button {
+          withAnimation(Motion.standard) {
+            isFullyExpanded.toggle()
+          }
+        } label: {
+          HStack(spacing: Spacing.xs) {
+            Image(systemName: isFullyExpanded
+              ? "arrow.down.right.and.arrow.up.left"
+              : "arrow.up.left.and.arrow.down.right")
+              .font(.system(size: 8))
+            Text(isFullyExpanded ? "Collapse" : "Expand")
+              .font(.system(size: TypeScale.mini, weight: .medium))
+          }
+          .foregroundStyle(Color.toolBash)
+        }
+        .buttonStyle(.plain)
+      }
+    }
+    .padding(.horizontal, Spacing.sm)
+    .padding(.vertical, Spacing.sm_)
+    .overlay(alignment: .top) {
+      Rectangle()
+        .fill(Color.textQuaternary.opacity(0.06))
+        .frame(height: 1)
+    }
+  }
+
+  // MARK: - Exit Code Pill
 
   private func exitCodePill(failed: Bool) -> some View {
     let color: Color = failed ? .feedbackNegative : .feedbackPositive

--- a/OrbitDockNative/OrbitDock/Views/ToolCards/Expanded/GenericExpandedView.swift
+++ b/OrbitDockNative/OrbitDock/Views/ToolCards/Expanded/GenericExpandedView.swift
@@ -15,7 +15,7 @@ struct GenericExpandedView: View {
     VStack(alignment: .leading, spacing: Spacing.md) {
       if let input = content.inputDisplay, !input.isEmpty {
         VStack(alignment: .leading, spacing: Spacing.xs) {
-          Text("Input")
+          Text(inputSectionHeader(input))
             .font(.system(size: TypeScale.caption, weight: .semibold))
             .foregroundStyle(Color.textTertiary)
           smartContent(input, language: nil)
@@ -27,18 +27,42 @@ struct GenericExpandedView: View {
       }
 
       if let output = content.outputDisplay, !output.isEmpty {
+        let hasError = output.lowercased().contains("error")
+          || output.lowercased().contains("failed")
+          || output.lowercased().contains("not found")
+
         VStack(alignment: .leading, spacing: Spacing.xs) {
-          Text("Output")
+          Text("Result")
             .font(.system(size: TypeScale.caption, weight: .semibold))
             .foregroundStyle(Color.textTertiary)
-          smartContent(output, language: content.language)
+
+          if output.count < 100, !output.contains("\n") {
+            HStack(spacing: Spacing.sm_) {
+              Image(systemName: hasError ? "xmark.circle.fill" : "checkmark.circle.fill")
+                .font(.system(size: IconScale.sm))
+                .foregroundStyle(hasError ? Color.feedbackNegative : Color.feedbackPositive)
+              Text(output)
+                .font(.system(size: TypeScale.body))
+                .foregroundStyle(hasError ? Color.feedbackNegative : Color.textSecondary)
+            }
+            .padding(Spacing.sm)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(
+              hasError
+                ? Color.feedbackNegative.opacity(OpacityTier.tint)
+                : Color.backgroundCode,
+              in: RoundedRectangle(cornerRadius: Radius.sm)
+            )
+          } else {
+            smartContent(output, language: content.language, hasError: hasError)
+          }
         }
       }
     }
   }
 
   @ViewBuilder
-  private func smartContent(_ text: String, language: String?) -> some View {
+  private func smartContent(_ text: String, language: String?, hasError: Bool = false) -> some View {
     if looksLikeJSON(text) {
       SmartJSONView(jsonString: text)
     } else {
@@ -47,8 +71,29 @@ struct GenericExpandedView: View {
         .foregroundStyle(Color.textSecondary)
         .padding(Spacing.sm)
         .frame(maxWidth: .infinity, alignment: .leading)
-        .background(Color.backgroundCode, in: RoundedRectangle(cornerRadius: Radius.sm))
+        .background(
+          hasError
+            ? Color.feedbackNegative.opacity(OpacityTier.tint)
+            : Color.backgroundCode,
+          in: RoundedRectangle(cornerRadius: Radius.sm)
+        )
     }
+  }
+
+  private func inputSectionHeader(_ input: String) -> String {
+    if ToolCardStyle.looksLikeJSON(input),
+       let data = input.data(using: .utf8),
+       let dict = try? JSONSerialization.jsonObject(with: data) as? [String: Any] {
+      if dict["command"] != nil { return "Command" }
+      if dict["query"] != nil { return "Query" }
+      if let path = dict["file_path"] as? String ?? dict["path"] as? String {
+        return path.components(separatedBy: "/").last ?? "File"
+      }
+      if dict.values.contains(where: { ($0 as? String)?.hasPrefix("http") == true }) {
+        return "URL"
+      }
+    }
+    return "Parameters"
   }
 
   private func looksLikeJSON(_ text: String) -> Bool {

--- a/OrbitDockNative/OrbitDock/Views/ToolCards/Expanded/TodoExpandedView.swift
+++ b/OrbitDockNative/OrbitDock/Views/ToolCards/Expanded/TodoExpandedView.swift
@@ -40,18 +40,16 @@ struct TodoExpandedView: View {
           return order(a.status) < order(b.status)
         }
 
-        VStack(alignment: .leading, spacing: Spacing.xs) {
+        VStack(alignment: .leading, spacing: Spacing.sm) {
           ForEach(Array(sortedItems.enumerated()), id: \.offset) { _, item in
             todoItemRow(item)
           }
         }
       }
 
-      if let input = content.inputDisplay, !input.isEmpty {
-        VStack(alignment: .leading, spacing: Spacing.xs) {
-          Text("Input")
-            .font(.system(size: TypeScale.caption, weight: .semibold))
-            .foregroundStyle(Color.textTertiary)
+      // Minimal fallback when todoItems is empty but content exists
+      if display == nil || display?.todoItems.isEmpty == true {
+        if let input = content.inputDisplay, !input.isEmpty {
           Text(input)
             .font(.system(size: TypeScale.code, design: .monospaced))
             .foregroundStyle(Color.textSecondary)
@@ -59,13 +57,8 @@ struct TodoExpandedView: View {
             .frame(maxWidth: .infinity, alignment: .leading)
             .background(Color.backgroundCode, in: RoundedRectangle(cornerRadius: Radius.sm))
         }
-      }
 
-      if let output = content.outputDisplay, !output.isEmpty {
-        VStack(alignment: .leading, spacing: Spacing.xs) {
-          Text("Output")
-            .font(.system(size: TypeScale.caption, weight: .semibold))
-            .foregroundStyle(Color.textTertiary)
+        if let output = content.outputDisplay, !output.isEmpty {
           Text(output)
             .font(.system(size: TypeScale.code, design: .monospaced))
             .foregroundStyle(Color.textSecondary)
@@ -87,20 +80,31 @@ struct TodoExpandedView: View {
     let isCompleted = item.status == "completed"
     let isInProgress = item.status == "in_progress"
 
-    return HStack(spacing: Spacing.sm) {
-      Image(systemName: isCompleted
-        ? "checkmark.circle.fill"
-        : isInProgress ? "circle.dotted" : "circle")
-        .font(.system(size: IconScale.md))
-        .foregroundStyle(
-          isCompleted ? Color.feedbackPositive
-            : isInProgress ? Color.accent
-            : Color.textQuaternary
-        )
+    return VStack(alignment: .leading, spacing: Spacing.xxs) {
+      HStack(spacing: Spacing.sm) {
+        Image(systemName: isCompleted
+          ? "checkmark.circle.fill"
+          : isInProgress ? "circle.dotted" : "circle")
+          .font(.system(size: IconScale.md))
+          .foregroundStyle(
+            isCompleted ? Color.feedbackPositive
+              : isInProgress ? Color.accent
+              : Color.textQuaternary
+          )
 
-      Text(item.content ?? item.status)
-        .font(.system(size: TypeScale.body))
-        .foregroundStyle(isCompleted ? Color.textTertiary : Color.textSecondary)
+        Text(item.content ?? item.status)
+          .font(.system(size: TypeScale.body))
+          .foregroundStyle(isCompleted ? Color.textQuaternary : Color.textSecondary)
+          .strikethrough(isCompleted, color: Color.textQuaternary)
+      }
+
+      // Show activeForm as secondary line for in-progress items
+      if isInProgress, let activeForm = item.activeForm, !activeForm.isEmpty {
+        Text(activeForm)
+          .font(.system(size: TypeScale.caption))
+          .foregroundStyle(Color.textTertiary)
+          .padding(.leading, IconScale.md + Spacing.sm)
+      }
     }
   }
 }

--- a/orbitdock-server/crates/connector-claude/src/lib.rs
+++ b/orbitdock-server/crates/connector-claude/src/lib.rs
@@ -22,7 +22,7 @@ use tracing::{debug, error, info, warn};
 use orbitdock_connector_core::{ApprovalType, ConnectorError, ConnectorEvent};
 use orbitdock_protocol::conversation_contracts::render_hints::RenderHints;
 use orbitdock_protocol::conversation_contracts::{
-    ConversationRow, ConversationRowEntry, MessageRowContent, ToolRow,
+    classify_tool_name, ConversationRow, ConversationRowEntry, MessageRowContent, ToolRow,
 };
 use orbitdock_protocol::domain_events::{ToolFamily, ToolKind, ToolStatus};
 
@@ -31,28 +31,27 @@ use orbitdock_protocol::domain_events::{ToolFamily, ToolKind, ToolStatus};
 // ---------------------------------------------------------------------------
 
 /// Classify a raw tool name from the Claude CLI into (ToolFamily, ToolKind).
+///
+/// Delegates to the shared `classify_tool_name` in orbitdock_protocol, with
+/// additional Claude-specific aliases (MultiEdit, FileRead, etc.).
 fn classify_tool(name: &str) -> (ToolFamily, ToolKind) {
+    // Claude-specific aliases not in the shared classifier
     match name {
-        "Bash" | "bash" => (ToolFamily::Shell, ToolKind::Bash),
-        "Read" | "read" | "FileRead" => (ToolFamily::FileRead, ToolKind::Read),
-        "Edit" | "edit" | "FileEdit" | "MultiEdit" => (ToolFamily::FileChange, ToolKind::Edit),
-        "Write" | "write" | "FileWrite" => (ToolFamily::FileChange, ToolKind::Write),
-        "NotebookEdit" => (ToolFamily::FileChange, ToolKind::NotebookEdit),
-        "Glob" | "glob" => (ToolFamily::Search, ToolKind::Glob),
-        "Grep" | "grep" => (ToolFamily::Search, ToolKind::Grep),
-        "ToolSearch" => (ToolFamily::Search, ToolKind::ToolSearch),
-        "WebSearch" | "websearch" => (ToolFamily::Web, ToolKind::WebSearch),
-        "WebFetch" | "webfetch" => (ToolFamily::Web, ToolKind::WebFetch),
-        "Agent" | "agent" => (ToolFamily::Agent, ToolKind::SpawnAgent),
-        "AskUserQuestion" => (ToolFamily::Question, ToolKind::AskUserQuestion),
-        "EnterPlanMode" => (ToolFamily::Plan, ToolKind::EnterPlanMode),
-        "ExitPlanMode" => (ToolFamily::Plan, ToolKind::ExitPlanMode),
-        "TodoWrite" => (ToolFamily::Todo, ToolKind::TodoWrite),
-        "CompactContext" => (ToolFamily::Context, ToolKind::CompactContext),
-        "task" => (ToolFamily::Agent, ToolKind::SpawnAgent),
-        n if n.starts_with("mcp__") => (ToolFamily::Mcp, ToolKind::McpToolCall),
-        _ => (ToolFamily::Generic, ToolKind::Generic),
+        "FileEdit" | "MultiEdit" => return (ToolFamily::FileChange, ToolKind::Edit),
+        "FileRead" => return (ToolFamily::FileRead, ToolKind::Read),
+        "FileWrite" => return (ToolFamily::FileChange, ToolKind::Write),
+        "SendMessage" => return (ToolFamily::Agent, ToolKind::SendAgentInput),
+        "TaskCreate" | "TaskUpdate" | "TaskList" | "TaskGet" => {
+            return (ToolFamily::Todo, ToolKind::TodoWrite)
+        }
+        "TaskOutput" => return (ToolFamily::Agent, ToolKind::TaskOutput),
+        "TaskStop" => return (ToolFamily::Agent, ToolKind::TaskStop),
+        "Skill" => return (ToolFamily::Mcp, ToolKind::McpToolCall),
+        "ReadMcpResourceTool" => return (ToolFamily::Mcp, ToolKind::ReadMcpResource),
+        "ListMcpResourcesTool" => return (ToolFamily::Mcp, ToolKind::ListMcpResources),
+        _ => {}
     }
+    classify_tool_name(name)
 }
 
 /// Build a flat JSON invocation value from a tool name and optional raw JSON input.

--- a/orbitdock-server/crates/connector-codex/src/event_mapping/mod.rs
+++ b/orbitdock-server/crates/connector-codex/src/event_mapping/mod.rs
@@ -13,3 +13,4 @@ pub(super) mod tools;
 
 pub(super) type SharedStringBuffers = Arc<tokio::sync::Mutex<HashMap<String, String>>>;
 pub(super) type SharedEnvironmentTracker = Arc<tokio::sync::Mutex<EnvironmentTracker>>;
+pub(super) type SharedPatchContexts = Arc<tokio::sync::Mutex<HashMap<String, serde_json::Value>>>;

--- a/orbitdock-server/crates/connector-codex/src/event_mapping/tools.rs
+++ b/orbitdock-server/crates/connector-codex/src/event_mapping/tools.rs
@@ -1,4 +1,4 @@
-use super::{SharedEnvironmentTracker, SharedStringBuffers};
+use super::{SharedEnvironmentTracker, SharedPatchContexts, SharedStringBuffers};
 use crate::runtime::row_entry;
 use crate::timeline::dynamic_tool_output_to_text;
 use crate::workers::iso_now;
@@ -215,7 +215,10 @@ pub(crate) async fn handle_exec_command_end(
     }]
 }
 
-pub(crate) fn handle_patch_apply_begin(event: PatchApplyBeginEvent) -> Vec<ConnectorEvent> {
+pub(crate) async fn handle_patch_apply_begin(
+    event: PatchApplyBeginEvent,
+    patch_contexts: &SharedPatchContexts,
+) -> Vec<ConnectorEvent> {
     let files: Vec<String> = event
         .changes
         .keys()
@@ -261,6 +264,17 @@ pub(crate) fn handle_patch_apply_begin(event: PatchApplyBeginEvent) -> Vec<Conne
         .collect::<Vec<_>>()
         .join("\n\n");
 
+    let invocation = json!({
+        "path": first_file,
+        "diff": unified_diff,
+    });
+
+    // Store for the end handler to merge
+    {
+        let mut contexts = patch_contexts.lock().await;
+        contexts.insert(event.call_id.clone(), invocation.clone());
+    }
+
     vec![ConnectorEvent::ConversationRowCreated(tool_row_entry(
         ToolRow {
             id: event.call_id.clone(),
@@ -276,10 +290,7 @@ pub(crate) fn handle_patch_apply_begin(event: PatchApplyBeginEvent) -> Vec<Conne
             ended_at: None,
             duration_ms: None,
             grouping_key: None,
-            invocation: json!({
-                "path": first_file,
-                "diff": unified_diff,
-            }),
+            invocation,
             result: None,
             render_hints: Default::default(),
             tool_display: None,
@@ -287,7 +298,16 @@ pub(crate) fn handle_patch_apply_begin(event: PatchApplyBeginEvent) -> Vec<Conne
     ))]
 }
 
-pub(crate) fn handle_patch_apply_end(event: PatchApplyEndEvent) -> Vec<ConnectorEvent> {
+pub(crate) async fn handle_patch_apply_end(
+    event: PatchApplyEndEvent,
+    patch_contexts: &SharedPatchContexts,
+) -> Vec<ConnectorEvent> {
+    // Retrieve the begin context (removes it from the map)
+    let begin_context = {
+        let mut contexts = patch_contexts.lock().await;
+        contexts.remove(&event.call_id)
+    };
+
     let mut output_lines: Vec<String> = Vec::new();
     output_lines.push(format!("status: {:?}", event.status));
     if event.success {
@@ -313,6 +333,19 @@ pub(crate) fn handle_patch_apply_end(event: PatchApplyEndEvent) -> Vec<Connector
         ToolStatus::Failed
     };
 
+    // Merge begin context (path + diff) into the end invocation
+    let invocation = if let Some(ctx) = begin_context {
+        json!({
+            "path": ctx.get("path").and_then(|v| v.as_str()).unwrap_or(""),
+            "diff": ctx.get("diff").and_then(|v| v.as_str()).unwrap_or(""),
+            "summary": output.clone(),
+        })
+    } else {
+        json!({
+            "summary": output.clone(),
+        })
+    };
+
     let entry = tool_row_entry(ToolRow {
         id: event.call_id.clone(),
         provider: Provider::Codex,
@@ -327,9 +360,7 @@ pub(crate) fn handle_patch_apply_end(event: PatchApplyEndEvent) -> Vec<Connector
         ended_at: Some(iso_now()),
         duration_ms: None,
         grouping_key: None,
-        invocation: json!({
-            "summary": output.clone(),
-        }),
+        invocation,
         result: Some(json!({
             "tool_name": "Edit",
             "output": output,

--- a/orbitdock-server/crates/connector-codex/src/lib.rs
+++ b/orbitdock-server/crates/connector-codex/src/lib.rs
@@ -87,6 +87,7 @@ impl CodexConnector {
         reasoning_tracker: &Arc<tokio::sync::Mutex<ReasoningEventTracker>>,
         current_model: &Arc<tokio::sync::Mutex<Option<String>>>,
         current_reasoning_effort: &Arc<tokio::sync::Mutex<Option<ReasoningEffort>>>,
+        patch_contexts: &Arc<tokio::sync::Mutex<HashMap<String, serde_json::Value>>>,
     ) -> Vec<ConnectorEvent> {
         #[allow(unreachable_patterns)]
         match event.msg {
@@ -146,9 +147,13 @@ impl CodexConnector {
                 event_mapping::tools::handle_exec_command_end(e, output_buffers).await
             }
 
-            EventMsg::PatchApplyBegin(e) => event_mapping::tools::handle_patch_apply_begin(e),
+            EventMsg::PatchApplyBegin(e) => {
+                event_mapping::tools::handle_patch_apply_begin(e, patch_contexts).await
+            }
 
-            EventMsg::PatchApplyEnd(e) => event_mapping::tools::handle_patch_apply_end(e),
+            EventMsg::PatchApplyEnd(e) => {
+                event_mapping::tools::handle_patch_apply_end(e, patch_contexts).await
+            }
 
             EventMsg::McpToolCallBegin(e) => event_mapping::tools::handle_mcp_tool_call_begin(e),
 

--- a/orbitdock-server/crates/connector-codex/src/runtime.rs
+++ b/orbitdock-server/crates/connector-codex/src/runtime.rs
@@ -133,6 +133,9 @@ impl CodexConnector {
         let current_model = Arc::new(tokio::sync::Mutex::new(Option::<String>::None));
         let current_reasoning_effort =
             Arc::new(tokio::sync::Mutex::new(Option::<ReasoningEffort>::None));
+        let patch_contexts = Arc::new(tokio::sync::Mutex::new(
+            HashMap::<String, serde_json::Value>::new(),
+        ));
 
         let tx = event_tx.clone();
         let thread_for_loop = thread.clone();
@@ -144,6 +147,7 @@ impl CodexConnector {
         let reasoning = reasoning_tracker.clone();
         let model = current_model.clone();
         let effort = current_reasoning_effort.clone();
+        let patches = patch_contexts.clone();
         tokio::spawn(async move {
             Self::event_loop(
                 thread_for_loop,
@@ -156,6 +160,7 @@ impl CodexConnector {
                 reasoning,
                 model,
                 effort,
+                patches,
             )
             .await;
         });
@@ -184,6 +189,7 @@ impl CodexConnector {
         reasoning_tracker: Arc<tokio::sync::Mutex<ReasoningEventTracker>>,
         current_model: Arc<tokio::sync::Mutex<Option<String>>>,
         current_reasoning_effort: Arc<tokio::sync::Mutex<Option<ReasoningEffort>>>,
+        patch_contexts: Arc<tokio::sync::Mutex<HashMap<String, serde_json::Value>>>,
     ) {
         loop {
             match thread.next_event().await {
@@ -198,6 +204,7 @@ impl CodexConnector {
                         &reasoning_tracker,
                         &current_model,
                         &current_reasoning_effort,
+                        &patch_contexts,
                     ))
                     .await;
                     for event in events {

--- a/orbitdock-server/crates/protocol/src/conversation_contracts/mod.rs
+++ b/orbitdock-server/crates/protocol/src/conversation_contracts/mod.rs
@@ -21,9 +21,9 @@ pub use rows::{
     ToolRowSummary, UserRow,
 };
 pub use tool_display::{
-    compute_diff_display, compute_expanded_output, compute_input_display, compute_tool_display,
-    detect_language, extract_start_line, DiffLine, DiffLineKind, ToolDiffPreview, ToolDisplay,
-    ToolTodoItem,
+    classify_tool_name, compute_diff_display, compute_expanded_output, compute_input_display,
+    compute_tool_display, detect_language, extract_start_line, DiffLine, DiffLineKind,
+    ToolDiffPreview, ToolDisplay, ToolTodoItem,
 };
 pub use tool_payloads::{ToolInvocationPayloadContract, ToolPreview, ToolResultPayloadContract};
 pub use workers::WorkerRow;

--- a/orbitdock-server/crates/protocol/src/conversation_contracts/rows.rs
+++ b/orbitdock-server/crates/protocol/src/conversation_contracts/rows.rs
@@ -197,8 +197,6 @@ pub struct ToolRowSummary {
 }
 
 impl ToolRow {
-    /// Convert to wire-safe summary, stripping raw invocation/result.
-    /// Guarantees `tool_display` is populated — computes it on the fly if missing.
     pub fn to_summary(&self) -> ToolRowSummary {
         let display = self.tool_display.clone().unwrap_or_else(|| {
             let result_str = self.result.as_ref().and_then(|v| v.as_str());
@@ -366,8 +364,10 @@ pub fn extract_row_content_str_summary(row: &ConversationRowSummary) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::{ConversationRow, ConversationRowEntry, MessageRowContent};
-    use crate::ImageInput;
+    use super::{ConversationRow, ConversationRowEntry, MessageRowContent, ToolRow};
+    use crate::conversation_contracts::render_hints::RenderHints;
+    use crate::domain_events::{ToolFamily, ToolKind, ToolStatus};
+    use crate::{ImageInput, Provider};
 
     #[test]
     fn message_row_content_round_trips_streaming_images_and_turn_id() {
@@ -415,5 +415,34 @@ mod tests {
         let decoded: ConversationRowEntry =
             serde_json::from_value(json).expect("deserialize conversation row");
         assert_eq!(decoded, entry);
+    }
+
+    #[test]
+    fn flat_invocation_passes_through_unchanged() {
+        // Current format: flat JSON, correct kind — should not be affected
+        let row = ToolRow {
+            id: "toolu_abc".into(),
+            provider: Provider::Claude,
+            family: ToolFamily::Shell,
+            kind: ToolKind::Bash,
+            status: ToolStatus::Completed,
+            title: "Bash".into(),
+            subtitle: None,
+            summary: None,
+            preview: None,
+            started_at: None,
+            ended_at: None,
+            duration_ms: None,
+            grouping_key: None,
+            invocation: serde_json::json!({"command": "ls -la"}),
+            result: Some(serde_json::json!({"output": "file1\nfile2"})),
+            render_hints: RenderHints::default(),
+            tool_display: None,
+        };
+
+        let summary = row.to_summary();
+        assert_eq!(summary.kind, ToolKind::Bash);
+        assert_eq!(summary.family, ToolFamily::Shell);
+        assert_eq!(summary.tool_display.tool_type, "bash");
     }
 }

--- a/orbitdock-server/crates/protocol/src/conversation_contracts/tool_display.rs
+++ b/orbitdock-server/crates/protocol/src/conversation_contracts/tool_display.rs
@@ -97,6 +97,8 @@ pub struct ToolTodoItem {
     pub status: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub content: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub active_form: Option<String>,
 }
 
 /// A single line in a structured diff.
@@ -459,15 +461,30 @@ fn extract_subtitle_from_input(
                 .and_then(|v| v.as_str())
                 .map(String::from)
         }
-        ToolKind::ViewImage => file_name_from_input(input),
+        ToolKind::ViewImage => file_name_from_input(input).or_else(|| {
+            input
+                .get("image_paths")
+                .and_then(|v| v.as_array())
+                .and_then(|a| a.first())
+                .and_then(|v| v.as_str())
+                .and_then(|p| p.rsplit('/').next())
+                .map(String::from)
+        }),
         ToolKind::Config => input.get("key").and_then(|v| v.as_str()).map(String::from),
+        ToolKind::ToolSearch => input
+            .get("query")
+            .and_then(|v| v.as_str())
+            .map(|q| truncate(q, 80)),
         _ => None,
     };
     result.filter(|s| !s.trim().is_empty())
 }
 
 fn file_name_from_input(input: &serde_json::Value) -> Option<String> {
-    let path = input.get("file_path").and_then(|v| v.as_str())?;
+    let path = input
+        .get("file_path")
+        .or_else(|| input.get("path"))
+        .and_then(|v| v.as_str())?;
     // Extract just the filename
     path.rsplit('/').next().map(String::from)
 }
@@ -599,7 +616,10 @@ pub fn detect_language(kind: ToolKind, input: Option<&serde_json::Value>) -> Opt
     ) {
         return None;
     }
-    let path = input?.get("file_path").and_then(|v| v.as_str())?;
+    let path = input?
+        .get("file_path")
+        .or_else(|| input?.get("path"))
+        .and_then(|v| v.as_str())?;
     let ext = path.rsplit('.').next()?;
     let lang = match ext {
         "swift" => "Swift",
@@ -683,7 +703,48 @@ fn compute_diff_preview(
                 deletions: 0,
             })
         }
-        _ => None,
+        _ => {
+            // Fallback: try parsing a unified diff (Codex sends "diff" or "unified_diff")
+            let diff_str = input
+                .get("unified_diff")
+                .or_else(|| input.get("diff"))
+                .and_then(|v| v.as_str())
+                .filter(|s| !s.is_empty())?;
+            let parsed = parse_unified_diff_string(diff_str);
+            if parsed.is_empty() {
+                return None;
+            }
+            let mut additions: u32 = 0;
+            let mut deletions: u32 = 0;
+            let mut first_changed: Option<(&str, bool)> = None;
+            for line in &parsed {
+                match line.kind {
+                    DiffLineKind::Addition => {
+                        additions += 1;
+                        if first_changed.is_none() {
+                            first_changed = Some((&line.content, true));
+                        }
+                    }
+                    DiffLineKind::Deletion => {
+                        deletions += 1;
+                        if first_changed.is_none() {
+                            first_changed = Some((&line.content, false));
+                        }
+                    }
+                    DiffLineKind::Context => {}
+                }
+            }
+            let (snippet, is_addition) = first_changed.unwrap_or(("", true));
+            let prefix = if is_addition { "+" } else { "-" };
+            Some(ToolDiffPreview {
+                context_line: None,
+                snippet_text: truncate(snippet, 80),
+                snippet_prefix: prefix.to_string(),
+                is_addition,
+                additions,
+                deletions,
+            })
+        }
     }
 }
 
@@ -705,7 +766,19 @@ pub fn compute_input_display(kind: ToolKind, input: Option<&serde_json::Value>) 
         }
         ToolKind::Read | ToolKind::Edit | ToolKind::Write | ToolKind::NotebookEdit => input
             .get("file_path")
+            .or_else(|| input.get("path"))
             .and_then(|v| v.as_str())
+            .map(String::from),
+        ToolKind::ViewImage => input
+            .get("file_path")
+            .and_then(|v| v.as_str())
+            .or_else(|| {
+                input
+                    .get("image_paths")
+                    .and_then(|v| v.as_array())
+                    .and_then(|a| a.first())
+                    .and_then(|v| v.as_str())
+            })
             .map(String::from),
         ToolKind::Glob | ToolKind::Grep => input
             .get("pattern")
@@ -727,6 +800,27 @@ pub fn compute_input_display(kind: ToolKind, input: Option<&serde_json::Value>) 
                 None if !label.is_empty() => Some(label.to_string()),
                 _ => None,
             }
+        }
+        ToolKind::ToolSearch => input
+            .get("query")
+            .and_then(|v| v.as_str())
+            .map(String::from),
+        ToolKind::ExitPlanMode => {
+            // ExitPlanMode carries allowedPrompts (internal) — don't display.
+            // If there's a plan field, extract the first heading as summary.
+            None
+        }
+        ToolKind::EnterPlanMode | ToolKind::UpdatePlan => {
+            // Show the plan explanation or title, not the raw JSON
+            input
+                .get("plan")
+                .and_then(|v| v.as_str())
+                .or_else(|| input.get("explanation").and_then(|v| v.as_str()))
+                .map(String::from)
+        }
+        ToolKind::TodoWrite => {
+            // Todo input isn't useful for expanded display — the items are shown via todoItems
+            None
         }
         ToolKind::McpToolCall | ToolKind::DynamicToolCall => {
             serde_json::to_string_pretty(input).ok()
@@ -888,7 +982,11 @@ pub fn compute_diff_display(
     let input = input?;
 
     // Check for pre-computed unified_diff first — parse it into structured lines
-    if let Some(diff_str) = input.get("unified_diff").and_then(|v| v.as_str()) {
+    if let Some(diff_str) = input
+        .get("unified_diff")
+        .or_else(|| input.get("diff"))
+        .and_then(|v| v.as_str())
+    {
         if !diff_str.is_empty() {
             return Some(parse_unified_diff_string(diff_str));
         }
@@ -1058,8 +1156,12 @@ fn extract_todo_items(kind: ToolKind, input: Option<&serde_json::Value>) -> Vec<
         Some(v) => v,
         None => return vec![],
     };
-    // TodoWrite input shape: {"tasks": [{"content": "...", "status": "completed"}, ...]}
-    let items = match input.get("tasks").and_then(|v| v.as_array()) {
+    // TodoWrite input shape: {"tasks": [...]} (Claude) or {"todos": [...]} (Codex)
+    let items = match input
+        .get("tasks")
+        .or_else(|| input.get("todos"))
+        .and_then(|v| v.as_array())
+    {
         Some(arr) => arr,
         None => return vec![],
     };
@@ -1075,7 +1177,47 @@ fn extract_todo_items(kind: ToolKind, input: Option<&serde_json::Value>) -> Vec<
                 .get("content")
                 .and_then(|v| v.as_str())
                 .map(|s| truncate(s, 200));
-            ToolTodoItem { status, content }
+            let active_form = item
+                .get("activeForm")
+                .and_then(|v| v.as_str())
+                .map(|s| truncate(s, 200));
+            ToolTodoItem {
+                status,
+                content,
+                active_form,
+            }
         })
         .collect()
+}
+
+/// Classify a tool name into (ToolFamily, ToolKind).
+/// Shared logic so both the connector and the legacy-unwrap path use the same mapping.
+pub fn classify_tool_name(name: &str) -> (ToolFamily, ToolKind) {
+    match name {
+        "Bash" | "bash" => (ToolFamily::Shell, ToolKind::Bash),
+        "Read" | "read" | "FileRead" => (ToolFamily::FileRead, ToolKind::Read),
+        "Edit" | "edit" | "FileEdit" | "MultiEdit" => (ToolFamily::FileChange, ToolKind::Edit),
+        "Write" | "write" | "FileWrite" => (ToolFamily::FileChange, ToolKind::Write),
+        "NotebookEdit" => (ToolFamily::FileChange, ToolKind::NotebookEdit),
+        "Glob" | "glob" => (ToolFamily::Search, ToolKind::Glob),
+        "Grep" | "grep" => (ToolFamily::Search, ToolKind::Grep),
+        "ToolSearch" => (ToolFamily::Search, ToolKind::ToolSearch),
+        "WebSearch" | "websearch" => (ToolFamily::Web, ToolKind::WebSearch),
+        "WebFetch" | "webfetch" => (ToolFamily::Web, ToolKind::WebFetch),
+        "Agent" | "agent" | "task" => (ToolFamily::Agent, ToolKind::SpawnAgent),
+        "AskUserQuestion" => (ToolFamily::Question, ToolKind::AskUserQuestion),
+        "EnterPlanMode" => (ToolFamily::Plan, ToolKind::EnterPlanMode),
+        "ExitPlanMode" => (ToolFamily::Plan, ToolKind::ExitPlanMode),
+        "UpdatePlan" => (ToolFamily::Plan, ToolKind::UpdatePlan),
+        "TodoWrite" | "todo_write" => (ToolFamily::Todo, ToolKind::TodoWrite),
+        "CompactContext" => (ToolFamily::Context, ToolKind::CompactContext),
+        "Config" => (ToolFamily::Generic, ToolKind::Config),
+        "EnterWorktree" => (ToolFamily::Generic, ToolKind::EnterWorktree),
+        "ViewImage" | "view_image" => (ToolFamily::Image, ToolKind::ViewImage),
+        "ImageGeneration" => (ToolFamily::Image, ToolKind::ImageGeneration),
+        "HookNotification" => (ToolFamily::Hook, ToolKind::HookNotification),
+        "HandoffRequested" => (ToolFamily::Agent, ToolKind::HandoffRequested),
+        n if n.starts_with("mcp__") => (ToolFamily::Mcp, ToolKind::McpToolCall),
+        _ => (ToolFamily::Generic, ToolKind::Generic),
+    }
 }

--- a/orbitdock-server/crates/server/src/infrastructure/persistence/transcripts.rs
+++ b/orbitdock-server/crates/server/src/infrastructure/persistence/transcripts.rs
@@ -3,7 +3,9 @@ use std::fs::File;
 use std::io::{BufRead, BufReader};
 
 use orbitdock_protocol::conversation_contracts::render_hints::RenderHints;
-use orbitdock_protocol::conversation_contracts::tool_display::compute_tool_display;
+use orbitdock_protocol::conversation_contracts::tool_display::{
+    classify_tool_name, compute_tool_display,
+};
 use orbitdock_protocol::conversation_contracts::{
     ConversationRow, ConversationRowEntry, MessageRowContent, ToolRow,
 };
@@ -40,20 +42,9 @@ fn role_from_str(role: &str) -> ParsedRole {
     }
 }
 
+/// Classify a tool name — delegates to the shared classifier in orbitdock_protocol.
 fn classify_tool(name: &str) -> (ToolFamily, ToolKind) {
-    match name {
-        "Bash" | "bash" => (ToolFamily::Shell, ToolKind::Bash),
-        "Read" | "read" | "FileRead" => (ToolFamily::FileRead, ToolKind::Read),
-        "Edit" | "edit" | "FileEdit" => (ToolFamily::FileChange, ToolKind::Edit),
-        "Write" | "write" | "FileWrite" => (ToolFamily::FileChange, ToolKind::Write),
-        "Glob" | "glob" => (ToolFamily::Search, ToolKind::Glob),
-        "Grep" | "grep" => (ToolFamily::Search, ToolKind::Grep),
-        "WebSearch" | "websearch" => (ToolFamily::Web, ToolKind::WebSearch),
-        "WebFetch" | "webfetch" => (ToolFamily::Web, ToolKind::WebFetch),
-        "Agent" | "agent" => (ToolFamily::Agent, ToolKind::SpawnAgent),
-        n if n.starts_with("mcp__") => (ToolFamily::Mcp, ToolKind::McpToolCall),
-        _ => (ToolFamily::Generic, ToolKind::Generic),
-    }
+    classify_tool_name(name)
 }
 
 fn extract_content_items(content: &Value, role: &str) -> Vec<ParsedItem> {


### PR DESCRIPTION
## Summary

- **Fix 3 Codex rendering bugs**: edit field name mismatches (`path`/`diff`), ViewImage `image_paths` array, PatchApplyEnd losing file context
- **Fix todo parsing**: support both `"todos"` and `"tasks"` keys from Claude API, extract `activeForm` for in-progress display
- **Unify tool classification**: single `classify_tool_name()` in protocol crate eliminates duplicate classifier in `transcripts.rs` that was missing 15+ tool types (ToolSearch, ExitPlanMode, TodoWrite, UpdatePlan, etc.) — root cause of generic rendering for passive/hook sessions
- **Redesign 4 expanded views**: bash (unified terminal block), todo (strikethrough + activeForm), generic fallback (semantic headers + error detection), SmartJSONView (KV threshold, path/URL awareness, uniform arrays)
- **Add compact preview containers**: mini-terminal for bash, micro progress bar for todo, backgroundCode containers for all preview strips
- **Proper input_display for ToolSearch, ExitPlanMode, EnterPlanMode, TodoWrite** — no more raw JSON dumps
- **Bump conversation spacing**: 2pt → 4pt between tool cards

## Test plan

- [x] Open a passive Claude session (hook-observed) — verify ToolSearch shows magnifying glass icon, ExitPlanMode shows plan badge
- [x] Open a managed Claude session — verify bash shows unified terminal, todo shows checklist with strikethrough
- [x] Open a Codex session with edits — verify file path and diff display render
- [x] Check generic fallback for unknown tools — semantic "Parameters"/"Result" headers, short output as result strip
- [x] Verify compact previews: bash `$` prompt, todo micro progress bar, all strips have backgroundCode container