### PR TITLE
💅🏼 iOS conversation UX overhaul

### DIFF
--- a/OrbitDockNative/OrbitDock.xcodeproj/project.pbxproj
+++ b/OrbitDockNative/OrbitDock.xcodeproj/project.pbxproj
@@ -528,6 +528,7 @@
 				ENABLE_PREVIEWS = YES;
 				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = OrbitDock/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = OrbitDock;
 				INFOPLIST_KEY_NSMicrophoneUsageDescription = "OrbitDock uses your microphone for local dictation.";
 				INFOPLIST_KEY_NSSpeechRecognitionUsageDescription = "OrbitDock uses speech recognition to transcribe local dictation on your device.";
@@ -566,6 +567,7 @@
 				ENABLE_PREVIEWS = YES;
 				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = OrbitDock/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = OrbitDock;
 				INFOPLIST_KEY_NSMicrophoneUsageDescription = "OrbitDock uses your microphone for local dictation.";
 				INFOPLIST_KEY_NSSpeechRecognitionUsageDescription = "OrbitDock uses speech recognition to transcribe local dictation on your device.";

--- a/OrbitDockNative/OrbitDock/Info.plist
+++ b/OrbitDockNative/OrbitDock/Info.plist
@@ -32,5 +32,10 @@
 	<string>NSApplication</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.developer-tools</string>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsLocalNetworking</key>
+		<true/>
+	</dict>
 </dict>
 </plist>

--- a/OrbitDockNative/OrbitDock/Views/Conversation/Cells/ActivityGroupRowView.swift
+++ b/OrbitDockNative/OrbitDock/Views/Conversation/Cells/ActivityGroupRowView.swift
@@ -19,6 +19,8 @@ struct ActivityGroupRowView: View {
   var contentForChild: ((String) -> ServerRowContent?)?
   var isChildLoading: ((String) -> Bool)?
 
+  @Environment(\.horizontalSizeClass) private var sizeClass
+
   private var statusColor: Color {
     group.status == .completed ? .feedbackPositive : .accent
   }
@@ -46,7 +48,7 @@ struct ActivityGroupRowView: View {
         .padding(.top, Spacing.xs)
       }
     }
-    .padding(.vertical, Spacing.xxs)
+    .padding(.vertical, sizeClass == .compact ? Spacing.xs : Spacing.xxs)
   }
 
   // MARK: - Collapsed Header
@@ -97,14 +99,22 @@ struct ActivityGroupRowView: View {
   // MARK: - Summary
 
   private var groupSummaryText: String {
-    // Build a concise summary like "Read, Edit, Bash"
-    let toolNames = group.children.prefix(4).map { child in
-      child.toolDisplay.summary
+    // Count-based summary: "3 Grep, 2 Read, 1 Edit"
+    var counts: [(type: String, count: Int)] = []
+    var seen: [String: Int] = [:]
+
+    for child in group.children {
+      let type = child.toolDisplay.toolType.capitalized
+      if let idx = seen[type] {
+        counts[idx].count += 1
+      } else {
+        seen[type] = counts.count
+        counts.append((type: type, count: 1))
+      }
     }
-    let joined = toolNames.joined(separator: ", ")
-    if group.childCount > 4 {
-      return "\(joined) + \(group.childCount - 4) more"
-    }
-    return joined
+
+    return counts.map { entry in
+      entry.count > 1 ? "\(entry.count) \(entry.type)" : entry.type
+    }.joined(separator: ", ")
   }
 }

--- a/OrbitDockNative/OrbitDock/Views/Conversation/Cells/MessageRowView.swift
+++ b/OrbitDockNative/OrbitDock/Views/Conversation/Cells/MessageRowView.swift
@@ -45,8 +45,10 @@ struct MessageRowView: View {
 
   // MARK: - User (bubble)
 
+  @Environment(\.horizontalSizeClass) private var sizeClass
+
   private var userMessage: some View {
-    let bubbleMax: CGFloat = 780
+    let bubbleMax: CGFloat = sizeClass == .compact ? 320 : 640
 
     return VStack(alignment: .trailing, spacing: Spacing.xs) {
       Text("You")
@@ -57,7 +59,7 @@ struct MessageRowView: View {
         MessageImageView(
           images: images,
           imageLoader: imageLoader,
-          maxWidth: bubbleMax - Spacing.lg_ * 2
+          maxWidth: bubbleMax - Spacing.md * 2
         )
       }
 
@@ -65,17 +67,14 @@ struct MessageRowView: View {
         MarkdownContentView(content: content, style: .standard)
       }
     }
-    .padding(.horizontal, Spacing.lg_)
-    .padding(.vertical, Spacing.md)
+    .padding(.horizontal, Spacing.md)
+    .padding(.vertical, Spacing.sm)
     .frame(maxWidth: bubbleMax, alignment: .trailing)
-    .background(
-      RoundedRectangle(cornerRadius: Radius.lg, style: .continuous)
-        .fill(Color.accent.opacity(OpacityTier.subtle))
-    )
-    .overlay(
-      RoundedRectangle(cornerRadius: Radius.lg, style: .continuous)
-        .stroke(Color.accent.opacity(0.06), lineWidth: 1)
-    )
+    .overlay(alignment: .trailing) {
+      Rectangle()
+        .fill(Color.accent.opacity(0.3))
+        .frame(width: EdgeBar.width)
+    }
     .padding(.vertical, Spacing.sm)
   }
 

--- a/OrbitDockNative/OrbitDock/Views/Conversation/Cells/TimelineRowContent.swift
+++ b/OrbitDockNative/OrbitDock/Views/Conversation/Cells/TimelineRowContent.swift
@@ -8,7 +8,6 @@
 
 import SwiftUI
 
-private let horizontalPad: CGFloat = Spacing.lg
 private let userBubbleMaxWidth: CGFloat = 640
 
 struct TimelineRowContent: View {
@@ -23,6 +22,8 @@ struct TimelineRowContent: View {
   var contentForChild: ((String) -> ServerRowContent?)?
   var isChildLoading: ((String) -> Bool)?
 
+  @Environment(\.horizontalSizeClass) private var sizeClass
+
   private var isUserRow: Bool {
     if case .user = entry.row { return true }
     return false
@@ -30,6 +31,10 @@ struct TimelineRowContent: View {
 
   private var imageLoader: ImageLoader? {
     clients?.imageLoader
+  }
+
+  private var horizontalPad: CGFloat {
+    sizeClass == .compact ? Spacing.md : Spacing.lg
   }
 
   var body: some View {

--- a/OrbitDockNative/OrbitDock/Views/Conversation/Cells/ToolCardView.swift
+++ b/OrbitDockNative/OrbitDock/Views/Conversation/Cells/ToolCardView.swift
@@ -20,6 +20,12 @@ struct ToolCardView: View {
   var isLoadingContent: Bool = false
   var onToggle: (() -> Void)?
 
+  @Environment(\.horizontalSizeClass) private var sizeClass
+
+  private var previewHorizontalPad: CGFloat {
+    sizeClass == .compact ? Spacing.sm : Spacing.md
+  }
+
   private var display: ServerToolDisplay? {
     toolRow.toolDisplay
   }
@@ -75,7 +81,7 @@ struct ToolCardView: View {
     .background(cardBackground)
     .overlay(alignment: .leading) { accentEdge }
     //  horizontal padding handled by TimelineRowContent
-    .padding(.vertical, Spacing.xs)
+    .padding(.vertical, sizeClass == .compact ? Spacing.sm_ : Spacing.xs)
     .contentShape(Rectangle())
     .onTapGesture { onToggle?() }
   }
@@ -112,67 +118,25 @@ struct ToolCardView: View {
     let isMinimal = displayTier == "minimal"
     let isProminent = displayTier == "prominent"
     let iconSize = isMinimal ? IconScale.sm : IconScale.md
-    let summaryColor = isFailed ? Color.feedbackNegative
-      : isProminent ? Color.textPrimary
-      : Color.textSecondary
-    let subtitleColor = isMinimal ? Color.textQuaternary : Color.textTertiary
 
     return HStack(spacing: Spacing.sm) {
+      // Tool icon
       Image(systemName: glyphSymbol)
         .font(.system(size: iconSize))
         .foregroundStyle(glyphColor)
         .frame(width: 16, height: 16)
 
-      VStack(alignment: .leading, spacing: 0) {
-        HStack(spacing: Spacing.sm_) {
-          Text(summary)
-            .font(display?.summaryFont == "monospace"
-              ? .system(size: TypeScale.body, design: .monospaced)
-              : .system(size: TypeScale.body, weight: .medium))
-            .foregroundStyle(summaryColor)
-
-          if let subtitle, !subtitle.isEmpty, display?.subtitleAbsorbsMeta == true {
-            Text(subtitle)
-              .font(.system(size: TypeScale.caption))
-              .foregroundStyle(subtitleColor)
-          }
-        }
-
-        if let subtitle, !subtitle.isEmpty, display?.subtitleAbsorbsMeta != true {
-          Text(subtitle)
-            .font(.system(size: TypeScale.caption))
-            .foregroundStyle(subtitleColor)
-        }
-      }
+      // Primary text: summary + optional inline subtitle
+      primaryText
+        .fixedSize(horizontal: false, vertical: true)
 
       Spacer(minLength: 0)
 
-      // Micro diff stats bar for edit tools
-      if toolType == "edit", let preview = display?.diffPreview {
-        MicroDiffStatsBar(additions: Int(preview.additions), deletions: Int(preview.deletions))
-      }
+      // Compact metric badge (diff stats, duration, line count)
+      compactMetricBadge
 
-      if let rightMeta, !rightMeta.isEmpty {
-        Text(rightMeta)
-          .font(.system(size: TypeScale.meta, weight: .medium, design: .monospaced))
-          .foregroundStyle(Color.textQuaternary)
-      }
-
-      if let lang = display?.language, !lang.isEmpty, !isExpanded {
-        languageBadge(lang)
-      }
-
-      if isRunning {
-        ProgressView().controlSize(.small)
-      } else if isFailed {
-        Image(systemName: "xmark.circle.fill")
-          .font(.system(size: IconScale.sm))
-          .foregroundStyle(Color.feedbackNegative)
-      }
-
-      Image(systemName: isExpanded ? "chevron.up" : "chevron.down")
-        .font(.system(size: 8, weight: .bold))
-        .foregroundStyle(Color.textQuaternary)
+      // Status indicator + expand chevron
+      statusAndChevron
     }
     .padding(.leading, Spacing.md + EdgeBar.width)
     .padding(.trailing, Spacing.md)
@@ -182,6 +146,87 @@ struct ToolCardView: View {
         ? AnyShapeStyle(glyphColor.opacity(OpacityTier.tint))
         : AnyShapeStyle(Color.clear)
     )
+  }
+
+  // MARK: - Compact Row Components
+
+  /// Composed Text with inline styling: "Summary · filename" or just "Summary"
+  private var primaryText: Text {
+    let isProminent = displayTier == "prominent"
+    let summaryColor = isFailed ? Color.feedbackNegative
+      : isProminent ? Color.textPrimary
+      : Color.textSecondary
+
+    let summaryText = Text(summary)
+      .font(display?.summaryFont == "monospace"
+        ? .system(size: TypeScale.body, design: .monospaced)
+        : .system(size: TypeScale.body, weight: .medium))
+      .foregroundColor(summaryColor)
+
+    guard let sub = compactDisplayName, !sub.isEmpty else {
+      return summaryText
+    }
+
+    return summaryText
+      + Text("  ")
+      + Text(sub)
+      .font(.system(size: TypeScale.caption, design: .monospaced))
+      .foregroundColor(Color.textTertiary)
+  }
+
+  /// Short display name for the compact row — filename or command excerpt.
+  /// Full subtitle available in the expanded view.
+  private static let fileToolTypes: Set<String> = ["edit", "write", "read", "glob", "grep"]
+
+  private var compactDisplayName: String? {
+    guard let subtitle, !subtitle.isEmpty else { return nil }
+
+    if Self.fileToolTypes.contains(toolType), subtitle.contains("/") {
+      let filename = (subtitle as NSString).lastPathComponent
+      guard filename.count > 22 else { return filename }
+      return "…" + filename.suffix(18)
+    }
+
+    return subtitle
+  }
+
+  /// Compact badge showing the single most important metric for this tool.
+  @ViewBuilder
+  private var compactMetricBadge: some View {
+    if toolType == "edit" || toolType == "write", let preview = display?.diffPreview,
+       preview.additions > 0 || preview.deletions > 0
+    {
+      HStack(spacing: Spacing.xxs) {
+        if preview.additions > 0 {
+          Text("+\(preview.additions)")
+            .foregroundStyle(Color.diffAddedAccent)
+        }
+        if preview.deletions > 0 {
+          Text("-\(preview.deletions)")
+            .foregroundStyle(Color.diffRemovedAccent)
+        }
+      }
+      .font(.system(size: TypeScale.micro, weight: .bold, design: .monospaced))
+    } else if let rightMeta, !rightMeta.isEmpty {
+      Text(rightMeta)
+        .font(.system(size: TypeScale.micro, weight: .medium, design: .monospaced))
+        .foregroundStyle(Color.textQuaternary)
+    }
+  }
+
+  @ViewBuilder
+  private var statusAndChevron: some View {
+    if isRunning {
+      ProgressView().controlSize(.small)
+    } else if isFailed {
+      Image(systemName: "xmark.circle.fill")
+        .font(.system(size: IconScale.sm))
+        .foregroundStyle(Color.feedbackNegative)
+    }
+
+    Image(systemName: isExpanded ? "chevron.up" : "chevron.down")
+      .font(.system(size: 8, weight: .bold))
+      .foregroundStyle(Color.textQuaternary)
   }
 
   // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
@@ -220,21 +265,8 @@ struct ToolCardView: View {
       Text(preview.snippetText)
         .font(.system(size: TypeScale.meta, design: .monospaced))
         .foregroundStyle(Color.textTertiary)
-      Spacer(minLength: 0)
-      HStack(spacing: Spacing.xs) {
-        if preview.additions > 0 {
-          Text("+\(preview.additions)")
-            .font(.system(size: TypeScale.mini, weight: .bold, design: .monospaced))
-            .foregroundStyle(Color.diffAddedAccent)
-        }
-        if preview.deletions > 0 {
-          Text("-\(preview.deletions)")
-            .font(.system(size: TypeScale.mini, weight: .bold, design: .monospaced))
-            .foregroundStyle(Color.diffRemovedAccent)
-        }
-      }
     }
-    .padding(.horizontal, Spacing.md)
+    .padding(.horizontal, previewHorizontalPad)
     .padding(.bottom, Spacing.sm_)
   }
 
@@ -249,7 +281,7 @@ struct ToolCardView: View {
     .padding(.horizontal, Spacing.sm)
     .padding(.vertical, Spacing.xs)
     .background(Color.backgroundCode, in: RoundedRectangle(cornerRadius: Radius.xs))
-    .padding(.horizontal, Spacing.md)
+    .padding(.horizontal, previewHorizontalPad)
     .padding(.bottom, Spacing.sm_)
   }
 
@@ -270,7 +302,7 @@ struct ToolCardView: View {
     .padding(.horizontal, Spacing.sm)
     .padding(.vertical, Spacing.xs)
     .background(Color.backgroundCode, in: RoundedRectangle(cornerRadius: Radius.xs))
-    .padding(.horizontal, Spacing.md)
+    .padding(.horizontal, previewHorizontalPad)
     .padding(.bottom, Spacing.sm_)
   }
 
@@ -303,7 +335,7 @@ struct ToolCardView: View {
     .padding(.horizontal, Spacing.sm)
     .padding(.vertical, Spacing.xs)
     .background(Color.backgroundCode, in: RoundedRectangle(cornerRadius: Radius.xs))
-    .padding(.horizontal, Spacing.md)
+    .padding(.horizontal, previewHorizontalPad)
     .padding(.bottom, Spacing.sm_)
   }
 

--- a/OrbitDockNative/OrbitDock/Views/Conversation/ConversationFollowPill.swift
+++ b/OrbitDockNative/OrbitDock/Views/Conversation/ConversationFollowPill.swift
@@ -1,0 +1,45 @@
+//
+//  ConversationFollowPill.swift
+//  OrbitDock
+//
+//  Floating "scroll to bottom" indicator overlaid on the conversation timeline.
+//  Appears when the user scrolls up (unpinned). Small trailing circle with
+//  optional unread count badge overlay.
+//
+
+import SwiftUI
+
+struct ConversationFollowPill: View {
+  let unreadCount: Int
+  let onTap: () -> Void
+
+  var body: some View {
+    Button(action: onTap) {
+      Image(systemName: "chevron.down")
+        .font(.system(size: TypeScale.micro, weight: .bold))
+        .foregroundStyle(Color.textTertiary)
+        .frame(width: 28, height: 28)
+        .background(
+          Circle()
+            .fill(Color.backgroundTertiary.opacity(0.85))
+            .themeShadow(Shadow.sm)
+        )
+        .overlay(
+          Circle()
+            .stroke(Color.surfaceBorder.opacity(OpacityTier.light), lineWidth: 0.5)
+        )
+        .overlay(alignment: .topTrailing) {
+          if unreadCount > 0 {
+            Text("\(min(unreadCount, 99))")
+              .font(.system(size: 8, weight: .bold, design: .monospaced))
+              .foregroundStyle(.white)
+              .padding(.horizontal, Spacing.xs)
+              .padding(.vertical, 1)
+              .background(Color.accent, in: Capsule())
+              .offset(x: 6, y: -4)
+          }
+        }
+    }
+    .buttonStyle(.plain)
+  }
+}

--- a/OrbitDockNative/OrbitDock/Views/Conversation/ConversationView.swift
+++ b/OrbitDockNative/OrbitDock/Views/Conversation/ConversationView.swift
@@ -77,7 +77,24 @@ struct ConversationView: View {
               .padding(.bottom, Spacing.xs)
             }
 
-            conversationTimeline
+            ZStack(alignment: .bottomTrailing) {
+              conversationTimeline
+
+              if !isPinned {
+                ConversationFollowPill(
+                  unreadCount: unreadCount,
+                  onTap: {
+                    isPinned = true
+                    unreadCount = 0
+                    scrollToBottomTrigger += 1
+                  }
+                )
+                .padding(.trailing, Spacing.lg)
+                .padding(.bottom, Spacing.sm)
+                .transition(.move(edge: .bottom).combined(with: .opacity))
+                .animation(Motion.standard, value: isPinned)
+              }
+            }
 
             if isSessionActive || displayStatus == .ended {
               OrbitStatusIndicator(

--- a/OrbitDockNative/OrbitDock/Views/Conversation/TimelineScrollView.swift
+++ b/OrbitDockNative/OrbitDock/Views/Conversation/TimelineScrollView.swift
@@ -15,6 +15,14 @@
 //    notifications (macOS) or pan gesture tracking (iOS) through
 //    TimelineUserScrollDetector.
 //
+//  Scroll-to-bottom strategy (two-phase reveal):
+//  1. Timeline renders with .defaultScrollAnchor(.bottom) but is hidden behind
+//     an opaque overlay so the user never sees a half-scrolled state.
+//  2. When the bottom sentinel's onAppear fires (meaning the viewport is at
+//     the bottom), the overlay fades out to reveal the settled timeline.
+//  3. Fallback: if the sentinel doesn't appear after layout yields, a forced
+//     scrollTo + reveal ensures the timeline is never stuck hidden.
+//
 
 import SwiftUI
 
@@ -30,6 +38,10 @@ struct TimelineScrollView: View {
   @State private var rowState = TimelineRowStateStore()
   @State private var sentinelVisible = true
   @State private var userIsLiveScrolling = false
+
+  /// False until the scroll view has settled at the bottom. Content is hidden
+  /// behind an opaque overlay until this flips to true.
+  @State private var isReady = false
 
   /// Tool grouping happens here — computed fresh when entries change.
   private var displayEntries: [ServerConversationRowEntry] {
@@ -71,21 +83,20 @@ struct TimelineScrollView: View {
           }
 
           // Bottom sentinel — tracks viewport visibility for pin state.
-          // onAppear re-pins (user scrolled back to bottom).
-          // onDisappear records that the sentinel left but does NOT unpin —
-          // unpin is deferred to TimelineUserScrollDetector.
+          // Also signals that the scroll view has settled at the bottom (isReady).
           Color.clear
             .frame(height: 1)
             .id("timeline-bottom")
             .onAppear {
               sentinelVisible = true
+              if !isReady {
+                withAnimation(Motion.fade) { isReady = true }
+              }
               guard !isPinned else { return }
               isPinned = true
             }
             .onDisappear {
               sentinelVisible = false
-              // Unpin immediately only if the user is actively scrolling.
-              // Content-push disappearances are corrected by auto-scroll.
               guard isPinned, userIsLiveScrolling else { return }
               isPinned = false
             }
@@ -98,21 +109,29 @@ struct TimelineScrollView: View {
       .scrollDismissesKeyboard(.interactively)
       .defaultScrollAnchor(.bottom)
       .background(Color.backgroundPrimary)
-      .onAppear {
-        guard let lastID = displayed.last?.id else { return }
-        proxy.scrollTo(lastID, anchor: .bottom)
+      // Hide content until scroll position has settled at the bottom.
+      .overlay {
+        if !isReady {
+          Color.backgroundPrimary
+        }
+      }
+      .animation(Motion.fade, value: isReady)
+      // Fallback: if defaultScrollAnchor didn't reach the bottom, force scroll + reveal.
+      .task {
+        await Task.yield()
+        await Task.yield()
+        guard !isReady else { return }
+        proxy.scrollTo("timeline-bottom", anchor: .bottom)
+        await Task.yield()
+        withAnimation(Motion.fade) { isReady = true }
       }
       .onChange(of: autoScrollVersion) { _, _ in
-        guard isPinned, let lastID = displayed.last?.id else { return }
-        proxy.scrollTo(lastID, anchor: .bottom)
+        guard isPinned else { return }
+        proxy.scrollTo("timeline-bottom", anchor: .bottom)
       }
       .onChange(of: scrollToBottomTrigger) { _, _ in
-        guard let lastID = displayed.last?.id else { return }
-        proxy.scrollTo(lastID, anchor: .bottom)
+        proxy.scrollTo("timeline-bottom", anchor: .bottom)
       }
-      // When user scroll ends, check if sentinel is still off-screen → unpin.
-      // Handles momentum scrolling: macOS didEndLiveScrollNotification fires
-      // after momentum settles; iOS tracks deceleration via contentOffset KVO.
       .onChange(of: userIsLiveScrolling) { _, isScrolling in
         guard !isScrolling, isPinned, !sentinelVisible else { return }
         isPinned = false
@@ -137,7 +156,6 @@ struct TimelineScrollView: View {
       isLoadingContent: fetchId.map { rowState.isFetching($0) } ?? false,
       onToggle: { id in
         let nowExpanded = rowState.toggleExpanded(id)
-        // Fetch content for newly expanded children (activity group child tools)
         if nowExpanded {
           rowState.fetchContentIfNeeded(rowId: id, sessionId: sessionId, clients: clients)
         }
@@ -155,7 +173,6 @@ struct TimelineScrollView: View {
     .task(id: isExpanded) {
       guard isExpanded, let fetchId else { return }
       rowState.fetchContentIfNeeded(rowId: fetchId, sessionId: sessionId, clients: clients)
-      // For activity groups, also fetch expanded children
       if case let .activityGroup(group) = entry.row {
         for child in group.children where rowState.isExpanded(child.id) {
           rowState.fetchContentIfNeeded(rowId: child.id, sessionId: sessionId, clients: clients)
@@ -166,7 +183,6 @@ struct TimelineScrollView: View {
 
   // MARK: - Row Identity Helpers
 
-  /// Returns the ID used for expand/collapse state, if the row type supports it.
   private static func expandableId(for entry: ServerConversationRowEntry) -> String? {
     switch entry.row {
       case let .tool(toolRow): toolRow.id
@@ -176,7 +192,6 @@ struct TimelineScrollView: View {
     }
   }
 
-  /// Returns the ID used for fetching expanded content, if applicable.
   private static func fetchableId(for entry: ServerConversationRowEntry) -> String? {
     switch entry.row {
       case let .tool(toolRow): toolRow.id

--- a/OrbitDockNative/OrbitDock/Views/SessionDetail/SessionDetailPlanning.swift
+++ b/OrbitDockNative/OrbitDock/Views/SessionDetail/SessionDetailPlanning.swift
@@ -208,8 +208,7 @@ enum SessionDetailLayoutIntent {
 
 enum SessionDetailFooterMode: Equatable {
   case direct
-  case passiveWithTakeOver
-  case passiveOnly
+  case passive
 }
 
 struct SessionDetailReviewNavigationPlan {
@@ -388,9 +387,12 @@ enum SessionDetailFooterPlanner {
     canTakeOver: Bool,
     needsApprovalOverlay: Bool
   ) -> SessionDetailFooterMode {
-    guard !isDirect else { return .direct }
-    guard canTakeOver, !needsApprovalOverlay else { return .passiveOnly }
-    return .passiveWithTakeOver
+    // canTakeOver means the user doesn't own this session — show passive view
+    // with takeover option. isDirect alone isn't enough because docked
+    // sessions can be isDirect but not owned.
+    if canTakeOver { return .passive }
+    if isDirect { return .direct }
+    return .passive
   }
 }
 

--- a/OrbitDockNative/OrbitDock/Views/SessionDetail/SessionDetailShellSections.swift
+++ b/OrbitDockNative/OrbitDock/Views/SessionDetail/SessionDetailShellSections.swift
@@ -32,17 +32,23 @@ struct SessionDetailFooter<DirectComposer: View, TakeOverBar: View, PassiveActio
   @ViewBuilder let takeOverBar: () -> TakeOverBar
   @ViewBuilder let passiveActionBar: () -> PassiveActionBar
 
+  @Environment(\.horizontalSizeClass) private var sizeClass
+
   var body: some View {
     switch mode {
       case .direct:
         directComposer()
-      case .passiveWithTakeOver:
-        VStack(spacing: 0) {
+      case .passive:
+        if sizeClass == .compact {
+          // Compact: just the takeover bar — clean single element.
+          // Status chips move inside as a secondary row.
           takeOverBar()
-          passiveActionBar()
+        } else {
+          VStack(spacing: 0) {
+            takeOverBar()
+            passiveActionBar()
+          }
         }
-      case .passiveOnly:
-        passiveActionBar()
     }
   }
 }

--- a/OrbitDockNative/OrbitDock/Views/SessionDetail/SessionDetailView+Sections.swift
+++ b/OrbitDockNative/OrbitDock/Views/SessionDetail/SessionDetailView+Sections.swift
@@ -75,6 +75,39 @@ extension SessionDetailView {
     )
   }
 
+  var passiveStatusStrip: some View {
+    ScrollView(.horizontal, showsIndicators: false) {
+      HStack(spacing: Spacing.sm) {
+        ContextGaugeCompact(stats: usageStats)
+
+        if let formattedCost = actionBarState.formattedCost {
+          Text(formattedCost)
+            .font(.system(size: TypeScale.code, weight: .semibold, design: .monospaced))
+            .foregroundStyle(.primary.opacity(OpacityTier.vivid))
+        }
+
+        if let branchLabel = actionBarState.branchLabel {
+          HStack(spacing: Spacing.xs) {
+            Image(systemName: "arrow.triangle.branch")
+              .font(.system(size: TypeScale.caption, weight: .semibold))
+            Text(branchLabel)
+              .font(.system(size: TypeScale.caption, weight: .medium, design: .monospaced))
+          }
+          .foregroundStyle(Color.gitBranch)
+        }
+
+        if let lastActivityAt = actionBarState.lastActivityAt {
+          Text(lastActivityAt, style: .relative)
+            .font(.system(size: TypeScale.caption, weight: .medium, design: .monospaced))
+            .foregroundStyle(Color.textTertiary)
+        }
+      }
+      .padding(.horizontal, Spacing.md)
+      .padding(.vertical, Spacing.sm_)
+    }
+    .scrollIndicators(.hidden)
+  }
+
   var compactActionBar: some View {
     SessionDetailCompactActionBar(
       state: actionBarState,

--- a/OrbitDockNative/OrbitDock/Views/SessionDetail/SessionDetailView.swift
+++ b/OrbitDockNative/OrbitDock/Views/SessionDetail/SessionDetailView.swift
@@ -134,9 +134,16 @@ struct SessionDetailView: View {
           scrollToBottomTrigger: $scrollToBottomTrigger
         )
       } takeOverBar: {
-        TakeOverInputBar {
-          Task { try? await scopedServerState.takeoverSession(sessionId) }
-        }
+        TakeOverInputBar(
+          onTakeOver: {
+            Task { try? await scopedServerState.takeoverSession(sessionId) }
+          },
+          statusContent: {
+            if isCompactLayout {
+              passiveStatusStrip
+            }
+          }
+        )
       } passiveActionBar: {
         actionBar
       }

--- a/OrbitDockNative/OrbitDock/Views/SessionDetail/TakeOverInputBar.swift
+++ b/OrbitDockNative/OrbitDock/Views/SessionDetail/TakeOverInputBar.swift
@@ -1,56 +1,61 @@
 import SwiftUI
 
-/// Input-bar-replacement CTA for passive sessions that can be taken over.
-/// Mimics the shape and position of a text input field, sitting above
-/// the action bar where the composer row would normally be.
-struct TakeOverInputBar: View {
+/// Unified passive footer for sessions the user doesn't own.
+/// Single card: takeover action + optional status metadata strip.
+struct TakeOverInputBar<StatusContent: View>: View {
   let onTakeOver: () -> Void
+  @ViewBuilder let statusContent: () -> StatusContent
 
   @State private var isHovering = false
 
   var body: some View {
-    Button(action: onTakeOver) {
-      HStack(spacing: Spacing.sm) {
-        // Orbit dot — echoes the app's identity
-        Circle()
-          .fill(Color.accent.opacity(isHovering ? 0.6 : 0.3))
-          .frame(width: 7, height: 7)
+    VStack(spacing: 0) {
+      // Primary: takeover action
+      Button(action: onTakeOver) {
+        HStack(spacing: Spacing.sm) {
+          Circle()
+            .fill(Color.accent.opacity(isHovering ? 0.6 : 0.3))
+            .frame(width: 7, height: 7)
 
-        Text("Take over to send messages")
-          .font(.system(size: TypeScale.body))
-          .foregroundStyle(Color.textTertiary)
+          Text("Take over to send messages")
+            .font(.system(size: TypeScale.body))
+            .foregroundStyle(Color.textTertiary)
 
-        Spacer()
+          Spacer()
 
-        HStack(spacing: Spacing.xs) {
-          Text("Take Over")
-            .font(.system(size: TypeScale.code, weight: .semibold))
-          Image(systemName: "arrow.right")
-            .font(.system(size: TypeScale.micro, weight: .bold))
-        }
-        .foregroundStyle(Color.accent)
-        .padding(.horizontal, Spacing.md)
-        .padding(.vertical, Spacing.xs)
-        .background(
-          Color.accent.opacity(isHovering ? OpacityTier.light : OpacityTier.subtle),
-          in: Capsule()
-        )
-      }
-      .padding(.horizontal, Spacing.md)
-      .padding(.vertical, Spacing.md_)
-      .background(
-        RoundedRectangle(cornerRadius: Radius.lg, style: .continuous)
-          .fill(Color.backgroundTertiary)
-      )
-      .overlay(
-        RoundedRectangle(cornerRadius: Radius.lg, style: .continuous)
-          .strokeBorder(
-            isHovering ? Color.accent.opacity(0.3) : Color.accent.opacity(0.12),
-            lineWidth: 1
+          HStack(spacing: Spacing.xs) {
+            Text("Take Over")
+              .font(.system(size: TypeScale.code, weight: .semibold))
+            Image(systemName: "arrow.right")
+              .font(.system(size: TypeScale.micro, weight: .bold))
+          }
+          .foregroundStyle(Color.accent)
+          .padding(.horizontal, Spacing.md)
+          .padding(.vertical, Spacing.xs)
+          .background(
+            Color.accent.opacity(isHovering ? OpacityTier.light : OpacityTier.subtle),
+            in: Capsule()
           )
-      )
+        }
+        .padding(.horizontal, Spacing.md)
+        .padding(.vertical, Spacing.md_)
+      }
+      .buttonStyle(.plain)
+
+      // Secondary: status metadata (if provided)
+      statusContent()
     }
-    .buttonStyle(.plain)
+    .background(
+      RoundedRectangle(cornerRadius: Radius.lg, style: .continuous)
+        .fill(Color.backgroundTertiary)
+    )
+    .overlay(
+      RoundedRectangle(cornerRadius: Radius.lg, style: .continuous)
+        .strokeBorder(
+          isHovering ? Color.accent.opacity(0.3) : Color.accent.opacity(0.12),
+          lineWidth: 1
+        )
+    )
     .onHover { hovering in
       withAnimation(Motion.hover) {
         isHovering = hovering
@@ -59,6 +64,13 @@ struct TakeOverInputBar: View {
     .padding(.horizontal, Spacing.lg)
     .padding(.top, Spacing.md)
     .padding(.bottom, Spacing.xs)
+  }
+}
+
+extension TakeOverInputBar where StatusContent == EmptyView {
+  init(onTakeOver: @escaping () -> Void) {
+    self.onTakeOver = onTakeOver
+    self.statusContent = { EmptyView() }
   }
 }
 

--- a/OrbitDockNative/OrbitDock/Views/Sessions/Composer/DirectSessionComposer+Footer.swift
+++ b/OrbitDockNative/OrbitDock/Views/Sessions/Composer/DirectSessionComposer+Footer.swift
@@ -32,24 +32,38 @@ extension DirectSessionComposer {
     .padding(.bottom, Spacing.sm_)
   }
 
+  var isCompactPassiveMode: Bool {
+    guard let model = pendingApprovalModel else { return false }
+    return model.mode == .takeover || model.mode == .passiveBlocked
+  }
+
+  @ViewBuilder
   var compactComposerFooter: some View {
-    HStack(spacing: Spacing.sm_) {
-      ScrollView(.horizontal, showsIndicators: false) {
+    if isCompactPassiveMode {
+      EmptyView()
+    } else if let model = pendingApprovalModel, pendingState.isExpanded {
+      // Active approval — full-width action bar with approve/deny actions trailing
+      HStack(spacing: Spacing.sm_) {
+        Spacer(minLength: 0)
+        pendingFooterActions(model)
+      }
+      .padding(.horizontal, Spacing.sm)
+      .padding(.bottom, Spacing.sm)
+    } else {
+      HStack(spacing: Spacing.sm_) {
         HStack(spacing: Spacing.xs) {
           compactComposeControls
         }
-        .padding(.trailing, Spacing.xs)
+        Spacer(minLength: 0)
+        composerSendButton
       }
-      .scrollIndicators(.hidden)
-
-      // Action cluster (varies by state)
-      composerFooterActions
+      .padding(.horizontal, Spacing.sm)
+      .padding(.bottom, Spacing.sm)
     }
-    .padding(.horizontal, Spacing.sm)
-    .padding(.bottom, Spacing.sm)
   }
 
   /// Footer action cluster — swaps between normal send and pending approval actions.
+  /// Used by desktop layout (compact uses inline send button).
   @ViewBuilder
   var composerFooterActions: some View {
     if let model = pendingApprovalModel, pendingState.isExpanded {
@@ -97,8 +111,11 @@ extension DirectSessionComposer {
       providerModelControlButton
     }
 
-    imageAttachmentDockControl
-    fileMentionControlButton
+    if !isCompact {
+      imageAttachmentDockControl
+      fileMentionControlButton
+    }
+
     commandDeckControlButton
 
     if shouldShowDictation {

--- a/OrbitDockNative/OrbitDock/Views/Sessions/Composer/DirectSessionComposer.swift
+++ b/OrbitDockNative/OrbitDock/Views/Sessions/Composer/DirectSessionComposer.swift
@@ -226,6 +226,10 @@ struct DirectSessionComposer: View {
         clearDictationDraftState()
       }
     }
+    .onChange(of: inputState.focus.measuredHeight) { _, _ in
+      guard isPinned else { return }
+      scrollToBottomTrigger += 1
+    }
     .onChange(of: dictationController.liveTranscript) { _, transcript in
       guard dictationController.isRecording else { return }
       updateDictationLivePreview(transcript)
@@ -266,6 +270,7 @@ struct DirectSessionComposer: View {
     )
     .frame(maxWidth: .infinity, alignment: .leading)
     .frame(height: inputState.focus.measuredHeight)
+    .animation(Motion.snappy, value: inputState.focus.measuredHeight)
     .layoutPriority(1)
     #if os(iOS)
       .toolbar {

--- a/OrbitDockNative/OrbitDock/Views/Sessions/Composer/DirectSessionComposerWorkflowMenus.swift
+++ b/OrbitDockNative/OrbitDock/Views/Sessions/Composer/DirectSessionComposerWorkflowMenus.swift
@@ -86,6 +86,18 @@ extension DirectSessionComposer {
 
     return Menu {
       Section("Compose") {
+        Button {
+          pickImages()
+        } label: {
+          Label("Attach Image", systemImage: "photo.badge.plus")
+        }
+
+        Button {
+          openFilePicker()
+        } label: {
+          Label("Attach File (@)", systemImage: "doc.badge.plus")
+        }
+
         if hasSkillsPanel {
           Button {
             Task { try? await serverState.listSkills(sessionId: sessionId) }

--- a/OrbitDockNative/OrbitDockTests/SessionDetail/SessionDetailPlanningTests.swift
+++ b/OrbitDockNative/OrbitDockTests/SessionDetail/SessionDetailPlanningTests.swift
@@ -127,9 +127,10 @@ struct SessionDetailPlanningTests {
     #expect(plan.navigateToComment == nil)
   }
 
-  @Test func footerPlannerOnlyShowsTakeoverForPassiveSessionsWithoutApprovalOverlay() {
+  @Test func footerPlannerShowsPassiveForNonOwnedSessions() {
+    // canTakeOver → passive, even if isDirect
     #expect(
-      isDirectFooterMode(
+      isPassiveFooterMode(
         SessionDetailFooterPlanner.mode(
           isDirect: true,
           canTakeOver: true,
@@ -137,17 +138,9 @@ struct SessionDetailPlanningTests {
         )
       )
     )
+    // canTakeOver with approval → still passive (approval visible in timeline)
     #expect(
-      isPassiveWithTakeOverFooterMode(
-        SessionDetailFooterPlanner.mode(
-          isDirect: false,
-          canTakeOver: true,
-          needsApprovalOverlay: false
-        )
-      )
-    )
-    #expect(
-      isPassiveOnlyFooterMode(
+      isPassiveFooterMode(
         SessionDetailFooterPlanner.mode(
           isDirect: false,
           canTakeOver: true,
@@ -155,8 +148,19 @@ struct SessionDetailPlanningTests {
         )
       )
     )
+    // isDirect without canTakeOver → direct (user owns it)
     #expect(
-      isPassiveOnlyFooterMode(
+      isDirectFooterMode(
+        SessionDetailFooterPlanner.mode(
+          isDirect: true,
+          canTakeOver: false,
+          needsApprovalOverlay: false
+        )
+      )
+    )
+    // Not direct, can't take over → passive
+    #expect(
+      isPassiveFooterMode(
         SessionDetailFooterPlanner.mode(
           isDirect: false,
           canTakeOver: false,
@@ -437,13 +441,8 @@ struct SessionDetailPlanningTests {
     return false
   }
 
-  private func isPassiveWithTakeOverFooterMode(_ mode: SessionDetailFooterMode) -> Bool {
-    if case .passiveWithTakeOver = mode { return true }
-    return false
-  }
-
-  private func isPassiveOnlyFooterMode(_ mode: SessionDetailFooterMode) -> Bool {
-    if case .passiveOnly = mode { return true }
+  private func isPassiveFooterMode(_ mode: SessionDetailFooterMode) -> Bool {
+    if case .passive = mode { return true }
     return false
   }
 


### PR DESCRIPTION
## Summary

- **Tool cards**: Single-line IDE layout — filename inline after summary, compact metric badge (diff stats or duration), no duplicate stats, smart path truncation for long filenames
- **Composer toolbar**: Trimmed to 4-5 essential buttons on compact (interrupt, model, command deck, dictation), image/file attachment moved to overflow menu, horizontal scroll removed
- **Scroll-to-bottom**: Two-phase reveal — timeline renders hidden behind overlay, reveals with fade once `.defaultScrollAnchor(.bottom)` settles at the bottom sentinel
- **Floating follow pill**: Small 28pt trailing circle with unread badge overlay replaces inline follow controls in the conversation
- **Activity groups**: Count-based summary ("3 Grep, 2 Read") instead of raw file paths/commands
- **User messages**: Removed bubble background, replaced with subtle trailing accent edge bar, max width 320pt on compact
- **Passive footer**: Simplified `SessionDetailFooterMode` from 3 modes to 2 (direct/passive). Unified `TakeOverInputBar` with inline status strip on compact — one cohesive card instead of stacked pieces. `canTakeOver` drives ownership detection so passive sessions always show takeover option
- **Approval actions**: Restored on compact composer footer with proper right-aligned layout
- **Composer height animation**: Smooth transition when text area grows/shrinks, scroll anchored while pinned

## Test plan

- [ ] iPhone SE simulator (375pt) — narrowest phone stress test
- [ ] iPhone 15 Pro simulator (393pt) — mainstream device
- [ ] iPad simulator — ensure `.pad` layout not regressed
- [ ] macOS build — tool card layout should look good on desktop too
- [ ] Type multi-line text in composer → scroll stays anchored, no jump
- [ ] Compact composer shows 4-5 buttons max, no horizontal scroll
- [ ] Scroll up in conversation → floating follow pill appears at bottom-trailing
- [ ] Tool cards: filename inline, diff stats in badge, no duplication
- [ ] Expand/collapse tool cards works correctly on both platforms
- [ ] Navigate to a conversation → starts at bottom, no blank flash
- [ ] Passive/docked session → unified TakeOverInputBar with status strip
- [ ] Owned session with pending approval → approve/deny buttons visible in compact footer
- [ ] Activity groups show "3 Grep, 2 Read" not raw file paths