### PR TITLE
🛡️ Default invalid provider values safely in mission delta broadcasting

### DIFF
--- a/orbitdock-server/crates/server/src/runtime/mission_orchestrator.rs
+++ b/orbitdock-server/crates/server/src/runtime/mission_orchestrator.rs
@@ -570,7 +570,16 @@ pub async fn broadcast_mission_delta(registry: &Arc<SessionRegistry>, mission: &
                     .as_deref()
                     .unwrap_or("claude")
                     .parse::<Provider>()
-                    .unwrap(),
+                    .unwrap_or_else(|_| {
+                        warn!(
+                            component = "mission_control",
+                            event = "provider.invalid_issue",
+                            issue_id = %row.issue_id,
+                            raw_value = ?row.provider,
+                            "Invalid provider for issue, falling back to Claude"
+                        );
+                        Provider::Claude
+                    }),
                 attempt: row.attempt,
                 error: row.last_error.clone(),
                 url: row.url.clone(),
@@ -579,7 +588,16 @@ pub async fn broadcast_mission_delta(registry: &Arc<SessionRegistry>, mission: &
         })
         .collect();
 
-    let primary_provider: Provider = mission.provider.parse().unwrap();
+    let primary_provider: Provider = mission.provider.parse().unwrap_or_else(|_| {
+        warn!(
+            component = "mission_control",
+            event = "provider.invalid_mission",
+            mission_id = %mission.id,
+            raw_value = %mission.provider,
+            "Invalid primary provider for mission, falling back to Claude"
+        );
+        Provider::Claude
+    });
 
     let orchestrator_running = registry.is_orchestrator_running();
     let orchestrator_status =
@@ -590,11 +608,18 @@ pub async fn broadcast_mission_delta(registry: &Arc<SessionRegistry>, mission: &
         if let Ok(config) =
             serde_json::from_str::<crate::domain::mission_control::config::MissionConfig>(json)
         {
-            let secondary = config
-                .provider
-                .secondary
-                .as_ref()
-                .map(|s| s.parse::<Provider>().unwrap());
+            let secondary = config.provider.secondary.as_ref().and_then(|s| {
+                s.parse::<Provider>().ok().or_else(|| {
+                    warn!(
+                        component = "mission_control",
+                        event = "provider.invalid_secondary",
+                        mission_id = %mission.id,
+                        raw_value = %s,
+                        "Invalid secondary provider for mission, dropping to None"
+                    );
+                    None
+                })
+            });
             (config.provider.strategy, secondary)
         } else {
             ("single".to_string(), None)


### PR DESCRIPTION
## Summary

- Replace three `unwrap()` calls in `broadcast_mission_delta` with safe fallbacks so a malformed stored provider string can't crash the broadcast loop
- Issue `row.provider`: falls back to `Provider::Claude`
- Mission `primary_provider`: falls back to `Provider::Claude`
- Mission `secondary_provider`: falls back to `None`
- Each fallback logs a `warn!` with the raw value for visibility

## Test plan

- [x] `make rust-ci` passes (302 tests, clippy, check)
- [ ] Manually verify: insert a bad provider value in SQLite → confirm broadcast doesn't panic and warning appears in logs

Closes #51