### PR TITLE
✨ Auto-end agent session on issue completion

### DIFF
--- a/OrbitDockNative/OrbitDock/Views/MissionControl/MissionAlertBoard.swift
+++ b/OrbitDockNative/OrbitDock/Views/MissionControl/MissionAlertBoard.swift
@@ -92,6 +92,17 @@ struct MissionAlertBoard: View {
               .buttonStyle(.plain)
             }
 
+            if let sessionId = issue.sessionId {
+              Button {
+                onNavigateToSession(sessionId)
+              } label: {
+                Text("Open \u{2192}")
+                  .font(.system(size: TypeScale.micro, weight: .semibold))
+                  .foregroundStyle(Color.accent)
+              }
+              .buttonStyle(.plain)
+            }
+
             Button {
               Task { await retryIssue(issue) }
             } label: {
@@ -178,6 +189,18 @@ struct MissionAlertBoard: View {
               }
               .buttonStyle(.plain)
               .help("Open in tracker")
+            }
+
+            if let sessionId = issue.sessionId {
+              Button {
+                onNavigateToSession(sessionId)
+              } label: {
+                Text("Open \u{2192}")
+                  .font(.system(size: TypeScale.micro, weight: .semibold))
+                  .foregroundStyle(Color.accent)
+              }
+              .buttonStyle(.plain)
+              .help("Open session")
             }
 
             Button {

--- a/orbitdock-server/crates/server/src/transport/http/mission_control.rs
+++ b/orbitdock-server/crates/server/src/transport/http/mission_control.rs
@@ -1311,6 +1311,26 @@ pub async fn report_issue_completed(
     let iid = issue_id.clone();
     let now = chrono::Utc::now().to_rfc3339();
 
+    // Look up the session_id for this issue before marking it completed
+    let session_id: Option<String> = {
+        let db_path = registry.db_path().clone();
+        let mid2 = mid.clone();
+        let iid2 = iid.clone();
+        tokio::task::spawn_blocking(move || {
+            let conn = rusqlite::Connection::open(&db_path).ok()?;
+            conn.query_row(
+                "SELECT session_id FROM mission_issues WHERE mission_id = ?1 AND issue_id = ?2",
+                params![mid2, iid2],
+                |row| row.get::<_, Option<String>>(0),
+            )
+            .ok()
+            .flatten()
+        })
+        .await
+        .ok()
+        .flatten()
+    };
+
     let _ = registry
         .persist()
         .send(PersistCommand::MissionIssueUpdateState {
@@ -1326,6 +1346,19 @@ pub async fn report_issue_completed(
         })
         .await;
 
+    // End the agent session now that its issue is done
+    if let Some(ref sid) = session_id {
+        crate::runtime::session_mutations::end_session(&registry, sid).await;
+        info!(
+            component = "mission_control",
+            event = "session.auto_ended",
+            mission_id = %mid,
+            issue_id = %iid,
+            session_id = %sid,
+            "Ended agent session after issue completed"
+        );
+    }
+
     crate::runtime::mission_orchestrator::broadcast_mission_delta_by_id(&registry, &mid).await;
 
     info!(
@@ -1334,6 +1367,7 @@ pub async fn report_issue_completed(
         mission_id = %mid,
         issue_id = %iid,
         tracker_state = ?body.tracker_state,
+        session_ended = session_id.is_some(),
         "Agent reported issue completed"
     );
 


### PR DESCRIPTION
## Summary
- When an agent calls `mission_set_status` with a terminal state (e.g. "Done"), the `report_issue_completed` endpoint now looks up the issue's `session_id` and calls `end_session` to cleanly terminate the agent — prevents agents from sitting idle and triggering stall detection after their work is complete
- Alert board rows (failed/blocked issues) now show an "Open →" link to navigate to the conversation when a session exists, so users can inspect what happened without needing to retry

## Test plan
- [ ] Start a mission, let an agent complete an issue — verify the session ends automatically after the agent sets status to Done
- [ ] Check that failed/blocked issues in the alert board show "Open →" alongside "Retry →" when a session exists
- [ ] Verify clicking "Open →" navigates to the conversation
- [ ] Confirm macOS and iOS builds pass