### PR TITLE
♻️ Box large enum variants in protocol types

### DIFF
--- a/orbitdock-server/crates/cli/src/client/ws.rs
+++ b/orbitdock-server/crates/cli/src/client/ws.rs
@@ -99,7 +99,7 @@ impl WsClient {
         let deadline = Duration::from_secs(15);
         loop {
             match self.recv_timeout(deadline).await? {
-                Some(ServerMessage::ConversationBootstrap { session, .. }) => return Ok(session),
+                Some(ServerMessage::ConversationBootstrap { session, .. }) => return Ok(*session),
                 Some(ServerMessage::Error { code, message, .. }) => {
                     bail!("[{code}] {message}");
                 }

--- a/orbitdock-server/crates/cli/src/commands/session.rs
+++ b/orbitdock-server/crates/cli/src/commands/session.rs
@@ -1029,7 +1029,7 @@ async fn watch(
 
     if output.json {
         output.print_json(&ServerMessage::ConversationBootstrap {
-            session: session.clone(),
+            session: Box::new(session.clone()),
             conversation: RowPageSummary {
                 rows: vec![],
                 total_row_count: 0,

--- a/orbitdock-server/crates/connector-core/src/transition.rs
+++ b/orbitdock-server/crates/connector-core/src/transition.rs
@@ -523,13 +523,13 @@ pub fn transition(
             })));
             effects.push(Effect::Emit(Box::new(ServerMessage::SessionDelta {
                 session_id: sid,
-                changes: StateChanges {
+                changes: Box::new(StateChanges {
                     work_status: Some(WorkStatus::Working),
                     last_activity_at: Some(now.to_string()),
                     current_turn_id: Some(Some(turn_id)),
                     turn_count: Some(state.turn_count),
                     ..Default::default()
-                },
+                }),
             })));
         }
 
@@ -594,13 +594,13 @@ pub fn transition(
             })));
             effects.push(Effect::Emit(Box::new(ServerMessage::SessionDelta {
                 session_id: sid,
-                changes: StateChanges {
+                changes: Box::new(StateChanges {
                     work_status: Some(WorkStatus::Waiting),
                     last_activity_at: Some(now.to_string()),
                     current_turn_id: Some(None),
                     current_diff: Some(None),
                     ..Default::default()
-                },
+                }),
             })));
         }
 
@@ -627,12 +627,12 @@ pub fn transition(
                 })));
                 effects.push(Effect::Emit(Box::new(ServerMessage::SessionDelta {
                     session_id: sid,
-                    changes: StateChanges {
+                    changes: Box::new(StateChanges {
                         work_status: Some(WorkStatus::Waiting),
                         last_activity_at: Some(now.to_string()),
                         current_turn_id: Some(None),
                         ..Default::default()
-                    },
+                    }),
                 })));
             }
         }
@@ -680,11 +680,11 @@ pub fn transition(
             })));
             effects.push(Effect::Emit(Box::new(ServerMessage::SessionDelta {
                 session_id: sid,
-                changes: StateChanges {
+                changes: Box::new(StateChanges {
                     work_status: Some(WorkStatus::Waiting),
                     last_activity_at: Some(now.to_string()),
                     ..Default::default()
-                },
+                }),
             })));
         }
 
@@ -874,7 +874,7 @@ pub fn transition(
             })));
             effects.push(Effect::Emit(Box::new(ServerMessage::ApprovalRequested {
                 session_id: sid,
-                request,
+                request: Box::new(request),
                 approval_version: None, // Filled by actor after apply_state
             })));
         }
@@ -900,12 +900,12 @@ pub fn transition(
                 })));
                 effects.push(Effect::Emit(Box::new(ServerMessage::SessionDelta {
                     session_id: sid,
-                    changes: StateChanges {
+                    changes: Box::new(StateChanges {
                         work_status: Some(WorkStatus::Working),
                         pending_approval: Some(None),
                         last_activity_at: Some(now.to_string()),
                         ..Default::default()
-                    },
+                    }),
                 })));
             }
         }
@@ -918,10 +918,10 @@ pub fn transition(
             })));
             effects.push(Effect::Emit(Box::new(ServerMessage::SessionDelta {
                 session_id: sid,
-                changes: StateChanges {
+                changes: Box::new(StateChanges {
                     permission_mode: Some(Some(mode)),
                     ..Default::default()
-                },
+                }),
             })));
         }
 
@@ -955,10 +955,10 @@ pub fn transition(
             })));
             effects.push(Effect::Emit(Box::new(ServerMessage::SessionDelta {
                 session_id: sid,
-                changes: StateChanges {
+                changes: Box::new(StateChanges {
                     current_diff: Some(Some(diff)),
                     ..Default::default()
-                },
+                }),
             })));
         }
 
@@ -972,10 +972,10 @@ pub fn transition(
             })));
             effects.push(Effect::Emit(Box::new(ServerMessage::SessionDelta {
                 session_id: sid,
-                changes: StateChanges {
+                changes: Box::new(StateChanges {
                     current_plan: Some(Some(plan)),
                     ..Default::default()
-                },
+                }),
             })));
         }
 
@@ -989,10 +989,10 @@ pub fn transition(
             })));
             effects.push(Effect::Emit(Box::new(ServerMessage::SessionDelta {
                 session_id: sid,
-                changes: StateChanges {
+                changes: Box::new(StateChanges {
                     custom_name: Some(Some(name)),
                     ..Default::default()
-                },
+                }),
             })));
         }
 
@@ -1033,11 +1033,11 @@ pub fn transition(
             })));
             effects.push(Effect::Emit(Box::new(ServerMessage::SessionDelta {
                 session_id: sid.clone(),
-                changes: StateChanges {
+                changes: Box::new(StateChanges {
                     work_status: Some(WorkStatus::Working),
                     last_activity_at: Some(now.to_string()),
                     ..Default::default()
-                },
+                }),
             })));
             effects.push(Effect::Emit(Box::new(ServerMessage::UndoStarted {
                 session_id: sid,
@@ -1057,11 +1057,11 @@ pub fn transition(
             })));
             effects.push(Effect::Emit(Box::new(ServerMessage::SessionDelta {
                 session_id: sid.clone(),
-                changes: StateChanges {
+                changes: Box::new(StateChanges {
                     work_status: Some(WorkStatus::Waiting),
                     last_activity_at: Some(now.to_string()),
                     ..Default::default()
-                },
+                }),
             })));
             effects.push(Effect::Emit(Box::new(ServerMessage::UndoCompleted {
                 session_id: sid,
@@ -1082,11 +1082,11 @@ pub fn transition(
             })));
             effects.push(Effect::Emit(Box::new(ServerMessage::SessionDelta {
                 session_id: sid.clone(),
-                changes: StateChanges {
+                changes: Box::new(StateChanges {
                     work_status: Some(WorkStatus::Waiting),
                     last_activity_at: Some(now.to_string()),
                     ..Default::default()
-                },
+                }),
             })));
             effects.push(Effect::Emit(Box::new(ServerMessage::ThreadRolledBack {
                 session_id: sid,
@@ -1139,7 +1139,7 @@ pub fn transition(
                 })));
                 effects.push(Effect::Emit(Box::new(ServerMessage::SessionDelta {
                     session_id: sid,
-                    changes: StateChanges {
+                    changes: Box::new(StateChanges {
                         current_cwd: Some(state.current_cwd.clone()),
                         git_branch: Some(state.git_branch.clone()),
                         git_sha: Some(state.git_sha.clone()),
@@ -1147,7 +1147,7 @@ pub fn transition(
                         repository_root: Some(state.repository_root.clone()),
                         is_worktree: Some(state.is_worktree),
                         ..Default::default()
-                    },
+                    }),
                 })));
             }
         }
@@ -1160,10 +1160,10 @@ pub fn transition(
             })));
             effects.push(Effect::Emit(Box::new(ServerMessage::SessionDelta {
                 session_id: sid,
-                changes: StateChanges {
+                changes: Box::new(StateChanges {
                     model: Some(Some(model)),
                     ..Default::default()
-                },
+                }),
             })));
         }
 

--- a/orbitdock-server/crates/protocol/src/client.rs
+++ b/orbitdock-server/crates/protocol/src/client.rs
@@ -21,7 +21,6 @@ fn is_true(value: &bool) -> bool {
 /// Messages sent from client to server
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
-#[allow(clippy::large_enum_variant)]
 pub enum ClientMessage {
     // Subscriptions
     SubscribeSession {

--- a/orbitdock-server/crates/protocol/src/server.rs
+++ b/orbitdock-server/crates/protocol/src/server.rs
@@ -10,7 +10,6 @@ use crate::types::*;
 /// Messages sent from server to client
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
-#[allow(clippy::large_enum_variant)]
 pub enum ServerMessage {
     // Full state sync
     SessionsList {
@@ -20,14 +19,14 @@ pub enum ServerMessage {
         conversations: Vec<DashboardConversationItem>,
     },
     ConversationBootstrap {
-        session: SessionState,
+        session: Box<SessionState>,
         conversation: RowPageSummary,
     },
 
     // Incremental updates
     SessionDelta {
         session_id: String,
-        changes: StateChanges,
+        changes: Box<StateChanges>,
     },
     ConversationRowsChanged {
         session_id: String,
@@ -39,7 +38,7 @@ pub enum ServerMessage {
     },
     ApprovalRequested {
         session_id: String,
-        request: ApprovalRequest,
+        request: Box<ApprovalRequest>,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         approval_version: Option<u64>,
     },

--- a/orbitdock-server/crates/server/src/connectors/claude_hooks/handler.rs
+++ b/orbitdock-server/crates/server/src/connectors/claude_hooks/handler.rs
@@ -110,7 +110,7 @@ pub async fn handle_hook_message(msg: ClientMessage, state: &Arc<SessionRegistry
 
                 existing
                     .send(SessionCommand::ApplyDelta {
-                        changes: orbitdock_protocol::StateChanges {
+                        changes: Box::new(orbitdock_protocol::StateChanges {
                             work_status: Some(orbitdock_protocol::WorkStatus::Waiting),
                             git_branch: git_branch.as_ref().map(|b| Some(b.clone())),
                             git_sha: git_sha.as_ref().map(|s| Some(s.clone())),
@@ -118,7 +118,7 @@ pub async fn handle_hook_message(msg: ClientMessage, state: &Arc<SessionRegistry
                             is_worktree: if is_worktree { Some(true) } else { None },
                             last_activity_at: Some(chrono_now()),
                             ..Default::default()
-                        },
+                        }),
                         persist_op: None,
                     })
                     .await;
@@ -282,10 +282,10 @@ pub async fn handle_hook_message(msg: ClientMessage, state: &Arc<SessionRegistry
                                     {
                                         actor
                                             .send(SessionCommand::ApplyDelta {
-                                                changes: orbitdock_protocol::StateChanges {
+                                                changes: Box::new(orbitdock_protocol::StateChanges {
                                                     summary: Some(Some(summary.clone())),
                                                     ..Default::default()
-                                                },
+                                                }),
                                                 persist_op: None,
                                             })
                                             .await;
@@ -359,13 +359,13 @@ pub async fn handle_hook_message(msg: ClientMessage, state: &Arc<SessionRegistry
                 if git_branch.is_some() && existing.snapshot().git_branch.is_none() {
                     existing
                         .send(SessionCommand::ApplyDelta {
-                            changes: orbitdock_protocol::StateChanges {
+                            changes: Box::new(orbitdock_protocol::StateChanges {
                                 git_branch: git_branch.as_ref().map(|b| Some(b.clone())),
                                 git_sha: git_sha.as_ref().map(|s| Some(s.clone())),
                                 repository_root: repository_root.as_ref().map(|r| Some(r.clone())),
                                 is_worktree: if is_worktree { Some(true) } else { None },
                                 ..Default::default()
-                            },
+                            }),
                             persist_op: None,
                         })
                         .await;
@@ -490,7 +490,7 @@ pub async fn handle_hook_message(msg: ClientMessage, state: &Arc<SessionRegistry
                     };
                     let _ = actor
                         .send(SessionCommand::ApplyDelta {
-                            changes,
+                            changes: Box::new(changes),
                             persist_op: None,
                         })
                         .await;
@@ -514,13 +514,13 @@ pub async fn handle_hook_message(msg: ClientMessage, state: &Arc<SessionRegistry
                         // Push delta to clients
                         let _ = actor
                             .send(SessionCommand::ApplyDelta {
-                                changes: orbitdock_protocol::StateChanges {
+                                changes: Box::new(orbitdock_protocol::StateChanges {
                                     git_branch: Some(Some(info.branch.clone())),
                                     git_sha: Some(Some(info.sha.clone())),
                                     repository_root: Some(Some(info.common_dir_root.clone())),
                                     is_worktree: if info.is_worktree { Some(true) } else { None },
                                     ..Default::default()
-                                },
+                                }),
                                 persist_op: None,
                             })
                             .await;
@@ -561,10 +561,10 @@ pub async fn handle_hook_message(msg: ClientMessage, state: &Arc<SessionRegistry
                         {
                             actor
                                 .send(SessionCommand::ApplyDelta {
-                                    changes: orbitdock_protocol::StateChanges {
+                                    changes: Box::new(orbitdock_protocol::StateChanges {
                                         summary: Some(Some(extracted_summary.clone())),
                                         ..Default::default()
-                                    },
+                                    }),
                                     persist_op: None,
                                 })
                                 .await;
@@ -612,11 +612,11 @@ pub async fn handle_hook_message(msg: ClientMessage, state: &Arc<SessionRegistry
             if let Some(work_status) = next_work_status {
                 actor
                     .send(SessionCommand::ApplyDelta {
-                        changes: orbitdock_protocol::StateChanges {
+                        changes: Box::new(orbitdock_protocol::StateChanges {
                             work_status: Some(work_status),
                             last_activity_at: Some(chrono_now()),
                             ..Default::default()
-                        },
+                        }),
                         persist_op: None,
                     })
                     .await;
@@ -788,13 +788,13 @@ pub async fn handle_hook_message(msg: ClientMessage, state: &Arc<SessionRegistry
                 if git_branch.is_some() && existing.snapshot().git_branch.is_none() {
                     existing
                         .send(SessionCommand::ApplyDelta {
-                            changes: orbitdock_protocol::StateChanges {
+                            changes: Box::new(orbitdock_protocol::StateChanges {
                                 git_branch: git_branch.as_ref().map(|b| Some(b.clone())),
                                 git_sha: git_sha.as_ref().map(|s| Some(s.clone())),
                                 repository_root: repository_root.as_ref().map(|r| Some(r.clone())),
                                 is_worktree: if is_worktree { Some(true) } else { None },
                                 ..Default::default()
-                            },
+                            }),
                             persist_op: None,
                         })
                         .await;
@@ -858,11 +858,11 @@ pub async fn handle_hook_message(msg: ClientMessage, state: &Arc<SessionRegistry
                         .await;
                     actor
                         .send(SessionCommand::ApplyDelta {
-                            changes: orbitdock_protocol::StateChanges {
+                            changes: Box::new(orbitdock_protocol::StateChanges {
                                 work_status: Some(orbitdock_protocol::WorkStatus::Working),
                                 last_activity_at: Some(chrono_now()),
                                 ..Default::default()
-                            },
+                            }),
                             persist_op: None,
                         })
                         .await;
@@ -946,7 +946,7 @@ pub async fn handle_hook_message(msg: ClientMessage, state: &Arc<SessionRegistry
                     }
                     actor
                         .send(SessionCommand::ApplyDelta {
-                            changes: delta,
+                            changes: Box::new(delta),
                             persist_op: None,
                         })
                         .await;
@@ -993,11 +993,11 @@ pub async fn handle_hook_message(msg: ClientMessage, state: &Arc<SessionRegistry
 
                     actor
                         .send(SessionCommand::ApplyDelta {
-                            changes: orbitdock_protocol::StateChanges {
+                            changes: Box::new(orbitdock_protocol::StateChanges {
                                 work_status: Some(orbitdock_protocol::WorkStatus::Working),
                                 last_activity_at: Some(chrono_now()),
                                 ..Default::default()
-                            },
+                            }),
                             persist_op: None,
                         })
                         .await;
@@ -1081,12 +1081,12 @@ pub async fn handle_hook_message(msg: ClientMessage, state: &Arc<SessionRegistry
                             .await;
                         actor
                             .send(SessionCommand::ApplyDelta {
-                                changes: orbitdock_protocol::StateChanges {
+                                changes: Box::new(orbitdock_protocol::StateChanges {
                                     work_status: Some(work_status),
                                     current_plan: plan_text.clone().map(Some),
                                     last_activity_at: Some(chrono_now()),
                                     ..Default::default()
-                                },
+                                }),
                                 persist_op: None,
                             })
                             .await;

--- a/orbitdock-server/crates/server/src/connectors/claude_hooks/session_materialization.rs
+++ b/orbitdock-server/crates/server/src/connectors/claude_hooks/session_materialization.rs
@@ -93,13 +93,13 @@ pub(crate) async fn materialize_claude_session(
     if git_branch.is_some() || repository_root.is_some() {
         actor
             .send(SessionCommand::ApplyDelta {
-                changes: orbitdock_protocol::StateChanges {
+                changes: Box::new(orbitdock_protocol::StateChanges {
                     git_branch: git_branch.as_ref().map(|value| Some(value.clone())),
                     git_sha: git_sha.as_ref().map(|value| Some(value.clone())),
                     repository_root: repository_root.as_ref().map(|value| Some(value.clone())),
                     is_worktree: if is_worktree { Some(true) } else { None },
                     ..Default::default()
-                },
+                }),
                 persist_op: None,
             })
             .await;

--- a/orbitdock-server/crates/server/src/connectors/claude_session.rs
+++ b/orbitdock-server/crates/server/src/connectors/claude_session.rs
@@ -164,7 +164,7 @@ pub fn start_event_loop(
                             };
                             let _ = actor_for_naming
                                 .send(crate::runtime::session_commands::SessionCommand::ApplyDelta {
-                                    changes,
+                                    changes: Box::new(changes),
                                     persist_op: None,
                                 })
                                 .await;

--- a/orbitdock-server/crates/server/src/connectors/codex_rollout/runtime.rs
+++ b/orbitdock-server/crates/server/src/connectors/codex_rollout/runtime.rs
@@ -705,10 +705,10 @@ impl WatcherRuntime {
                 if let Some(effort) = effort {
                     actor
                         .send(SessionCommand::ApplyDelta {
-                            changes: StateChanges {
+                            changes: Box::new(StateChanges {
                                 effort: Some(Some(effort)),
                                 ..Default::default()
-                            },
+                            }),
                             persist_op: None,
                         })
                         .await;
@@ -940,7 +940,7 @@ impl WatcherRuntime {
                 };
                 let _ = actor
                     .send(SessionCommand::ApplyDelta {
-                        changes,
+                        changes: Box::new(changes),
                         persist_op: None,
                     })
                     .await;
@@ -1284,7 +1284,7 @@ impl WatcherRuntime {
                     actor
                         .send(SessionCommand::Broadcast {
                             msg: ServerMessage::ConversationBootstrap {
-                                session: state,
+                                session: Box::new(state),
                                 conversation: RowPageSummary {
                                     rows: vec![],
                                     total_row_count: 0,
@@ -1313,7 +1313,7 @@ impl WatcherRuntime {
 
             actor
                 .send(SessionCommand::ApplyDelta {
-                    changes: merged,
+                    changes: Box::new(merged),
                     persist_op: None,
                 })
                 .await;

--- a/orbitdock-server/crates/server/src/runtime/background/git_refresh.rs
+++ b/orbitdock-server/crates/server/src/runtime/background/git_refresh.rs
@@ -81,7 +81,7 @@ async fn refresh_subscribed_sessions(state: &SessionRegistry) {
 
                 actor
                     .send(SessionCommand::ApplyDelta {
-                        changes,
+                        changes: Box::new(changes),
                         persist_op: None,
                     })
                     .await;

--- a/orbitdock-server/crates/server/src/runtime/message_dispatch.rs
+++ b/orbitdock-server/crates/server/src/runtime/message_dispatch.rs
@@ -84,7 +84,7 @@ pub(crate) async fn dispatch_send_message(
         };
         let _ = actor
             .send(SessionCommand::ApplyDelta {
-                changes,
+                changes: Box::new(changes),
                 persist_op: None,
             })
             .await;
@@ -114,7 +114,7 @@ pub(crate) async fn dispatch_send_message(
         };
         let _ = actor
             .send(SessionCommand::ApplyDelta {
-                changes,
+                changes: Box::new(changes),
                 persist_op: None,
             })
             .await;
@@ -134,7 +134,7 @@ pub(crate) async fn dispatch_send_message(
         };
         let _ = actor
             .send(SessionCommand::ApplyDelta {
-                changes,
+                changes: Box::new(changes),
                 persist_op: None,
             })
             .await;

--- a/orbitdock-server/crates/server/src/runtime/session_activation.rs
+++ b/orbitdock-server/crates/server/src/runtime/session_activation.rs
@@ -29,12 +29,12 @@ pub(crate) async fn reactivate_passive_and_prepare_subscribe(
     let now = chrono_now();
     actor
         .send(SessionCommand::ApplyDelta {
-            changes: StateChanges {
+            changes: Box::new(StateChanges {
                 status: Some(SessionStatus::Active),
                 work_status: Some(WorkStatus::Waiting),
                 last_activity_at: Some(now),
                 ..Default::default()
-            },
+            }),
             persist_op: Some(PersistOp::SessionUpdate {
                 id: session_id.to_string(),
                 status: Some(SessionStatus::Active),

--- a/orbitdock-server/crates/server/src/runtime/session_command_handler.rs
+++ b/orbitdock-server/crates/server/src/runtime/session_command_handler.rs
@@ -47,40 +47,23 @@ async fn execute_persist_op(op: PersistOp, persist_tx: &mpsc::Sender<PersistComm
             session_id,
             custom_name: name,
         },
-        PersistOp::SetSessionConfig {
-            session_id,
-            approval_policy,
-            sandbox_mode,
-            permission_mode,
-            collaboration_mode,
-            multi_agent,
-            personality,
-            service_tier,
-            developer_instructions,
-            model,
-            effort,
-            codex_config_mode,
-            codex_config_profile,
-            codex_model_provider,
-            codex_config_source,
-            codex_config_overrides_json,
-        } => PersistCommand::SetSessionConfig {
-            session_id,
-            approval_policy,
-            sandbox_mode,
-            permission_mode,
-            collaboration_mode,
-            multi_agent,
-            personality,
-            service_tier,
-            developer_instructions,
-            model,
-            effort,
-            codex_config_mode,
-            codex_config_profile,
-            codex_model_provider,
-            codex_config_source,
-            codex_config_overrides_json,
+        PersistOp::SetSessionConfig(cfg) => PersistCommand::SetSessionConfig {
+            session_id: cfg.session_id,
+            approval_policy: cfg.approval_policy,
+            sandbox_mode: cfg.sandbox_mode,
+            permission_mode: cfg.permission_mode,
+            collaboration_mode: cfg.collaboration_mode,
+            multi_agent: cfg.multi_agent,
+            personality: cfg.personality,
+            service_tier: cfg.service_tier,
+            developer_instructions: cfg.developer_instructions,
+            model: cfg.model,
+            effort: cfg.effort,
+            codex_config_mode: cfg.codex_config_mode,
+            codex_config_profile: cfg.codex_config_profile,
+            codex_model_provider: cfg.codex_model_provider,
+            codex_config_source: cfg.codex_config_source,
+            codex_config_overrides_json: cfg.codex_config_overrides_json,
         },
     };
     let _ = persist_tx.send(cmd).await;
@@ -105,10 +88,10 @@ async fn persist_and_broadcast_mark_read(
 
     handle.broadcast(ServerMessage::SessionDelta {
         session_id: session_id.clone(),
-        changes: StateChanges {
+        changes: Box::new(StateChanges {
             unread_count: Some(0),
             ..Default::default()
-        },
+        }),
     });
     handle.broadcast(ServerMessage::SessionListItemUpdated {
         session: SessionListItem::from_summary(&handle.summary()),
@@ -310,11 +293,11 @@ pub async fn handle_session_command(
             handle.set_last_activity_at(Some(now.clone()));
             handle.broadcast(ServerMessage::SessionDelta {
                 session_id,
-                changes: StateChanges {
+                changes: Box::new(StateChanges {
                     subagents: Some(merged_subagents),
                     last_activity_at: Some(now),
                     ..Default::default()
-                },
+                }),
             });
         }
         SessionCommand::SetPendingAttention {
@@ -348,12 +331,12 @@ pub async fn handle_session_command(
             handle.set_last_activity_at(Some(now.clone()));
             handle.broadcast(ServerMessage::SessionDelta {
                 session_id,
-                changes: StateChanges {
+                changes: Box::new(StateChanges {
                     status: Some(SessionStatus::Ended),
                     work_status: Some(WorkStatus::Ended),
                     last_activity_at: Some(now),
                     ..Default::default()
-                },
+                }),
             });
         }
         SessionCommand::SetCustomNameAndNotify {
@@ -368,11 +351,11 @@ pub async fn handle_session_command(
             }
             handle.broadcast(ServerMessage::SessionDelta {
                 session_id,
-                changes: StateChanges {
+                changes: Box::new(StateChanges {
                     custom_name: Some(name),
                     last_activity_at: Some(chrono_now()),
                     ..Default::default()
-                },
+                }),
             });
             let _ = reply.send(handle.summary());
         }
@@ -441,7 +424,7 @@ pub async fn handle_session_command(
             if let Some(changes) = observability_changes {
                 handle.broadcast(ServerMessage::SessionDelta {
                     session_id: handle.id().to_string(),
-                    changes,
+                    changes: Box::new(changes),
                 });
             }
         }
@@ -560,12 +543,12 @@ pub async fn handle_session_command(
                 let session_id = handle.id().to_string();
                 handle.broadcast(ServerMessage::SessionDelta {
                     session_id,
-                    changes: StateChanges {
+                    changes: Box::new(StateChanges {
                         work_status: Some(work_status),
                         pending_approval: Some(next_pending_approval.clone()),
                         approval_version: Some(approval_version),
                         ..Default::default()
-                    },
+                    }),
                 });
             }
 
@@ -792,7 +775,7 @@ pub(crate) async fn dispatch_transition_input(
     ) {
         handle.broadcast(ServerMessage::SessionDelta {
             session_id: handle.id().to_string(),
-            changes,
+            changes: Box::new(changes),
         });
     }
 

--- a/orbitdock-server/crates/server/src/runtime/session_commands.rs
+++ b/orbitdock-server/crates/server/src/runtime/session_commands.rs
@@ -11,7 +11,6 @@ use crate::domain::sessions::conversation::{ConversationBootstrap, ConversationP
 
 /// A persistence operation that the actor executes on behalf of the caller.
 /// The actor already holds `persist_tx`, so callers don't need to pass it.
-#[allow(clippy::large_enum_variant)]
 pub enum PersistOp {
     SessionUpdate {
         id: String,
@@ -23,29 +22,31 @@ pub enum PersistOp {
         session_id: String,
         name: Option<String>,
     },
-    SetSessionConfig {
-        session_id: String,
-        approval_policy: Option<Option<String>>,
-        sandbox_mode: Option<Option<String>>,
-        permission_mode: Option<Option<String>>,
-        collaboration_mode: Option<Option<String>>,
-        multi_agent: Option<Option<bool>>,
-        personality: Option<Option<String>>,
-        service_tier: Option<Option<String>>,
-        developer_instructions: Option<Option<String>>,
-        model: Option<Option<String>>,
-        effort: Option<Option<String>>,
-        codex_config_mode: Option<orbitdock_protocol::CodexConfigMode>,
-        codex_config_profile: Option<String>,
-        codex_model_provider: Option<String>,
-        codex_config_source: Option<orbitdock_protocol::CodexConfigSource>,
-        codex_config_overrides_json: Option<String>,
-    },
+    SetSessionConfig(Box<SessionConfigPersist>),
+}
+
+/// Payload for `PersistOp::SetSessionConfig`, boxed to keep the enum small.
+pub struct SessionConfigPersist {
+    pub session_id: String,
+    pub approval_policy: Option<Option<String>>,
+    pub sandbox_mode: Option<Option<String>>,
+    pub permission_mode: Option<Option<String>>,
+    pub collaboration_mode: Option<Option<String>>,
+    pub multi_agent: Option<Option<bool>>,
+    pub personality: Option<Option<String>>,
+    pub service_tier: Option<Option<String>>,
+    pub developer_instructions: Option<Option<String>>,
+    pub model: Option<Option<String>>,
+    pub effort: Option<Option<String>>,
+    pub codex_config_mode: Option<orbitdock_protocol::CodexConfigMode>,
+    pub codex_config_profile: Option<String>,
+    pub codex_model_provider: Option<String>,
+    pub codex_config_source: Option<orbitdock_protocol::CodexConfigSource>,
+    pub codex_config_overrides_json: Option<String>,
 }
 
 /// A command that can be sent to a session actor.
 #[allow(dead_code)]
-#[allow(clippy::large_enum_variant)]
 pub enum SessionCommand {
     // -- Queries (use oneshot reply channels) --
     /// Get the retained in-memory session snapshot.
@@ -126,7 +127,7 @@ pub enum SessionCommand {
     // -- Compound operations --
     /// Apply a StateChanges delta, optionally persist, and broadcast SessionDelta.
     ApplyDelta {
-        changes: StateChanges,
+        changes: Box<StateChanges>,
         persist_op: Option<PersistOp>,
     },
 

--- a/orbitdock-server/crates/server/src/runtime/session_direct_start.rs
+++ b/orbitdock-server/crates/server/src/runtime/session_direct_start.rs
@@ -175,10 +175,10 @@ pub(crate) async fn start_direct_claude_session(
     if let Some(mode) = permission_mode {
         let _ = actor_handle
             .send(SessionCommand::ApplyDelta {
-                changes: orbitdock_protocol::StateChanges {
+                changes: Box::new(orbitdock_protocol::StateChanges {
                     permission_mode: Some(Some(mode.to_string())),
                     ..Default::default()
-                },
+                }),
                 persist_op: None,
             })
             .await;

--- a/orbitdock-server/crates/server/src/runtime/session_mutations.rs
+++ b/orbitdock-server/crates/server/src/runtime/session_mutations.rs
@@ -8,7 +8,7 @@ use crate::infrastructure::persistence::PersistCommand;
 use crate::runtime::codex_config::{
     resolve_codex_settings, serialize_codex_overrides, CodexConfigSelection,
 };
-use crate::runtime::session_commands::{PersistOp, SessionCommand};
+use crate::runtime::session_commands::{PersistOp, SessionCommand, SessionConfigPersist};
 use crate::runtime::session_registry::SessionRegistry;
 use crate::support::session_modes::is_passive_rollout_session;
 
@@ -254,7 +254,7 @@ pub(crate) async fn update_session_config(
 
     actor
         .send(SessionCommand::ApplyDelta {
-            changes: orbitdock_protocol::StateChanges {
+            changes: Box::new(orbitdock_protocol::StateChanges {
                 approval_policy: approval_policy.clone(),
                 approval_policy_details: approval_policy_details.clone(),
                 sandbox_mode: sandbox_mode.clone(),
@@ -272,27 +272,29 @@ pub(crate) async fn update_session_config(
                 codex_config_source: codex_config_source.map(Some),
                 codex_config_overrides: codex_config_overrides.clone().map(Some),
                 ..Default::default()
-            },
-            persist_op: Some(PersistOp::SetSessionConfig {
-                session_id: session_id.to_string(),
-                approval_policy: approval_policy.clone(),
-                sandbox_mode: sandbox_mode.clone(),
-                permission_mode: permission_mode.clone(),
-                collaboration_mode: collaboration_mode.clone(),
-                multi_agent,
-                personality: personality.clone(),
-                service_tier: service_tier.clone(),
-                developer_instructions: developer_instructions.clone(),
-                model: model.clone(),
-                effort: effort.clone(),
-                codex_config_mode: codex_config_mode.flatten(),
-                codex_config_profile: codex_config_profile.flatten(),
-                codex_model_provider: codex_model_provider.flatten(),
-                codex_config_source,
-                codex_config_overrides_json: codex_config_overrides
-                    .as_ref()
-                    .and_then(serialize_codex_overrides),
             }),
+            persist_op: Some(PersistOp::SetSessionConfig(Box::new(
+                SessionConfigPersist {
+                    session_id: session_id.to_string(),
+                    approval_policy: approval_policy.clone(),
+                    sandbox_mode: sandbox_mode.clone(),
+                    permission_mode: permission_mode.clone(),
+                    collaboration_mode: collaboration_mode.clone(),
+                    multi_agent,
+                    personality: personality.clone(),
+                    service_tier: service_tier.clone(),
+                    developer_instructions: developer_instructions.clone(),
+                    model: model.clone(),
+                    effort: effort.clone(),
+                    codex_config_mode: codex_config_mode.flatten(),
+                    codex_config_profile: codex_config_profile.flatten(),
+                    codex_model_provider: codex_model_provider.flatten(),
+                    codex_config_source,
+                    codex_config_overrides_json: codex_config_overrides
+                        .as_ref()
+                        .and_then(serialize_codex_overrides),
+                },
+            ))),
         })
         .await;
 

--- a/orbitdock-server/crates/server/src/runtime/session_resume.rs
+++ b/orbitdock-server/crates/server/src/runtime/session_resume.rs
@@ -197,10 +197,10 @@ async fn spawn_claude_resume(state: &Arc<SessionRegistry>, params: ClaudeResumeP
                     if let Some(actor) = state.get_session(&session_id) {
                         actor
                             .send(SessionCommand::ApplyDelta {
-                                changes: orbitdock_protocol::StateChanges {
+                                changes: Box::new(orbitdock_protocol::StateChanges {
                                     permission_mode: Some(Some(mode.clone())),
                                     ..Default::default()
-                                },
+                                }),
                                 persist_op: None,
                             })
                             .await;

--- a/orbitdock-server/crates/server/src/runtime/session_runtime_helpers.rs
+++ b/orbitdock-server/crates/server/src/runtime/session_runtime_helpers.rs
@@ -181,11 +181,11 @@ pub(crate) async fn mark_session_working_after_send(
     let now = chrono_now();
     actor
         .send(SessionCommand::ApplyDelta {
-            changes: StateChanges {
+            changes: Box::new(StateChanges {
                 work_status: Some(WorkStatus::Working),
                 last_activity_at: Some(now.clone()),
                 ..Default::default()
-            },
+            }),
             persist_op: Some(PersistOp::SessionUpdate {
                 id: session_id.to_string(),
                 status: None,

--- a/orbitdock-server/crates/server/src/runtime/session_takeover.rs
+++ b/orbitdock-server/crates/server/src/runtime/session_takeover.rs
@@ -15,7 +15,7 @@ use crate::infrastructure::persistence::{
     load_latest_codex_turn_context_settings_from_transcript_path,
     load_messages_from_transcript_path, load_session_permission_mode, PersistCommand,
 };
-use crate::runtime::session_commands::{PersistOp, SessionCommand};
+use crate::runtime::session_commands::{PersistOp, SessionCommand, SessionConfigPersist};
 use crate::runtime::session_lifecycle_policy::{plan_takeover_config, TakeoverConfigInputs};
 use crate::runtime::session_registry::SessionRegistry;
 use crate::runtime::session_runtime_helpers::{
@@ -384,7 +384,7 @@ async fn complete_codex_takeover(
                 }
                 actor
                     .send(SessionCommand::ApplyDelta {
-                        changes,
+                        changes: Box::new(changes),
                         persist_op: None,
                     })
                     .await;
@@ -513,10 +513,10 @@ async fn complete_claude_takeover(
                 if let Some(actor) = state.get_session(&session_id) {
                     actor
                         .send(SessionCommand::ApplyDelta {
-                            changes: orbitdock_protocol::StateChanges {
+                            changes: Box::new(orbitdock_protocol::StateChanges {
                                 permission_mode: Some(Some(mode.clone())),
                                 ..Default::default()
-                            },
+                            }),
                             persist_op: takeover_permission_persist_op(
                                 &session_id,
                                 persist_permission_mode,
@@ -530,7 +530,7 @@ async fn complete_claude_takeover(
             if let Some(actor) = state.get_session(&session_id) {
                 actor
                     .send(SessionCommand::ApplyDelta {
-                        changes: direct_mode_activation_changes(Provider::Claude),
+                        changes: Box::new(direct_mode_activation_changes(Provider::Claude)),
                         persist_op: None,
                     })
                     .await;
@@ -595,22 +595,24 @@ fn takeover_permission_persist_op(
         return None;
     }
 
-    permission_mode.map(|permission_mode| PersistOp::SetSessionConfig {
-        session_id: session_id.to_string(),
-        approval_policy: None,
-        sandbox_mode: None,
-        permission_mode: Some(Some(permission_mode)),
-        collaboration_mode: None,
-        multi_agent: None,
-        personality: None,
-        service_tier: None,
-        developer_instructions: None,
-        model: None,
-        effort: None,
-        codex_config_mode: None,
-        codex_config_profile: None,
-        codex_model_provider: None,
-        codex_config_source: None,
-        codex_config_overrides_json: None,
+    permission_mode.map(|permission_mode| {
+        PersistOp::SetSessionConfig(Box::new(SessionConfigPersist {
+            session_id: session_id.to_string(),
+            approval_policy: None,
+            sandbox_mode: None,
+            permission_mode: Some(Some(permission_mode)),
+            collaboration_mode: None,
+            multi_agent: None,
+            personality: None,
+            service_tier: None,
+            developer_instructions: None,
+            model: None,
+            effort: None,
+            codex_config_mode: None,
+            codex_config_profile: None,
+            codex_model_provider: None,
+            codex_config_source: None,
+            codex_config_overrides_json: None,
+        }))
     })
 }

--- a/orbitdock-server/crates/server/src/support/ai_naming.rs
+++ b/orbitdock-server/crates/server/src/support/ai_naming.rs
@@ -96,7 +96,7 @@ pub fn spawn_naming_task(
                 };
                 let _ = actor
                     .send(SessionCommand::ApplyDelta {
-                        changes,
+                        changes: Box::new(changes),
                         persist_op: None,
                     })
                     .await;
@@ -104,10 +104,10 @@ pub fn spawn_naming_task(
                 // Also broadcast to list subscribers (dashboard sidebar)
                 let _ = list_tx.send(ServerMessage::SessionDelta {
                     session_id: session_id.clone(),
-                    changes: StateChanges {
+                    changes: Box::new(StateChanges {
                         summary: Some(Some(name.clone())),
                         ..Default::default()
-                    },
+                    }),
                 });
 
                 // Persist to DB

--- a/orbitdock-server/crates/server/src/support/snapshot_compaction.rs
+++ b/orbitdock-server/crates/server/src/support/snapshot_compaction.rs
@@ -63,9 +63,9 @@ pub(crate) fn sanitize_server_message_for_transport(msg: ServerMessage) -> Serve
             session,
             conversation,
         } => {
-            let prepared = prepare_snapshot_for_transport(session);
+            let prepared = prepare_snapshot_for_transport(*session);
             ServerMessage::ConversationBootstrap {
-                session: prepared,
+                session: Box::new(prepared),
                 conversation,
             }
         }

--- a/orbitdock-server/crates/server/src/transport/websocket/connection.rs
+++ b/orbitdock-server/crates/server/src/transport/websocket/connection.rs
@@ -91,7 +91,7 @@ async fn handle_socket(socket: WebSocket, state: Arc<SessionRegistry>) {
         while let Some(msg) = outbound_rx.recv().await {
             let result = match msg {
                 OutboundMessage::Json(server_msg) => {
-                    let sanitized = sanitize_server_message_for_transport(server_msg);
+                    let sanitized = sanitize_server_message_for_transport(*server_msg);
                     match serde_json::to_string(&sanitized) {
                         Ok(json) => {
                             if json.len() > WS_MAX_TEXT_MESSAGE_BYTES {

--- a/orbitdock-server/crates/server/src/transport/websocket/handlers/session_forks.rs
+++ b/orbitdock-server/crates/server/src/transport/websocket/handlers/session_forks.rs
@@ -212,7 +212,7 @@ pub(crate) async fn handle_fork_session(
                     send_json(
                         client_tx,
                         ServerMessage::ConversationBootstrap {
-                            session: started.snapshot,
+                            session: Box::new(started.snapshot),
                             conversation: RowPageSummary {
                                 rows: vec![],
                                 total_row_count: 0,
@@ -373,7 +373,7 @@ pub(crate) async fn handle_fork_session(
                     send_json(
                         client_tx,
                         ServerMessage::ConversationBootstrap {
-                            session: started.snapshot,
+                            session: Box::new(started.snapshot),
                             conversation: RowPageSummary {
                                 rows: vec![],
                                 total_row_count: 0,

--- a/orbitdock-server/crates/server/src/transport/websocket/handlers/session_lifecycle.rs
+++ b/orbitdock-server/crates/server/src/transport/websocket/handlers/session_lifecycle.rs
@@ -17,7 +17,9 @@ use crate::infrastructure::persistence::{
     PersistCommand,
 };
 use crate::runtime::restored_sessions::load_prepared_resume_session;
-use crate::runtime::session_commands::{PersistOp, SessionCommand, SubscribeResult};
+use crate::runtime::session_commands::{
+    PersistOp, SessionCommand, SessionConfigPersist, SubscribeResult,
+};
 use crate::runtime::session_lifecycle_policy::{plan_takeover_config, TakeoverConfigInputs};
 use crate::runtime::session_registry::SessionRegistry;
 use crate::runtime::session_runtime_helpers::{
@@ -138,7 +140,7 @@ pub(crate) async fn handle(
             send_json(
                 client_tx,
                 ServerMessage::ConversationBootstrap {
-                    session: snapshot,
+                    session: Box::new(snapshot),
                     conversation: RowPageSummary {
                         rows: vec![],
                         total_row_count: 0,
@@ -242,10 +244,10 @@ pub(crate) async fn handle(
                             if let Some(actor) = state.get_session(&session_id) {
                                 actor
                                     .send(SessionCommand::ApplyDelta {
-                                        changes: StateChanges {
+                                        changes: Box::new(StateChanges {
                                             permission_mode: Some(Some(mode.clone())),
                                             ..Default::default()
-                                        },
+                                        }),
                                         persist_op: None,
                                     })
                                     .await;
@@ -276,14 +278,14 @@ pub(crate) async fn handle(
                             client_tx,
                             ServerMessage::SessionDelta {
                                 session_id: session_id.clone(),
-                                changes: StateChanges {
+                                changes: Box::new(StateChanges {
                                     claude_integration_mode: Some(Some(
                                         ClaudeIntegrationMode::Direct,
                                     )),
                                     status: Some(SessionStatus::Active),
                                     work_status: Some(WorkStatus::Waiting),
                                     ..Default::default()
-                                },
+                                }),
                             },
                         )
                         .await;
@@ -718,7 +720,7 @@ pub(crate) async fn handle(
                             }
                             actor
                                 .send(SessionCommand::ApplyDelta {
-                                    changes,
+                                    changes: Box::new(changes),
                                     persist_op: None,
                                 })
                                 .await;
@@ -876,29 +878,31 @@ pub(crate) async fn handle(
                             if let Some(actor) = state.get_session(&session_id) {
                                 actor
                                     .send(SessionCommand::ApplyDelta {
-                                        changes: orbitdock_protocol::StateChanges {
+                                        changes: Box::new(orbitdock_protocol::StateChanges {
                                             permission_mode: Some(Some(mode.clone())),
                                             ..Default::default()
-                                        },
+                                        }),
                                         persist_op: if requested_permission_mode.is_some() {
-                                            Some(PersistOp::SetSessionConfig {
-                                                session_id: session_id.clone(),
-                                                approval_policy: None,
-                                                sandbox_mode: None,
-                                                permission_mode: Some(Some(mode.clone())),
-                                                collaboration_mode: None,
-                                                multi_agent: None,
-                                                personality: None,
-                                                service_tier: None,
-                                                developer_instructions: None,
-                                                model: None,
-                                                effort: None,
-                                                codex_config_mode: None,
-                                                codex_config_profile: None,
-                                                codex_model_provider: None,
-                                                codex_config_source: None,
-                                                codex_config_overrides_json: None,
-                                            })
+                                            Some(PersistOp::SetSessionConfig(Box::new(
+                                                SessionConfigPersist {
+                                                    session_id: session_id.clone(),
+                                                    approval_policy: None,
+                                                    sandbox_mode: None,
+                                                    permission_mode: Some(Some(mode.clone())),
+                                                    collaboration_mode: None,
+                                                    multi_agent: None,
+                                                    personality: None,
+                                                    service_tier: None,
+                                                    developer_instructions: None,
+                                                    model: None,
+                                                    effort: None,
+                                                    codex_config_mode: None,
+                                                    codex_config_profile: None,
+                                                    codex_model_provider: None,
+                                                    codex_config_source: None,
+                                                    codex_config_overrides_json: None,
+                                                },
+                                            )))
                                         } else {
                                             None
                                         },
@@ -912,7 +916,9 @@ pub(crate) async fn handle(
                         if let Some(actor) = state.get_session(&session_id) {
                             actor
                                 .send(SessionCommand::ApplyDelta {
-                                    changes: direct_mode_activation_changes(Provider::Claude),
+                                    changes: Box::new(direct_mode_activation_changes(
+                                        Provider::Claude,
+                                    )),
                                     persist_op: None,
                                 })
                                 .await;
@@ -1024,7 +1030,9 @@ pub(crate) async fn handle(
                                 send_json(
                                     client_tx,
                                     ServerMessage::ConversationBootstrap {
-                                        session: prepare_snapshot_for_transport(*snapshot),
+                                        session: Box::new(prepare_snapshot_for_transport(
+                                            *snapshot,
+                                        )),
                                         conversation: RowPageSummary {
                                             rows: vec![],
                                             total_row_count: 0,

--- a/orbitdock-server/crates/server/src/transport/websocket/handlers/session_management.rs
+++ b/orbitdock-server/crates/server/src/transport/websocket/handlers/session_management.rs
@@ -99,7 +99,7 @@ pub(crate) async fn handle_create_session(
     send_json(
         client_tx,
         ServerMessage::ConversationBootstrap {
-            session: snapshot,
+            session: Box::new(snapshot),
             conversation: RowPageSummary {
                 rows: vec![],
                 total_row_count: 0,

--- a/orbitdock-server/crates/server/src/transport/websocket/test_support.rs
+++ b/orbitdock-server/crates/server/src/transport/websocket/test_support.rs
@@ -22,7 +22,7 @@ pub(crate) fn new_test_state() -> Arc<SessionRegistry> {
 #[allow(dead_code)]
 pub(crate) async fn recv_json(client_rx: &mut mpsc::Receiver<OutboundMessage>) -> ServerMessage {
     match client_rx.recv().await.expect("expected outbound message") {
-        OutboundMessage::Json(message) => message,
+        OutboundMessage::Json(message) => *message,
         OutboundMessage::Raw(_) => panic!("expected JSON message, got raw payload"),
         OutboundMessage::Pong(_) => panic!("expected JSON message, got pong"),
     }

--- a/orbitdock-server/crates/server/src/transport/websocket/transport.rs
+++ b/orbitdock-server/crates/server/src/transport/websocket/transport.rs
@@ -12,16 +12,15 @@ use crate::support::snapshot_compaction::{
 };
 
 /// Messages that can be sent through the WebSocket.
-#[allow(clippy::large_enum_variant)]
 #[derive(Debug)]
 pub(crate) enum OutboundMessage {
-    Json(ServerMessage),
+    Json(Box<ServerMessage>),
     Raw(String),
     Pong(Bytes),
 }
 
 pub(crate) async fn send_json(tx: &mpsc::Sender<OutboundMessage>, msg: ServerMessage) {
-    let _ = tx.send(OutboundMessage::Json(msg)).await;
+    let _ = tx.send(OutboundMessage::Json(Box::new(msg))).await;
 }
 
 pub(crate) async fn send_rest_only_error(
@@ -102,7 +101,7 @@ pub(crate) async fn send_snapshot_if_requested(
         send_json(
             tx,
             ServerMessage::ConversationBootstrap {
-                session: prepare_snapshot_for_transport(snapshot),
+                session: Box::new(prepare_snapshot_for_transport(snapshot)),
                 conversation: RowPageSummary {
                     rows: vec![],
                     total_row_count: 0,
@@ -144,7 +143,11 @@ pub(crate) fn spawn_broadcast_forwarder(
         loop {
             match rx.recv().await {
                 Ok(msg) => {
-                    if outbound_tx.send(OutboundMessage::Json(msg)).await.is_err() {
+                    if outbound_tx
+                        .send(OutboundMessage::Json(Box::new(msg)))
+                        .await
+                        .is_err()
+                    {
                         break;
                     }
                 }
@@ -157,11 +160,11 @@ pub(crate) fn spawn_broadcast_forwarder(
                         "Broadcast subscriber lagged, skipped {n} messages"
                     );
                     let _ = outbound_tx
-                        .send(OutboundMessage::Json(ServerMessage::Error {
+                        .send(OutboundMessage::Json(Box::new(ServerMessage::Error {
                             code: "lagged".to_string(),
                             message: format!("Subscriber lagged, skipped {n} messages"),
                             session_id: session_id.clone(),
-                        }))
+                        })))
                         .await;
                 }
                 Err(tokio::sync::broadcast::error::RecvError::Closed) => break,


### PR DESCRIPTION
## Summary

- Box oversized fields in `ServerMessage`, `PersistOp`, `OutboundMessage`, and `SessionCommand` to eliminate all `clippy::large_enum_variant` warnings
- Remove all 5 `#[allow(clippy::large_enum_variant)]` directives with zero new `#[allow(clippy::...)]` additions
- Extract `SessionConfigPersist` payload struct for `PersistOp::SetSessionConfig`

### Changes by enum

| Enum | Boxed field(s) | Size reduction |
|------|---------------|----------------|
| `ServerMessage::ConversationBootstrap` | `session: Box<SessionState>` | 2120 → ~96 bytes |
| `ServerMessage::SessionDelta` | `changes: Box<StateChanges>` | 1624 → ~32 bytes |
| `ServerMessage::ApprovalRequested` | `request: Box<ApprovalRequest>` | 736 → ~40 bytes |
| `OutboundMessage::Json` | `Box<ServerMessage>` | 2120 → ~8 bytes |
| `PersistOp::SetSessionConfig` | `Box<SessionConfigPersist>` | 315 → ~8 bytes |
| `SessionCommand::ApplyDelta` | `changes: Box<StateChanges>` | 1656 → ~16 bytes |

Closes #75

## Test plan

- [x] `make rust-ci` passes (fmt, clippy, tests)
- [x] Zero `clippy::large_enum_variant` warnings remain
- [x] No new `#[allow(clippy::...)]` directives added
- [x] Serde roundtrip tests pass (existing tests cover `ConversationBootstrap`, `SessionDelta`, `ApprovalRequested`)