### PR TITLE
🐛 Preserve conversation history when a session ends

### DIFF
--- a/OrbitDockNative/OrbitDock/Services/Server/SessionObservable.swift
+++ b/OrbitDockNative/OrbitDock/Services/Server/SessionObservable.swift
@@ -462,12 +462,9 @@ final class SessionObservable {
     slashCommands = []
     claudeSkillNames = []
     claudeToolNames = []
-    diff = nil
-    plan = nil
     currentTurnId = nil
     permissionMode = .default
     attentionReason = .none
-    clearConversation()
   }
 
   /// Drop heavy detail payloads when a session is no longer observed.


### PR DESCRIPTION
## Summary

- Removed `clearConversation()` call from `clearTransientState()` so `rowEntries` persist after a `session_ended` event
- Preserved `diff` and `plan` so review/summary context remains viewable on ended sessions
- Truly transient state (approvals, MCP, shell context, skills, slash commands) is still cleared

Fixes #69

## Test plan

- [ ] End an active session and verify the conversation transcript remains visible
- [ ] Verify diff/plan tabs still render on an ended session
- [ ] Reload/re-navigate to an ended session and confirm HTTP bootstrap still works
- [ ] Verify pending approvals and MCP state are cleared on session end