### PR TITLE
♻️ Refactor Codex connector and session constructor argument counts

### DIFF
--- a/orbitdock-server/crates/connector-codex/src/lib.rs
+++ b/orbitdock-server/crates/connector-codex/src/lib.rs
@@ -22,15 +22,13 @@ pub use codex_arg0::arg0_dispatch;
 use codex_core::{CodexThread, ThreadManager};
 use codex_protocol::openai_models::ReasoningEffort;
 use codex_protocol::protocol::{Event, EventMsg};
-use std::collections::HashMap;
 use std::path::PathBuf;
-use std::sync::atomic::AtomicU64;
 use std::sync::Arc;
 use tokio::sync::mpsc;
 use tracing::debug;
 
 pub use self::config::discover_models;
-use self::runtime::{EnvironmentTracker, ReasoningEventTracker, StreamingMessage};
+use self::runtime::EventLoopState;
 use orbitdock_connector_core::ConnectorEvent;
 
 /// Outcome of a steer_turn attempt
@@ -82,19 +80,19 @@ pub struct UpdateConfigOptions<'a> {
 
 impl CodexConnector {
     /// Translate a codex-core Event to ConnectorEvent(s)
-    #[allow(clippy::too_many_arguments)]
-    async fn translate_event(
-        event: Event,
-        output_buffers: &Arc<tokio::sync::Mutex<HashMap<String, String>>>,
-        delta_buffers: &Arc<tokio::sync::Mutex<HashMap<String, String>>>,
-        streaming_message: &Arc<tokio::sync::Mutex<Option<StreamingMessage>>>,
-        msg_counter: &AtomicU64,
-        env_tracker: &Arc<tokio::sync::Mutex<EnvironmentTracker>>,
-        reasoning_tracker: &Arc<tokio::sync::Mutex<ReasoningEventTracker>>,
-        current_model: &Arc<tokio::sync::Mutex<Option<String>>>,
-        current_reasoning_effort: &Arc<tokio::sync::Mutex<Option<ReasoningEffort>>>,
-        patch_contexts: &Arc<tokio::sync::Mutex<HashMap<String, serde_json::Value>>>,
-    ) -> Vec<ConnectorEvent> {
+    async fn translate_event(event: Event, state: &EventLoopState) -> Vec<ConnectorEvent> {
+        let EventLoopState {
+            output_buffers,
+            delta_buffers,
+            streaming_message,
+            msg_counter,
+            env_tracker,
+            reasoning_tracker,
+            current_model,
+            current_reasoning_effort,
+            patch_contexts,
+        } = state;
+
         #[allow(unreachable_patterns)]
         match event.msg {
             EventMsg::UserMessage(e) => {

--- a/orbitdock-server/crates/connector-codex/src/runtime.rs
+++ b/orbitdock-server/crates/connector-codex/src/runtime.rs
@@ -13,6 +13,19 @@ use std::sync::Arc;
 use tokio::sync::mpsc;
 use tracing::{debug, error, info};
 
+/// Groups the shared Arc<Mutex> state threaded through the event loop.
+pub(super) struct EventLoopState {
+    pub(super) output_buffers: Arc<tokio::sync::Mutex<HashMap<String, String>>>,
+    pub(super) delta_buffers: Arc<tokio::sync::Mutex<HashMap<String, String>>>,
+    pub(super) streaming_message: Arc<tokio::sync::Mutex<Option<StreamingMessage>>>,
+    pub(super) msg_counter: Arc<AtomicU64>,
+    pub(super) env_tracker: Arc<tokio::sync::Mutex<EnvironmentTracker>>,
+    pub(super) reasoning_tracker: Arc<tokio::sync::Mutex<ReasoningEventTracker>>,
+    pub(super) current_model: Arc<tokio::sync::Mutex<Option<String>>>,
+    pub(super) current_reasoning_effort: Arc<tokio::sync::Mutex<Option<ReasoningEffort>>>,
+    pub(super) patch_contexts: Arc<tokio::sync::Mutex<HashMap<String, serde_json::Value>>>,
+}
+
 /// Tracks an in-progress assistant message being streamed via deltas
 pub(super) struct StreamingMessage {
     pub(super) message_id: String,
@@ -120,49 +133,33 @@ impl CodexConnector {
         info!("Started codex thread: {:?}", thread_id);
 
         let (event_tx, event_rx) = mpsc::channel(256);
-        let output_buffers = Arc::new(tokio::sync::Mutex::new(HashMap::<String, String>::new()));
-        let delta_buffers = Arc::new(tokio::sync::Mutex::new(HashMap::<String, String>::new()));
-        let streaming_message = Arc::new(tokio::sync::Mutex::new(Option::<StreamingMessage>::None));
-        let msg_counter = Arc::new(AtomicU64::new(0));
-        let env_tracker = Arc::new(tokio::sync::Mutex::new(EnvironmentTracker {
-            cwd: None,
-            branch: None,
-            sha: None,
-        }));
-        let reasoning_tracker = Arc::new(tokio::sync::Mutex::new(ReasoningEventTracker::default()));
+
         let current_model = Arc::new(tokio::sync::Mutex::new(Option::<String>::None));
         let current_reasoning_effort =
             Arc::new(tokio::sync::Mutex::new(Option::<ReasoningEffort>::None));
-        let patch_contexts = Arc::new(tokio::sync::Mutex::new(
-            HashMap::<String, serde_json::Value>::new(),
-        ));
 
-        let tx = event_tx.clone();
+        let state = EventLoopState {
+            output_buffers: Arc::new(tokio::sync::Mutex::new(HashMap::<String, String>::new())),
+            delta_buffers: Arc::new(tokio::sync::Mutex::new(HashMap::<String, String>::new())),
+            streaming_message: Arc::new(tokio::sync::Mutex::new(Option::<StreamingMessage>::None)),
+            msg_counter: Arc::new(AtomicU64::new(0)),
+            env_tracker: Arc::new(tokio::sync::Mutex::new(EnvironmentTracker {
+                cwd: None,
+                branch: None,
+                sha: None,
+            })),
+            reasoning_tracker: Arc::new(tokio::sync::Mutex::new(ReasoningEventTracker::default())),
+            current_model: current_model.clone(),
+            current_reasoning_effort: current_reasoning_effort.clone(),
+            patch_contexts: Arc::new(tokio::sync::Mutex::new(
+                HashMap::<String, serde_json::Value>::new(),
+            )),
+        };
+
         let thread_for_loop = thread.clone();
-        let buffers = output_buffers.clone();
-        let deltas = delta_buffers.clone();
-        let streaming = streaming_message.clone();
-        let counter = msg_counter.clone();
-        let tracker = env_tracker.clone();
-        let reasoning = reasoning_tracker.clone();
-        let model = current_model.clone();
-        let effort = current_reasoning_effort.clone();
-        let patches = patch_contexts.clone();
+        let tx = event_tx.clone();
         tokio::spawn(async move {
-            Self::event_loop(
-                thread_for_loop,
-                tx,
-                buffers,
-                deltas,
-                streaming,
-                counter,
-                tracker,
-                reasoning,
-                model,
-                effort,
-                patches,
-            )
-            .await;
+            Self::event_loop(thread_for_loop, tx, state).await;
         });
 
         Ok(Self {
@@ -177,36 +174,15 @@ impl CodexConnector {
     }
 
     /// Async event loop — pulls events from CodexThread and translates them
-    #[allow(clippy::too_many_arguments)]
     async fn event_loop(
         thread: Arc<CodexThread>,
         tx: mpsc::Sender<ConnectorEvent>,
-        output_buffers: Arc<tokio::sync::Mutex<HashMap<String, String>>>,
-        delta_buffers: Arc<tokio::sync::Mutex<HashMap<String, String>>>,
-        streaming_message: Arc<tokio::sync::Mutex<Option<StreamingMessage>>>,
-        msg_counter: Arc<AtomicU64>,
-        env_tracker: Arc<tokio::sync::Mutex<EnvironmentTracker>>,
-        reasoning_tracker: Arc<tokio::sync::Mutex<ReasoningEventTracker>>,
-        current_model: Arc<tokio::sync::Mutex<Option<String>>>,
-        current_reasoning_effort: Arc<tokio::sync::Mutex<Option<ReasoningEffort>>>,
-        patch_contexts: Arc<tokio::sync::Mutex<HashMap<String, serde_json::Value>>>,
+        state: EventLoopState,
     ) {
         loop {
             match thread.next_event().await {
                 Ok(event) => {
-                    let events = Box::pin(Self::translate_event(
-                        event,
-                        &output_buffers,
-                        &delta_buffers,
-                        &streaming_message,
-                        &msg_counter,
-                        &env_tracker,
-                        &reasoning_tracker,
-                        &current_model,
-                        &current_reasoning_effort,
-                        &patch_contexts,
-                    ))
-                    .await;
+                    let events = Box::pin(Self::translate_event(event, &state)).await;
                     for event in events {
                         if tx.send(event).await.is_err() {
                             debug!("Event channel closed, stopping event loop");

--- a/orbitdock-server/crates/connector-codex/src/session.rs
+++ b/orbitdock-server/crates/connector-codex/src/session.rs
@@ -16,6 +16,18 @@ use tokio::sync::oneshot;
 
 use crate::{CodexConfigOverrides, CodexConnector, CodexControlPlane, UpdateConfigOptions};
 
+/// Groups the parameters common to all Codex session constructors.
+#[derive(Debug, Clone)]
+pub struct CodexSessionConfig<'a> {
+    pub cwd: &'a str,
+    pub model: Option<&'a str>,
+    pub approval_policy: Option<&'a str>,
+    pub sandbox_mode: Option<&'a str>,
+    pub config_overrides: CodexConfigOverrides,
+    pub control_plane: CodexControlPlane,
+    pub dynamic_tools_json: Vec<serde_json::Value>,
+}
+
 #[derive(Debug)]
 pub enum CodexExecApproval {
     Approved,
@@ -326,14 +338,17 @@ impl CodexSession {
         sandbox_mode: Option<&str>,
         config_overrides: CodexConfigOverrides,
     ) -> Result<Self, ConnectorError> {
-        Self::new_with_config_overrides_and_control_plane(
+        Self::new_with_config(
             session_id,
-            cwd,
-            model,
-            approval_policy,
-            sandbox_mode,
-            config_overrides,
-            CodexControlPlane::default(),
+            CodexSessionConfig {
+                cwd,
+                model,
+                approval_policy,
+                sandbox_mode,
+                config_overrides,
+                control_plane: CodexControlPlane::default(),
+                dynamic_tools_json: Vec::new(),
+            },
         )
         .await
     }
@@ -347,14 +362,17 @@ impl CodexSession {
         sandbox_mode: Option<&str>,
         control_plane: CodexControlPlane,
     ) -> Result<Self, ConnectorError> {
-        Self::new_with_config_overrides_and_control_plane(
+        Self::new_with_config(
             session_id,
-            cwd,
-            model,
-            approval_policy,
-            sandbox_mode,
-            CodexConfigOverrides::default(),
-            control_plane,
+            CodexSessionConfig {
+                cwd,
+                model,
+                approval_policy,
+                sandbox_mode,
+                config_overrides: CodexConfigOverrides::default(),
+                control_plane,
+                dynamic_tools_json: Vec::new(),
+            },
         )
         .await
     }
@@ -369,15 +387,17 @@ impl CodexSession {
         config_overrides: CodexConfigOverrides,
         control_plane: CodexControlPlane,
     ) -> Result<Self, ConnectorError> {
-        Self::new_with_config_overrides_control_plane_and_tools(
+        Self::new_with_config(
             session_id,
-            cwd,
-            model,
-            approval_policy,
-            sandbox_mode,
-            config_overrides,
-            control_plane,
-            Vec::new(),
+            CodexSessionConfig {
+                cwd,
+                model,
+                approval_policy,
+                sandbox_mode,
+                config_overrides,
+                control_plane,
+                dynamic_tools_json: Vec::new(),
+            },
         )
         .await
     }
@@ -395,47 +415,39 @@ impl CodexSession {
         control_plane: CodexControlPlane,
         dynamic_tools_json: Vec<serde_json::Value>,
     ) -> Result<Self, ConnectorError> {
-        Self::new_with_config_overrides_control_plane_and_tools(
+        Self::new_with_config(
             session_id,
-            cwd,
-            model,
-            approval_policy,
-            sandbox_mode,
-            CodexConfigOverrides::default(),
-            control_plane,
-            dynamic_tools_json,
+            CodexSessionConfig {
+                cwd,
+                model,
+                approval_policy,
+                sandbox_mode,
+                config_overrides: CodexConfigOverrides::default(),
+                control_plane,
+                dynamic_tools_json,
+            },
         )
         .await
     }
 
-    /// Create a new Codex session with explicit config overrides, control-plane
-    /// settings, and dynamic tools.
-    ///
-    /// Accepts `Vec<serde_json::Value>` for cross-crate flexibility — converts to
-    /// `DynamicToolSpec` internally.
-    #[allow(clippy::too_many_arguments)]
-    pub async fn new_with_config_overrides_control_plane_and_tools(
+    /// Create a new Codex session from a session config.
+    pub async fn new_with_config(
         session_id: String,
-        cwd: &str,
-        model: Option<&str>,
-        approval_policy: Option<&str>,
-        sandbox_mode: Option<&str>,
-        config_overrides: CodexConfigOverrides,
-        control_plane: CodexControlPlane,
-        dynamic_tools_json: Vec<serde_json::Value>,
+        config: CodexSessionConfig<'_>,
     ) -> Result<Self, ConnectorError> {
-        let dynamic_tools: Vec<codex_protocol::dynamic_tools::DynamicToolSpec> = dynamic_tools_json
+        let dynamic_tools: Vec<codex_protocol::dynamic_tools::DynamicToolSpec> = config
+            .dynamic_tools_json
             .into_iter()
             .filter_map(|v| serde_json::from_value(v).ok())
             .collect();
 
         let connector = CodexConnector::new_with_config_overrides_control_plane_and_tools(
-            cwd,
-            model,
-            approval_policy,
-            sandbox_mode,
-            &config_overrides,
-            control_plane,
+            config.cwd,
+            config.model,
+            config.approval_policy,
+            config.sandbox_mode,
+            &config.config_overrides,
+            config.control_plane,
             dynamic_tools,
         )
         .await?;
@@ -474,15 +486,18 @@ impl CodexSession {
         sandbox_mode: Option<&str>,
         config_overrides: CodexConfigOverrides,
     ) -> Result<Self, ConnectorError> {
-        Self::resume_with_config_overrides_and_control_plane(
+        Self::resume_with_config(
             session_id,
-            cwd,
             thread_id,
-            model,
-            approval_policy,
-            sandbox_mode,
-            config_overrides,
-            CodexControlPlane::default(),
+            CodexSessionConfig {
+                cwd,
+                model,
+                approval_policy,
+                sandbox_mode,
+                config_overrides,
+                control_plane: CodexControlPlane::default(),
+                dynamic_tools_json: Vec::new(),
+            },
         )
         .await
     }
@@ -497,39 +512,36 @@ impl CodexSession {
         sandbox_mode: Option<&str>,
         control_plane: CodexControlPlane,
     ) -> Result<Self, ConnectorError> {
-        Self::resume_with_config_overrides_and_control_plane(
+        Self::resume_with_config(
             session_id,
-            cwd,
             thread_id,
-            model,
-            approval_policy,
-            sandbox_mode,
-            CodexConfigOverrides::default(),
-            control_plane,
+            CodexSessionConfig {
+                cwd,
+                model,
+                approval_policy,
+                sandbox_mode,
+                config_overrides: CodexConfigOverrides::default(),
+                control_plane,
+                dynamic_tools_json: Vec::new(),
+            },
         )
         .await
     }
 
-    /// Resume an existing Codex session with explicit config overrides and control-plane settings.
-    #[allow(clippy::too_many_arguments)]
-    pub async fn resume_with_config_overrides_and_control_plane(
+    /// Resume an existing Codex session from a session config.
+    pub async fn resume_with_config(
         session_id: String,
-        cwd: &str,
         thread_id: &str,
-        model: Option<&str>,
-        approval_policy: Option<&str>,
-        sandbox_mode: Option<&str>,
-        config_overrides: CodexConfigOverrides,
-        control_plane: CodexControlPlane,
+        config: CodexSessionConfig<'_>,
     ) -> Result<Self, ConnectorError> {
         let connector = CodexConnector::resume_with_config_overrides_and_control_plane(
-            cwd,
+            config.cwd,
             thread_id,
-            model,
-            approval_policy,
-            sandbox_mode,
-            &config_overrides,
-            control_plane,
+            config.model,
+            config.approval_policy,
+            config.sandbox_mode,
+            &config.config_overrides,
+            config.control_plane,
         )
         .await?;
 

--- a/orbitdock-server/crates/server/src/runtime/session_activation.rs
+++ b/orbitdock-server/crates/server/src/runtime/session_activation.rs
@@ -296,55 +296,37 @@ async fn start_lazy_codex_connector(
         let effective_sandbox = effective
             .and_then(|value| value.sandbox_mode.clone())
             .or(sandbox);
-        if let Some(ref tid) = thread_id {
-            match CodexSession::resume_with_config_overrides_and_control_plane(
-                sid.clone(),
-                &project,
-                tid,
-                effective_model.as_deref(),
-                effective_approval.as_deref(),
-                effective_sandbox.as_deref(),
-                orbitdock_connector_codex::CodexConfigOverrides {
+        let build_session_config = |cp: orbitdock_connector_codex::CodexControlPlane| {
+            orbitdock_connector_codex::session::CodexSessionConfig {
+                cwd: &project,
+                model: effective_model.as_deref(),
+                approval_policy: effective_approval.as_deref(),
+                sandbox_mode: effective_sandbox.as_deref(),
+                config_overrides: orbitdock_connector_codex::CodexConfigOverrides {
                     model_provider: effective.and_then(|value| value.model_provider.clone()),
                     config_profile: effective.and_then(|value| value.config_profile.clone()),
                 },
-                control_plane.clone(),
+                control_plane: cp,
+                dynamic_tools_json: Vec::new(),
+            }
+        };
+
+        if let Some(ref tid) = thread_id {
+            match CodexSession::resume_with_config(
+                sid.clone(),
+                tid,
+                build_session_config(control_plane.clone()),
             )
             .await
             {
                 Ok(codex) => Ok(codex),
                 Err(_) => {
-                    CodexSession::new_with_config_overrides_and_control_plane(
-                        sid.clone(),
-                        &project,
-                        effective_model.as_deref(),
-                        effective_approval.as_deref(),
-                        effective_sandbox.as_deref(),
-                        orbitdock_connector_codex::CodexConfigOverrides {
-                            model_provider: effective
-                                .and_then(|value| value.model_provider.clone()),
-                            config_profile: effective
-                                .and_then(|value| value.config_profile.clone()),
-                        },
-                        control_plane,
-                    )
-                    .await
+                    CodexSession::new_with_config(sid.clone(), build_session_config(control_plane))
+                        .await
                 }
             }
         } else {
-            CodexSession::new_with_config_overrides_and_control_plane(
-                sid.clone(),
-                &project,
-                effective_model.as_deref(),
-                effective_approval.as_deref(),
-                effective_sandbox.as_deref(),
-                orbitdock_connector_codex::CodexConfigOverrides {
-                    model_provider: effective.and_then(|value| value.model_provider.clone()),
-                    config_profile: effective.and_then(|value| value.config_profile.clone()),
-                },
-                control_plane,
-            )
-            .await
+            CodexSession::new_with_config(sid.clone(), build_session_config(control_plane)).await
         }
     });
 

--- a/orbitdock-server/crates/server/src/runtime/session_direct_start.rs
+++ b/orbitdock-server/crates/server/src/runtime/session_direct_start.rs
@@ -70,24 +70,26 @@ pub(crate) async fn start_direct_codex_session(
         .collect();
 
     let mut connector_task = tokio::spawn(async move {
-        CodexSession::new_with_config_overrides_control_plane_and_tools(
+        CodexSession::new_with_config(
             task_session_id,
-            &cwd,
-            model.as_deref(),
-            approval_policy.as_deref(),
-            sandbox_mode.as_deref(),
-            CodexConfigOverrides {
-                model_provider,
-                config_profile,
+            orbitdock_connector_codex::session::CodexSessionConfig {
+                cwd: &cwd,
+                model: model.as_deref(),
+                approval_policy: approval_policy.as_deref(),
+                sandbox_mode: sandbox_mode.as_deref(),
+                config_overrides: CodexConfigOverrides {
+                    model_provider,
+                    config_profile,
+                },
+                control_plane: CodexControlPlane {
+                    collaboration_mode,
+                    multi_agent,
+                    personality,
+                    service_tier,
+                    developer_instructions,
+                },
+                dynamic_tools_json,
             },
-            CodexControlPlane {
-                collaboration_mode,
-                multi_agent,
-                personality,
-                service_tier,
-                developer_instructions,
-            },
-            dynamic_tools_json,
         )
         .await
     });

--- a/orbitdock-server/crates/server/src/runtime/session_resume.rs
+++ b/orbitdock-server/crates/server/src/runtime/session_resume.rs
@@ -337,55 +337,41 @@ async fn spawn_codex_resume(state: &Arc<SessionRegistry>, request: CodexResumeRe
             let effective_sandbox = effective
                 .and_then(|value| value.sandbox_mode.clone())
                 .or(sandbox_mode);
-            if let Some(thread_id) = codex_thread_id.as_deref() {
-                match CodexSession::resume_with_config_overrides_and_control_plane(
-                    task_session_id.clone(),
-                    &project_path,
-                    thread_id,
-                    effective_model.as_deref(),
-                    effective_approval.as_deref(),
-                    effective_sandbox.as_deref(),
-                    orbitdock_connector_codex::CodexConfigOverrides {
+            let build_session_config = |cp: orbitdock_connector_codex::CodexControlPlane| {
+                orbitdock_connector_codex::session::CodexSessionConfig {
+                    cwd: &project_path,
+                    model: effective_model.as_deref(),
+                    approval_policy: effective_approval.as_deref(),
+                    sandbox_mode: effective_sandbox.as_deref(),
+                    config_overrides: orbitdock_connector_codex::CodexConfigOverrides {
                         model_provider: effective.and_then(|value| value.model_provider.clone()),
                         config_profile: effective.and_then(|value| value.config_profile.clone()),
                     },
-                    control_plane.clone(),
+                    control_plane: cp,
+                    dynamic_tools_json: Vec::new(),
+                }
+            };
+
+            if let Some(thread_id) = codex_thread_id.as_deref() {
+                match CodexSession::resume_with_config(
+                    task_session_id.clone(),
+                    thread_id,
+                    build_session_config(control_plane.clone()),
                 )
                 .await
                 {
                     Ok(session) => Ok(session),
                     Err(_) => {
-                        CodexSession::new_with_config_overrides_and_control_plane(
+                        CodexSession::new_with_config(
                             task_session_id,
-                            &project_path,
-                            effective_model.as_deref(),
-                            effective_approval.as_deref(),
-                            effective_sandbox.as_deref(),
-                            orbitdock_connector_codex::CodexConfigOverrides {
-                                model_provider: effective
-                                    .and_then(|value| value.model_provider.clone()),
-                                config_profile: effective
-                                    .and_then(|value| value.config_profile.clone()),
-                            },
-                            control_plane,
+                            build_session_config(control_plane),
                         )
                         .await
                     }
                 }
             } else {
-                CodexSession::new_with_config_overrides_and_control_plane(
-                    task_session_id,
-                    &project_path,
-                    effective_model.as_deref(),
-                    effective_approval.as_deref(),
-                    effective_sandbox.as_deref(),
-                    orbitdock_connector_codex::CodexConfigOverrides {
-                        model_provider: effective.and_then(|value| value.model_provider.clone()),
-                        config_profile: effective.and_then(|value| value.config_profile.clone()),
-                    },
-                    control_plane,
-                )
-                .await
+                CodexSession::new_with_config(task_session_id, build_session_config(control_plane))
+                    .await
             }
         });
 


### PR DESCRIPTION
## Summary

- Introduce `EventLoopState` struct in `runtime.rs` to group the 9 `Arc<Mutex>` parameters shared by `translate_event` (10→2 params) and `event_loop` (11→3 params)
- Introduce `CodexSessionConfig` struct in `session.rs` to group the repeating session constructor parameters, adding `new_with_config` and `resume_with_config` as canonical entry points
- Update all callers in `session_activation`, `session_resume`, and `session_direct_start` to use the new config struct
- All 4 `#[allow(clippy::too_many_arguments)]` in `connector-codex` removed

## Test plan

- [x] `make rust-ci` passes (fmt, clippy, build, tests)
- [x] No remaining `allow(clippy::too_many_arguments)` in `connector-codex`

Closes #77