### PR TITLE
♻️ Scope audit: bootstrap vs incremental boundaries + params struct cleanup

### DIFF
--- a/orbitdock-server/crates/server/src/connectors/claude_hooks/handler.rs
+++ b/orbitdock-server/crates/server/src/connectors/claude_hooks/handler.rs
@@ -21,7 +21,7 @@ use orbitdock_protocol::{ClientMessage, Provider, ServerMessage, SubagentInfo, S
 use crate::domain::sessions::transition::{
     approval_preview, approval_question, approval_question_prompts, ApprovalPreviewInput,
 };
-use crate::infrastructure::persistence::PersistCommand;
+use crate::infrastructure::persistence::{ApprovalRequestedParams, PersistCommand};
 use crate::runtime::session_commands::SessionCommand;
 use crate::runtime::session_registry::{PendingClaudeSession, SessionRegistry};
 use crate::runtime::session_runtime_helpers::sync_transcript_messages;
@@ -1102,32 +1102,34 @@ pub async fn handle_hook_message(msg: ClientMessage, state: &Arc<SessionRegistry
                         );
 
                         let _ = persist_tx
-                            .send(PersistCommand::ApprovalRequested {
-                                session_id: session_id.clone(),
-                                request_id: request_id.clone(),
-                                approval_type,
-                                tool_name: Some(tool_name.clone()),
-                                tool_input: serialized_input.clone(),
-                                command: None,
-                                file_path: None,
-                                diff: None,
-                                question: question_text.clone(),
-                                question_prompts,
-                                preview,
-                                permission_reason: None,
-                                requested_permissions: None,
-                                granted_permissions: None,
-                                cwd: None,
-                                proposed_amendment: None,
-                                permission_suggestions: permission_suggestions.clone(),
-                                elicitation_mode: None,
-                                elicitation_schema: None,
-                                elicitation_url: None,
-                                elicitation_message: None,
-                                mcp_server_name: None,
-                                network_host: None,
-                                network_protocol: None,
-                            })
+                            .send(PersistCommand::ApprovalRequested(Box::new(
+                                ApprovalRequestedParams {
+                                    session_id: session_id.clone(),
+                                    request_id: request_id.clone(),
+                                    approval_type,
+                                    tool_name: Some(tool_name.clone()),
+                                    tool_input: serialized_input.clone(),
+                                    command: None,
+                                    file_path: None,
+                                    diff: None,
+                                    question: question_text.clone(),
+                                    question_prompts,
+                                    preview,
+                                    permission_reason: None,
+                                    requested_permissions: None,
+                                    granted_permissions: None,
+                                    cwd: None,
+                                    proposed_amendment: None,
+                                    permission_suggestions: permission_suggestions.clone(),
+                                    elicitation_mode: None,
+                                    elicitation_schema: None,
+                                    elicitation_url: None,
+                                    elicitation_message: None,
+                                    mcp_server_name: None,
+                                    network_host: None,
+                                    network_protocol: None,
+                                },
+                            )))
                             .await;
 
                         if let Some(plan_text) = plan_text {

--- a/orbitdock-server/crates/server/src/domain/sessions/transition.rs
+++ b/orbitdock-server/crates/server/src/domain/sessions/transition.rs
@@ -3,7 +3,7 @@
 
 pub use orbitdock_connector_core::transition::*;
 
-use crate::infrastructure::persistence::PersistCommand;
+use crate::infrastructure::persistence::{ApprovalRequestedParams, PersistCommand};
 
 /// Convert a transition PersistOp into the server's PersistCommand.
 pub fn persist_op_to_command(op: PersistOp) -> PersistCommand {
@@ -103,7 +103,7 @@ pub fn persist_op_to_command(op: PersistOp) -> PersistCommand {
             mcp_server_name,
             network_host,
             network_protocol,
-        } => PersistCommand::ApprovalRequested {
+        } => PersistCommand::ApprovalRequested(Box::new(ApprovalRequestedParams {
             session_id,
             request_id,
             approval_type,
@@ -128,7 +128,7 @@ pub fn persist_op_to_command(op: PersistOp) -> PersistCommand {
             mcp_server_name,
             network_host,
             network_protocol,
-        },
+        })),
         PersistOp::EnvironmentUpdate {
             session_id,
             cwd,

--- a/orbitdock-server/crates/server/src/infrastructure/persistence/approvals.rs
+++ b/orbitdock-server/crates/server/src/infrastructure/persistence/approvals.rs
@@ -1,37 +1,11 @@
+use super::commands::ApprovalRequestedParams;
 use super::*;
-
-pub(super) struct ApprovalRequestedRecord {
-    pub session_id: String,
-    pub request_id: String,
-    pub approval_type: ApprovalType,
-    pub tool_name: Option<String>,
-    pub tool_input: Option<String>,
-    pub command: Option<String>,
-    pub file_path: Option<String>,
-    pub diff: Option<String>,
-    pub question: Option<String>,
-    pub question_prompts: Vec<ApprovalQuestionPrompt>,
-    pub preview: Option<ApprovalPreview>,
-    pub permission_reason: Option<String>,
-    pub requested_permissions: Option<Value>,
-    pub granted_permissions: Option<Value>,
-    pub cwd: Option<String>,
-    pub proposed_amendment: Option<Vec<String>>,
-    pub permission_suggestions: Option<Value>,
-    pub elicitation_mode: Option<String>,
-    pub elicitation_schema: Option<Value>,
-    pub elicitation_url: Option<String>,
-    pub elicitation_message: Option<String>,
-    pub mcp_server_name: Option<String>,
-    pub network_host: Option<String>,
-    pub network_protocol: Option<String>,
-}
 
 pub(super) fn persist_approval_requested(
     conn: &Connection,
-    record: ApprovalRequestedRecord,
+    record: ApprovalRequestedParams,
 ) -> Result<(), rusqlite::Error> {
-    let ApprovalRequestedRecord {
+    let ApprovalRequestedParams {
         session_id,
         request_id,
         approval_type,

--- a/orbitdock-server/crates/server/src/infrastructure/persistence/commands.rs
+++ b/orbitdock-server/crates/server/src/infrastructure/persistence/commands.rs
@@ -11,31 +11,7 @@ use orbitdock_protocol::{
 #[derive(Debug)]
 pub enum PersistCommand {
     /// Create a new session
-    SessionCreate {
-        id: String,
-        provider: Provider,
-        project_path: String,
-        project_name: Option<String>,
-        branch: Option<String>,
-        model: Option<String>,
-        approval_policy: Option<String>,
-        sandbox_mode: Option<String>,
-        permission_mode: Option<String>,
-        collaboration_mode: Option<String>,
-        multi_agent: Option<bool>,
-        personality: Option<String>,
-        service_tier: Option<String>,
-        developer_instructions: Option<String>,
-        codex_config_mode: Option<CodexConfigMode>,
-        codex_config_profile: Option<String>,
-        codex_model_provider: Option<String>,
-        codex_config_source: Option<CodexConfigSource>,
-        codex_config_overrides_json: Option<String>,
-        forked_from_session_id: Option<String>,
-        mission_id: Option<String>,
-        issue_identifier: Option<String>,
-        allow_bypass_permissions: bool,
-    },
+    SessionCreate(Box<SessionCreateParams>),
 
     /// Update session status/work_status
     SessionUpdate {
@@ -299,32 +275,7 @@ pub enum PersistCommand {
     DeleteRolloutCheckpoint { path: String },
 
     /// Persist an approval request event
-    ApprovalRequested {
-        session_id: String,
-        request_id: String,
-        approval_type: ApprovalType,
-        tool_name: Option<String>,
-        tool_input: Option<String>,
-        command: Option<String>,
-        file_path: Option<String>,
-        diff: Option<String>,
-        question: Option<String>,
-        question_prompts: Vec<ApprovalQuestionPrompt>,
-        preview: Option<ApprovalPreview>,
-        permission_reason: Option<String>,
-        requested_permissions: Option<Value>,
-        granted_permissions: Option<Value>,
-        cwd: Option<String>,
-        proposed_amendment: Option<Vec<String>>,
-        permission_suggestions: Option<Value>,
-        elicitation_mode: Option<String>,
-        elicitation_schema: Option<Value>,
-        elicitation_url: Option<String>,
-        elicitation_message: Option<String>,
-        mcp_server_name: Option<String>,
-        network_host: Option<String>,
-        network_protocol: Option<String>,
-    },
+    ApprovalRequested(Box<ApprovalRequestedParams>),
 
     /// Persist the user decision for an approval request
     ApprovalDecision {
@@ -462,4 +413,61 @@ impl PersistCommand {
             }
         )
     }
+}
+
+/// Payload for `PersistCommand::SessionCreate`, boxed to keep the enum small.
+#[derive(Debug)]
+pub struct SessionCreateParams {
+    pub id: String,
+    pub provider: Provider,
+    pub project_path: String,
+    pub project_name: Option<String>,
+    pub branch: Option<String>,
+    pub model: Option<String>,
+    pub approval_policy: Option<String>,
+    pub sandbox_mode: Option<String>,
+    pub permission_mode: Option<String>,
+    pub collaboration_mode: Option<String>,
+    pub multi_agent: Option<bool>,
+    pub personality: Option<String>,
+    pub service_tier: Option<String>,
+    pub developer_instructions: Option<String>,
+    pub codex_config_mode: Option<CodexConfigMode>,
+    pub codex_config_profile: Option<String>,
+    pub codex_model_provider: Option<String>,
+    pub codex_config_source: Option<CodexConfigSource>,
+    pub codex_config_overrides_json: Option<String>,
+    pub forked_from_session_id: Option<String>,
+    pub mission_id: Option<String>,
+    pub issue_identifier: Option<String>,
+    pub allow_bypass_permissions: bool,
+}
+
+/// Payload for `PersistCommand::ApprovalRequested`, boxed to keep the enum small.
+#[derive(Debug)]
+pub struct ApprovalRequestedParams {
+    pub session_id: String,
+    pub request_id: String,
+    pub approval_type: ApprovalType,
+    pub tool_name: Option<String>,
+    pub tool_input: Option<String>,
+    pub command: Option<String>,
+    pub file_path: Option<String>,
+    pub diff: Option<String>,
+    pub question: Option<String>,
+    pub question_prompts: Vec<ApprovalQuestionPrompt>,
+    pub preview: Option<ApprovalPreview>,
+    pub permission_reason: Option<String>,
+    pub requested_permissions: Option<Value>,
+    pub granted_permissions: Option<Value>,
+    pub cwd: Option<String>,
+    pub proposed_amendment: Option<Vec<String>>,
+    pub permission_suggestions: Option<Value>,
+    pub elicitation_mode: Option<String>,
+    pub elicitation_schema: Option<Value>,
+    pub elicitation_url: Option<String>,
+    pub elicitation_message: Option<String>,
+    pub mcp_server_name: Option<String>,
+    pub network_host: Option<String>,
+    pub network_protocol: Option<String>,
 }

--- a/orbitdock-server/crates/server/src/infrastructure/persistence/mod.rs
+++ b/orbitdock-server/crates/server/src/infrastructure/persistence/mod.rs
@@ -33,7 +33,7 @@ use orbitdock_protocol::{
 };
 
 pub(crate) use approvals::{delete_approval, list_approvals};
-pub(crate) use commands::PersistCommand;
+pub(crate) use commands::{ApprovalRequestedParams, PersistCommand, SessionCreateParams};
 pub(crate) use config::load_config_value;
 pub(crate) use messages::{
     load_message_page_for_session, load_messages_for_session, load_row_by_id_async,
@@ -190,31 +190,32 @@ pub(super) fn execute_command(
     cmd: PersistCommand,
 ) -> Result<(), rusqlite::Error> {
     match cmd {
-        PersistCommand::SessionCreate {
-            id,
-            provider,
-            project_path,
-            project_name,
-            branch,
-            model,
-            approval_policy,
-            sandbox_mode,
-            permission_mode,
-            collaboration_mode,
-            multi_agent,
-            personality,
-            service_tier,
-            developer_instructions,
-            codex_config_mode,
-            codex_config_profile,
-            codex_model_provider,
-            codex_config_source,
-            codex_config_overrides_json,
-            forked_from_session_id,
-            mission_id,
-            issue_identifier,
-            allow_bypass_permissions,
-        } => {
+        PersistCommand::SessionCreate(params) => {
+            let SessionCreateParams {
+                id,
+                provider,
+                project_path,
+                project_name,
+                branch,
+                model,
+                approval_policy,
+                sandbox_mode,
+                permission_mode,
+                collaboration_mode,
+                multi_agent,
+                personality,
+                service_tier,
+                developer_instructions,
+                codex_config_mode,
+                codex_config_profile,
+                codex_model_provider,
+                codex_config_source,
+                codex_config_overrides_json,
+                forked_from_session_id,
+                mission_id,
+                issue_identifier,
+                allow_bypass_permissions,
+            } = *params;
             let provider_str = match provider {
                 Provider::Claude => "claude",
                 Provider::Codex => "codex",
@@ -1390,60 +1391,9 @@ pub(super) fn execute_command(
             )?;
         }
 
-        PersistCommand::ApprovalRequested {
-            session_id,
-            request_id,
-            approval_type,
-            tool_name,
-            tool_input,
-            command,
-            file_path,
-            diff,
-            question,
-            question_prompts,
-            preview,
-            permission_reason,
-            requested_permissions,
-            granted_permissions,
-            cwd,
-            proposed_amendment,
-            permission_suggestions,
-            elicitation_mode,
-            elicitation_schema,
-            elicitation_url,
-            elicitation_message,
-            mcp_server_name,
-            network_host,
-            network_protocol,
-        } => approvals::persist_approval_requested(
-            conn,
-            approvals::ApprovalRequestedRecord {
-                session_id,
-                request_id,
-                approval_type,
-                tool_name,
-                tool_input,
-                command,
-                file_path,
-                diff,
-                question,
-                question_prompts,
-                preview,
-                permission_reason,
-                requested_permissions,
-                granted_permissions,
-                cwd,
-                proposed_amendment,
-                permission_suggestions,
-                elicitation_mode,
-                elicitation_schema,
-                elicitation_url,
-                elicitation_message,
-                mcp_server_name,
-                network_host,
-                network_protocol,
-            },
-        )?,
+        PersistCommand::ApprovalRequested(params) => {
+            approvals::persist_approval_requested(conn, *params)?
+        }
 
         PersistCommand::ApprovalDecision {
             session_id,

--- a/orbitdock-server/crates/server/src/runtime/session_creation.rs
+++ b/orbitdock-server/crates/server/src/runtime/session_creation.rs
@@ -8,7 +8,7 @@ use orbitdock_protocol::{
 };
 
 use crate::domain::sessions::session::{SessionConfigPatch, SessionHandle};
-use crate::infrastructure::persistence::PersistCommand;
+use crate::infrastructure::persistence::{PersistCommand, SessionCreateParams};
 use crate::runtime::session_direct_start::{
     start_direct_claude_session, start_direct_codex_session, StartDirectCodexRequest,
 };
@@ -193,31 +193,33 @@ async fn persist_direct_session_create(
         codex_config_overrides_json,
     } = request;
     let _ = persist_tx
-        .send(PersistCommand::SessionCreate {
-            id: id.clone(),
-            provider,
-            project_path,
-            project_name,
-            branch,
-            model,
-            approval_policy,
-            sandbox_mode,
-            permission_mode,
-            collaboration_mode,
-            multi_agent,
-            personality,
-            service_tier,
-            developer_instructions,
-            codex_config_mode,
-            codex_config_profile,
-            codex_model_provider,
-            codex_config_source,
-            codex_config_overrides_json,
-            forked_from_session_id: None,
-            mission_id,
-            issue_identifier,
-            allow_bypass_permissions,
-        })
+        .send(PersistCommand::SessionCreate(Box::new(
+            SessionCreateParams {
+                id: id.clone(),
+                provider,
+                project_path,
+                project_name,
+                branch,
+                model,
+                approval_policy,
+                sandbox_mode,
+                permission_mode,
+                collaboration_mode,
+                multi_agent,
+                personality,
+                service_tier,
+                developer_instructions,
+                codex_config_mode,
+                codex_config_profile,
+                codex_model_provider,
+                codex_config_source,
+                codex_config_overrides_json,
+                forked_from_session_id: None,
+                mission_id,
+                issue_identifier,
+                allow_bypass_permissions,
+            },
+        )))
         .await;
 
     if let Some(effort_name) = effort {

--- a/orbitdock-server/crates/server/src/runtime/session_fork_runtime.rs
+++ b/orbitdock-server/crates/server/src/runtime/session_fork_runtime.rs
@@ -11,7 +11,9 @@ use orbitdock_protocol::{
 use crate::connectors::claude_session::{ClaudeSession, ClaudeSessionConfig};
 use crate::connectors::codex_session::CodexSession;
 use crate::domain::sessions::session::{SessionConfigPatch, SessionHandle};
-use crate::infrastructure::persistence::{load_messages_from_transcript_path, PersistCommand};
+use crate::infrastructure::persistence::{
+    load_messages_from_transcript_path, PersistCommand, SessionCreateParams,
+};
 use crate::runtime::session_fork_policy::{
     remap_rows_for_fork, select_fork_rows, truncate_rows_before_nth_user_row,
 };
@@ -84,31 +86,33 @@ pub(crate) async fn start_claude_fork_session(
     let persist_tx = state.persist().clone();
 
     let _ = persist_tx
-        .send(PersistCommand::SessionCreate {
-            id: new_session_id.clone(),
-            provider: Provider::Claude,
-            project_path: effective_cwd.to_string(),
-            project_name,
-            branch: fork_branch,
-            model: effective_model.map(ToOwned::to_owned),
-            approval_policy: None,
-            sandbox_mode: None,
-            permission_mode: permission_mode.map(ToOwned::to_owned),
-            collaboration_mode: None,
-            multi_agent: None,
-            personality: None,
-            service_tier: None,
-            developer_instructions: None,
-            codex_config_mode: None,
-            codex_config_profile: None,
-            codex_model_provider: None,
-            codex_config_source: None,
-            codex_config_overrides_json: None,
-            forked_from_session_id: Some(source_session_id.to_string()),
-            mission_id: None,
-            issue_identifier: None,
-            allow_bypass_permissions: false,
-        })
+        .send(PersistCommand::SessionCreate(Box::new(
+            SessionCreateParams {
+                id: new_session_id.clone(),
+                provider: Provider::Claude,
+                project_path: effective_cwd.to_string(),
+                project_name,
+                branch: fork_branch,
+                model: effective_model.map(ToOwned::to_owned),
+                approval_policy: None,
+                sandbox_mode: None,
+                permission_mode: permission_mode.map(ToOwned::to_owned),
+                collaboration_mode: None,
+                multi_agent: None,
+                personality: None,
+                service_tier: None,
+                developer_instructions: None,
+                codex_config_mode: None,
+                codex_config_profile: None,
+                codex_model_provider: None,
+                codex_config_source: None,
+                codex_config_overrides_json: None,
+                forked_from_session_id: Some(source_session_id.to_string()),
+                mission_id: None,
+                issue_identifier: None,
+                allow_bypass_permissions: false,
+            },
+        )))
         .await;
 
     handle.set_list_tx(state.list_tx());
@@ -187,31 +191,33 @@ pub(crate) async fn finalize_codex_fork_session(
     let persist_tx = state.persist().clone();
 
     let _ = persist_tx
-        .send(PersistCommand::SessionCreate {
-            id: new_session_id.clone(),
-            provider: Provider::Codex,
-            project_path: effective_cwd.to_string(),
-            project_name,
-            branch: fork_branch,
-            model: effective_model.map(ToOwned::to_owned),
-            approval_policy: effective_approval_policy.map(ToOwned::to_owned),
-            sandbox_mode: effective_sandbox_mode.map(ToOwned::to_owned),
-            permission_mode: None,
-            collaboration_mode: None,
-            multi_agent: None,
-            personality: None,
-            service_tier: None,
-            developer_instructions: None,
-            codex_config_mode: None,
-            codex_config_profile: None,
-            codex_model_provider: None,
-            codex_config_source: None,
-            codex_config_overrides_json: None,
-            forked_from_session_id: Some(source_session_id.to_string()),
-            mission_id: None,
-            issue_identifier: None,
-            allow_bypass_permissions: false,
-        })
+        .send(PersistCommand::SessionCreate(Box::new(
+            SessionCreateParams {
+                id: new_session_id.clone(),
+                provider: Provider::Codex,
+                project_path: effective_cwd.to_string(),
+                project_name,
+                branch: fork_branch,
+                model: effective_model.map(ToOwned::to_owned),
+                approval_policy: effective_approval_policy.map(ToOwned::to_owned),
+                sandbox_mode: effective_sandbox_mode.map(ToOwned::to_owned),
+                permission_mode: None,
+                collaboration_mode: None,
+                multi_agent: None,
+                personality: None,
+                service_tier: None,
+                developer_instructions: None,
+                codex_config_mode: None,
+                codex_config_profile: None,
+                codex_model_provider: None,
+                codex_config_source: None,
+                codex_config_overrides_json: None,
+                forked_from_session_id: Some(source_session_id.to_string()),
+                mission_id: None,
+                issue_identifier: None,
+                allow_bypass_permissions: false,
+            },
+        )))
         .await;
 
     for entry in forked_rows {

--- a/orbitdock-server/crates/server/src/transport/http/review_comments.rs
+++ b/orbitdock-server/crates/server/src/transport/http/review_comments.rs
@@ -323,7 +323,9 @@ mod tests {
     use orbitdock_protocol::{Provider, ReviewCommentStatus, ReviewCommentTag};
 
     use crate::domain::sessions::session::SessionHandle;
-    use crate::infrastructure::persistence::{flush_batch_for_test, PersistCommand};
+    use crate::infrastructure::persistence::{
+        flush_batch_for_test, PersistCommand, SessionCreateParams,
+    };
     use crate::transport::http::test_support::{
         flush_next_persist_command, new_persist_test_state,
     };
@@ -354,31 +356,33 @@ mod tests {
         ));
         flush_batch_for_test(
             &db_path,
-            vec![PersistCommand::SessionCreate {
-                id: session_id.clone(),
-                provider: Provider::Codex,
-                project_path: "/tmp/orbitdock-review-contract".to_string(),
-                project_name: Some("orbitdock-review-contract".to_string()),
-                branch: Some("main".to_string()),
-                model: Some("gpt-5".to_string()),
-                approval_policy: None,
-                sandbox_mode: None,
-                permission_mode: None,
-                collaboration_mode: None,
-                multi_agent: None,
-                personality: None,
-                service_tier: None,
-                developer_instructions: None,
-                codex_config_mode: None,
-                codex_config_profile: None,
-                codex_model_provider: None,
-                codex_config_source: None,
-                codex_config_overrides_json: None,
-                forked_from_session_id: None,
-                mission_id: None,
-                issue_identifier: None,
-                allow_bypass_permissions: false,
-            }],
+            vec![PersistCommand::SessionCreate(Box::new(
+                SessionCreateParams {
+                    id: session_id.clone(),
+                    provider: Provider::Codex,
+                    project_path: "/tmp/orbitdock-review-contract".to_string(),
+                    project_name: Some("orbitdock-review-contract".to_string()),
+                    branch: Some("main".to_string()),
+                    model: Some("gpt-5".to_string()),
+                    approval_policy: None,
+                    sandbox_mode: None,
+                    permission_mode: None,
+                    collaboration_mode: None,
+                    multi_agent: None,
+                    personality: None,
+                    service_tier: None,
+                    developer_instructions: None,
+                    codex_config_mode: None,
+                    codex_config_profile: None,
+                    codex_model_provider: None,
+                    codex_config_source: None,
+                    codex_config_overrides_json: None,
+                    forked_from_session_id: None,
+                    mission_id: None,
+                    issue_identifier: None,
+                    allow_bypass_permissions: false,
+                },
+            ))],
         )
         .expect("persist session row for review comment contract test");
 


### PR DESCRIPTION
## Summary

Investigation and bounded cleanup for #86 — auditing whether bootstrap/snapshot payloads should be split from incremental protocol and actor messages.

### Investigation findings

Audited all three core enums (`ServerMessage` ~45 variants, `SessionCommand` ~35 variants, `PersistCommand` ~40 variants) and traced the bootstrap vs incremental data flow.

**The boundaries are already well-shaped:**

- **Bootstrap path**: REST `GET /sessions/:id/bootstrap` OR WS `ConversationBootstrap` message (full `SessionState` + `RowPageSummary`)
- **Incremental path**: WS subscription with `since_revision` → `SubscribeResult::Replay` events or individual `SessionDelta`/`ConversationRowsChanged` messages
- **Actor boundary**: `SubscribeResult::Snapshot` vs `SubscribeResult::Replay` IS the bootstrap/incremental decision point
- **Ring buffer**: Last 1000 events retained for replay; gap > 1 revision forces snapshot fallback

Splitting the Rust enums would add wrapper types at the transport layer (all messages share the same WS connection, all commands target the same actor mailbox, all writes flow to the same persistence writer) — net complexity increase for no design clarity.

### Cleanup implemented

Extracted params structs for the two largest `PersistCommand` inline variants, following the pattern established by `SessionConfigPersist`:

- `SessionCreate` (23 inline fields) → `Box<SessionCreateParams>`
- `ApprovalRequested` (27 inline fields) → `Box<ApprovalRequestedParams>`

`ApprovalRequested` had its fields duplicated **four times**: the enum variant, `ApprovalRequestedRecord` in `approvals.rs`, the `PersistOp` conversion, and the claude handler construction. The new `ApprovalRequestedParams` replaces the redundant record struct.

### Not doing

- Splitting `ServerMessage` into separate enums (wrapper needed at WS transport, net complexity increase)
- Splitting `SessionCommand` (multi-channel `select!` complexity)
- Splitting `PersistCommand` into separate layers (single writer channel)
- Extracting params for medium-sized variants (`ClaudeSessionUpsert` 16 fields, `ClaudeSessionUpdate` 13 fields) — borderline, can be follow-up if needed

No follow-up issues needed.

Closes #86