### PR TITLE
⏮️ Fix conversation rollback/restore controls for both providers

### DIFF
--- a/OrbitDockNative/OrbitDock/Services/Server/SessionObservable.swift
+++ b/OrbitDockNative/OrbitDock/Services/Server/SessionObservable.swift
@@ -81,6 +81,8 @@ final class SessionObservable {
 
   // Operation flags
   var undoInProgress: Bool = false
+  var compactInProgress: Bool = false
+  var rollbackInProgress: Bool = false
   var forkInProgress: Bool = false
   var forkedFrom: String?
 
@@ -451,6 +453,8 @@ final class SessionObservable {
     pendingPermissionDetail = nil
     pendingQuestion = nil
     undoInProgress = false
+    compactInProgress = false
+    rollbackInProgress = false
     forkInProgress = false
     pendingShellContext = []
     mcpTools = [:]

--- a/OrbitDockNative/OrbitDock/Services/Server/SessionStore+Commands.swift
+++ b/OrbitDockNative/OrbitDock/Services/Server/SessionStore+Commands.swift
@@ -250,7 +250,13 @@ extension SessionStore {
   }
 
   func compactContext(_ sessionId: String) async throws {
-    try await clients.conversation.compactContext(sessionId)
+    session(sessionId).compactInProgress = true
+    do {
+      try await clients.conversation.compactContext(sessionId)
+    } catch {
+      session(sessionId).compactInProgress = false
+      throw error
+    }
   }
 
   func undoLastTurn(_ sessionId: String) async throws {
@@ -264,7 +270,13 @@ extension SessionStore {
   }
 
   func rollbackTurns(_ sessionId: String, numTurns: UInt32) async throws {
-    try await clients.conversation.rollbackTurns(sessionId, numTurns: numTurns)
+    session(sessionId).rollbackInProgress = true
+    do {
+      try await clients.conversation.rollbackTurns(sessionId, numTurns: numTurns)
+    } catch {
+      session(sessionId).rollbackInProgress = false
+      throw error
+    }
   }
 
   func rewindFiles(_ sessionId: String, userMessageId: String) async throws {

--- a/OrbitDockNative/OrbitDock/Services/Server/SessionStore+Events.swift
+++ b/OrbitDockNative/OrbitDock/Services/Server/SessionStore+Events.swift
@@ -79,8 +79,10 @@ extension SessionStore {
         obs.slashCommands = Set(slashCommands)
         obs.claudeSkillNames = skills
         obs.claudeToolNames = tools
-      case .contextCompacted:
-        break
+      case let .contextCompacted(sessionId):
+        let obs = session(sessionId)
+        obs.compactInProgress = false
+        Task { await self.hydrateSessionFromHTTPBootstrap(sessionId: sessionId) }
       case let .undoStarted(sessionId, message):
         let obs = session(sessionId)
         obs.undoInProgress = true
@@ -94,6 +96,7 @@ extension SessionStore {
           Task { await self.hydrateSessionFromHTTPBootstrap(sessionId: sessionId) }
         }
       case let .threadRolledBack(sessionId, _):
+        session(sessionId).rollbackInProgress = false
         Task { await self.hydrateSessionFromHTTPBootstrap(sessionId: sessionId) }
       case let .sessionForked(sourceSessionId, newSessionId, _):
         let obs = session(sourceSessionId)

--- a/OrbitDockNative/OrbitDock/Views/Sessions/Composer/DirectSessionComposerViewModel.swift
+++ b/OrbitDockNative/OrbitDock/Views/Sessions/Composer/DirectSessionComposerViewModel.swift
@@ -281,6 +281,10 @@ final class DirectSessionComposerViewModel {
     try await currentSessionStore.compactContext(resolvedSessionId)
   }
 
+  func rollbackTurns(numTurns: UInt32) async throws {
+    try await currentSessionStore.rollbackTurns(resolvedSessionId, numTurns: numTurns)
+  }
+
   func resumeSession() async throws {
     try await currentSessionStore.resumeSession(resolvedSessionId)
   }
@@ -345,6 +349,14 @@ final class DirectSessionComposerViewModel {
 
   var undoInProgress: Bool {
     sessionState.undoInProgress
+  }
+
+  var compactInProgress: Bool {
+    sessionState.compactInProgress
+  }
+
+  var rollbackInProgress: Bool {
+    sessionState.rollbackInProgress
   }
 
   func consumeShellContext() -> String? {
@@ -422,7 +434,10 @@ final class DirectSessionComposerViewModel {
       forkInProgress: session.forkInProgress,
       lastFilesPersistedAt: session.lastFilesPersistedAt,
       lastActivityAt: session.lastActivityAt,
-      undoInProgress: session.undoInProgress
+      undoInProgress: session.undoInProgress,
+      compactInProgress: session.compactInProgress,
+      rollbackInProgress: session.rollbackInProgress,
+      turnCount: session.turnCount
     )
   }
 }
@@ -479,6 +494,9 @@ struct DirectSessionComposerSessionState {
   let lastFilesPersistedAt: Date?
   let lastActivityAt: Date?
   let undoInProgress: Bool
+  let compactInProgress: Bool
+  let rollbackInProgress: Bool
+  let turnCount: UInt64
 
   var hasClaudeSkills: Bool {
     !claudeSkillNames.isEmpty
@@ -588,6 +606,9 @@ struct DirectSessionComposerSessionState {
     forkInProgress: false,
     lastFilesPersistedAt: nil,
     lastActivityAt: nil,
-    undoInProgress: false
+    undoInProgress: false,
+    compactInProgress: false,
+    rollbackInProgress: false,
+    turnCount: 0
   )
 }

--- a/OrbitDockNative/OrbitDock/Views/Sessions/Composer/DirectSessionComposerWorkflowMenus.swift
+++ b/OrbitDockNative/OrbitDock/Views/Sessions/Composer/DirectSessionComposerWorkflowMenus.swift
@@ -65,12 +65,31 @@ extension DirectSessionComposer {
     }
     .disabled(!canContinueInNewSession)
 
+    if obs.isDirect, obs.turnCount > 0 {
+      Menu {
+        ForEach(1...min(Int(obs.turnCount), 5), id: \.self) { n in
+          Button {
+            Task { try? await viewModel.rollbackTurns(numTurns: UInt32(n)) }
+          } label: {
+            Label(n == 1 ? "1 turn" : "\(n) turns", systemImage: "arrow.uturn.backward.square")
+          }
+        }
+      } label: {
+        Label("Rollback Turns", systemImage: "arrow.uturn.backward.square")
+      }
+      .disabled(viewModel.rollbackInProgress || obs.workStatus == .working)
+    }
+
     if obs.hasTokenUsage {
       Button {
         Task { try? await viewModel.compactContext() }
       } label: {
-        Label("Compact Context", systemImage: "arrow.triangle.2.circlepath")
+        Label(
+          viewModel.compactInProgress ? "Compacting…" : "Compact Context",
+          systemImage: "arrow.triangle.2.circlepath"
+        )
       }
+      .disabled(viewModel.compactInProgress)
     }
 
     if hasMcpData {

--- a/orbitdock-server/crates/server/src/connectors/claude_session.rs
+++ b/orbitdock-server/crates/server/src/connectors/claude_session.rs
@@ -266,6 +266,32 @@ pub fn start_event_loop(
                                 }
                             }
                         }
+                        ClaudeAction::Undo => {
+                            dispatch_connector_event(
+                                &session_id,
+                                ConnectorEvent::UndoStarted { message: Some("Undoing last turn...".to_string()) },
+                                &mut session_handle,
+                                &persist,
+                            ).await;
+                            match session.connector.send_message("/undo", None, None, &[]).await {
+                                Ok(()) => {
+                                    dispatch_connector_event(
+                                        &session_id,
+                                        ConnectorEvent::UndoCompleted { success: true, message: None },
+                                        &mut session_handle,
+                                        &persist,
+                                    ).await;
+                                }
+                                Err(e) => {
+                                    dispatch_connector_event(
+                                        &session_id,
+                                        ConnectorEvent::UndoCompleted { success: false, message: Some(format!("Undo failed: {e}")) },
+                                        &mut session_handle,
+                                        &persist,
+                                    ).await;
+                                }
+                            }
+                        }
                         _ => {
                             if let Err(e) = ClaudeSession::handle_action(&session.connector, action).await {
                                 error!(


### PR DESCRIPTION
## Summary

Fixes #104 — conversation control operations (undo, compact, rollback) were inconsistently implemented across Codex and Claude providers.

- **Claude undo event feedback**: `ClaudeAction::Undo` now emits `UndoStarted`/`UndoCompleted` events in the event loop (same pattern as `RewindFiles`), so the client's `undoInProgress` flag properly cycles and `hydrateSessionFromHTTPBootstrap` fires for Claude sessions
- **Compact event handler**: The `contextCompacted` client handler was a no-op `break` — now clears `compactInProgress` and hydrates the session. Added `compactInProgress` optimistic flag with error rollback. Note: Claude's CLI already emits `compact_boundary` → `ContextCompacted`, so no server-side changes were needed for compact
- **Rollback turns UI**: Added a "Rollback Turns" submenu (1–5 turns) to the turn actions menu, gated on `obs.isDirect && obs.turnCount > 0`. Added `rollbackInProgress` flag with event-driven reset on `threadRolledBack`
- **Compact button disabled state**: "Compact Context" button now shows "Compacting…" and disables while in progress

## Files changed

### Server (Rust)
- `claude_session.rs` — Move `ClaudeAction::Undo` out of catch-all, emit synthetic `UndoStarted`/`UndoCompleted` events

### Client (Swift)
- `SessionObservable.swift` — Add `compactInProgress`, `rollbackInProgress` flags; clear in `clearTransientState()`
- `SessionStore+Events.swift` — Handle `contextCompacted` with hydration; clear `rollbackInProgress` on `threadRolledBack`
- `SessionStore+Commands.swift` — Optimistic `compactInProgress`/`rollbackInProgress` with error rollback
- `DirectSessionComposerViewModel.swift` — Add `rollbackTurns(numTurns:)` proxy; thread new flags + `turnCount` through state struct
- `DirectSessionComposerWorkflowMenus.swift` — Rollback submenu + compact disable state

## Test plan

- [x] `make rust-ci` passes
- [x] `make build` succeeds (macOS)
- [x] `make test-unit` passes
- [ ] Manual: Codex undo triggers, button disables, conversation hydrates
- [ ] Manual: Codex compact triggers, button disables, conversation hydrates
- [ ] Manual: Codex rollback triggers from UI, conversation hydrates
- [ ] Manual: Claude undo triggers, `undoInProgress` properly cycles, conversation hydrates
- [ ] Manual: Claude compact triggers, `compactInProgress` properly cycles, conversation hydrates
- [ ] Manual: Claude rollback (via RewindFiles conversion) works from UI