### PR TITLE
✍️ Use Apple Foundation Models for local conversation naming

### DIFF
--- a/OrbitDockNative/OrbitDock/Services/LocalConversationNamingService.swift
+++ b/OrbitDockNative/OrbitDock/Services/LocalConversationNamingService.swift
@@ -1,0 +1,76 @@
+//
+//  LocalConversationNamingService.swift
+//  OrbitDock
+//
+//  On-device conversation naming via Apple Foundation Models.
+//  Generates concise session titles without requiring an OpenAI API key.
+//
+
+import Foundation
+#if canImport(FoundationModels)
+  import FoundationModels
+#endif
+
+nonisolated enum LocalNamingAvailability: Equatable, Sendable {
+  case available
+  case unavailable
+}
+
+nonisolated enum LocalNamingAvailabilityResolver {
+  static var current: LocalNamingAvailability {
+    #if canImport(FoundationModels)
+      if #available(macOS 26.0, iOS 26.0, *) {
+        return SystemLanguageModel.default.availability == .available ? .available : .unavailable
+      }
+    #endif
+    return .unavailable
+  }
+}
+
+#if canImport(FoundationModels)
+  @available(macOS 26.0, iOS 26.0, *)
+  @Generable(description: "A concise conversation title")
+  struct GeneratedSessionTitle {
+    @Guide(description: "A concise 3-7 word title for this coding session. Title case. No quotes. No trailing punctuation.")
+    var name: String
+  }
+
+  @available(macOS 26.0, iOS 26.0, *)
+  enum LocalConversationNamingService {
+    private static let instructions = Instructions {
+      """
+      You name coding sessions. Given a user's first message to an AI coding assistant, \
+      produce a concise 3-7 word title for the conversation.
+
+      Rules:
+      - Use title case
+      - No quotes around the title
+      - No trailing punctuation
+      - Avoid generic titles like "New Conversation" or project-name-only labels
+      - Focus on the intent or topic of the user's message
+      """
+    }
+
+    static func generateTitle(from prompt: String) async -> String? {
+      guard SystemLanguageModel.default.availability == .available else { return nil }
+
+      let truncated = prompt.count > 500 ? String(prompt.prefix(500)) : prompt
+
+      do {
+        let session = LanguageModelSession(instructions: instructions)
+        let response = try await session.respond(
+          to: truncated,
+          generating: GeneratedSessionTitle.self
+        )
+        let name = response.content.name
+          .trimmingCharacters(in: .whitespacesAndNewlines)
+          .trimmingCharacters(in: CharacterSet(charactersIn: "\"'"))
+
+        guard !name.isEmpty else { return nil }
+        return name
+      } catch {
+        return nil
+      }
+    }
+  }
+#endif

--- a/OrbitDockNative/OrbitDock/Services/Server/API/SessionsClient.swift
+++ b/OrbitDockNative/OrbitDock/Services/Server/API/SessionsClient.swift
@@ -618,6 +618,15 @@ struct SessionsClient: Sendable {
     )
   }
 
+  func setSummary(_ sessionId: String, summary: String) async throws {
+    struct Body: Encodable { let summary: String }
+    let _: ServerAcceptedResponse = try await http.request(
+      path: "/api/sessions/\(requestBuilder.encodePathComponent(sessionId))/summary",
+      method: "PATCH",
+      body: Body(summary: summary)
+    )
+  }
+
   func updateSessionConfig(_ sessionId: String, config: UpdateSessionConfigRequest) async throws {
     let _: ServerAcceptedResponse = try await http.request(
       path: "/api/sessions/\(requestBuilder.encodePathComponent(sessionId))/config",

--- a/OrbitDockNative/OrbitDock/Services/Server/SessionStore+Commands.swift
+++ b/OrbitDockNative/OrbitDock/Services/Server/SessionStore+Commands.swift
@@ -19,6 +19,8 @@ extension SessionStore {
     request.images = images
     request.mentions = mentions
     try await clients.conversation.sendMessage(sessionId, request: request)
+
+    triggerLocalNamingIfNeeded(sessionId: sessionId, prompt: content)
   }
 
   func steerTurn(
@@ -152,6 +154,10 @@ extension SessionStore {
 
   func renameSession(_ sessionId: String, name: String?) async throws {
     try await clients.sessions.renameSession(sessionId, name: name)
+  }
+
+  func setSummary(_ sessionId: String, summary: String) async throws {
+    try await clients.sessions.setSummary(sessionId, summary: summary)
   }
 
   func updateSessionConfig(
@@ -479,6 +485,27 @@ extension SessionStore {
   func handleMemoryPressure() {
     for (_, observable) in _sessionObservables where !subscribedSessions.contains(observable.id) {
       observable.trimInactiveDetailPayloads()
+    }
+  }
+
+  // MARK: - Local Conversation Naming
+
+  private func triggerLocalNamingIfNeeded(sessionId: String, prompt: String) {
+    guard LocalNamingAvailabilityResolver.current == .available else { return }
+
+    let obs = session(sessionId)
+    guard obs.customName == nil, obs.summary == nil else { return }
+    guard _localNamingClaimedSessions.insert(sessionId).inserted else { return }
+
+    Task {
+      #if canImport(FoundationModels)
+        if #available(macOS 26.0, iOS 26.0, *) {
+          guard let name = await LocalConversationNamingService.generateTitle(from: prompt) else {
+            return
+          }
+          try? await setSummary(sessionId, summary: name)
+        }
+      #endif
     }
   }
 }

--- a/OrbitDockNative/OrbitDock/Services/Server/SessionStore.swift
+++ b/OrbitDockNative/OrbitDock/Services/Server/SessionStore.swift
@@ -85,6 +85,7 @@ final class SessionStore {
   @ObservationIgnored var inFlightSessionRecoveries: [SessionGenerationKey: GenerationTask<Void>] = [:]
   @ObservationIgnored var recoveredSessionGenerations: [String: UInt64] = [:]
   @ObservationIgnored var lastOlderMessagesRequestBeforeSequence: [String: UInt64] = [:]
+  @ObservationIgnored var _localNamingClaimedSessions: Set<String> = []
   @ObservationIgnored var connectionRecoveryTask: GenerationTask<Void>?
   @ObservationIgnored var eventProcessingTask: Task<Void, Never>?
   @ObservationIgnored private(set) var eventProcessingStartCount = 0

--- a/orbitdock-server/crates/server/src/runtime/session_mutations.rs
+++ b/orbitdock-server/crates/server/src/runtime/session_mutations.rs
@@ -2,6 +2,8 @@ use std::sync::Arc;
 
 use orbitdock_protocol::{CodexApprovalPolicy, CodexConfigMode, ServerMessage, SessionListItem};
 
+use orbitdock_protocol::StateChanges;
+
 use crate::connectors::claude_session::ClaudeAction;
 use crate::connectors::codex_session::CodexAction;
 use crate::infrastructure::persistence::PersistCommand;
@@ -85,6 +87,47 @@ pub(crate) async fn rename_session(
                 .await;
         }
     }
+
+    Ok(())
+}
+
+pub(crate) async fn set_summary(
+    state: &Arc<SessionRegistry>,
+    session_id: &str,
+    summary: String,
+) -> Result<(), SessionMutationError> {
+    let actor = state
+        .get_session(session_id)
+        .ok_or_else(|| SessionMutationError::NotFound(session_id.to_string()))?;
+
+    // Apply summary delta to in-memory state and broadcast to session subscribers
+    actor
+        .send(SessionCommand::ApplyDelta {
+            changes: Box::new(StateChanges {
+                summary: Some(Some(summary.clone())),
+                ..Default::default()
+            }),
+            persist_op: None,
+        })
+        .await;
+
+    // Broadcast to dashboard/sidebar list subscribers
+    state.broadcast_to_list(ServerMessage::SessionDelta {
+        session_id: session_id.to_string(),
+        changes: Box::new(StateChanges {
+            summary: Some(Some(summary.clone())),
+            ..Default::default()
+        }),
+    });
+
+    // Persist to DB
+    let _ = state
+        .persist()
+        .send(PersistCommand::SetSummary {
+            session_id: session_id.to_string(),
+            summary,
+        })
+        .await;
 
     Ok(())
 }

--- a/orbitdock-server/crates/server/src/transport/http/mod.rs
+++ b/orbitdock-server/crates/server/src/transport/http/mod.rs
@@ -87,7 +87,7 @@ pub use session_lifecycle::{
     batch_write_codex_config, create_session, end_session, fork_session,
     fork_session_to_existing_worktree, fork_session_to_worktree, get_codex_config_catalog,
     get_codex_config_documents, get_codex_preferences, inspect_codex_config, rename_session,
-    resume_session, takeover_session, update_codex_preferences, update_session_config,
+    resume_session, set_summary, takeover_session, update_codex_preferences, update_session_config,
     write_codex_config_value,
 };
 pub use sessions::{

--- a/orbitdock-server/crates/server/src/transport/http/router.rs
+++ b/orbitdock-server/crates/server/src/transport/http/router.rs
@@ -81,6 +81,10 @@ fn session_write_routes() -> Router<Arc<SessionRegistry>> {
             patch(super::rename_session),
         )
         .route(
+            "/api/sessions/{session_id}/summary",
+            patch(super::set_summary),
+        )
+        .route(
             "/api/sessions/{session_id}/config",
             patch(super::update_session_config),
         )

--- a/orbitdock-server/crates/server/src/transport/http/session_lifecycle.rs
+++ b/orbitdock-server/crates/server/src/transport/http/session_lifecycle.rs
@@ -21,8 +21,8 @@ use crate::runtime::session_fork_targets::{
 };
 use crate::runtime::session_mutations::{
     end_session as end_runtime_session, rename_session as rename_runtime_session,
-    update_session_config as update_runtime_session_config, SessionConfigUpdate,
-    SessionMutationError,
+    set_summary as set_runtime_summary, update_session_config as update_runtime_session_config,
+    SessionConfigUpdate, SessionMutationError,
 };
 use crate::runtime::session_resume::{launch_resumed_session, ResumeSessionError};
 use crate::runtime::session_takeover::{
@@ -132,6 +132,23 @@ pub async fn rename_session(
     Json(body): Json<RenameSessionRequest>,
 ) -> Result<Json<AcceptedResponse>, (StatusCode, Json<ApiErrorResponse>)> {
     rename_runtime_session(&state, &session_id, body.name)
+        .await
+        .map_err(map_session_mutation_error)?;
+
+    Ok(Json(AcceptedResponse { accepted: true }))
+}
+
+#[derive(Debug, Deserialize)]
+pub struct SetSummaryRequest {
+    pub summary: String,
+}
+
+pub async fn set_summary(
+    Path(session_id): Path<String>,
+    State(state): State<Arc<SessionRegistry>>,
+    Json(body): Json<SetSummaryRequest>,
+) -> Result<Json<AcceptedResponse>, (StatusCode, Json<ApiErrorResponse>)> {
+    set_runtime_summary(&state, &session_id, body.summary)
         .await
         .map_err(map_session_mutation_error)?;
 


### PR DESCRIPTION
## Summary

- Add on-device conversation naming via Apple Foundation Models (macOS 26+/iOS 26+) so Apple clients no longer need an OpenAI API key for auto-generated titles
- Add `PATCH /api/sessions/{id}/summary` server endpoint for clients to persist generated titles to the existing `summary` column
- New `LocalConversationNamingService` uses `@Generable` structured output to produce concise 3-7 word session titles
- Naming triggers after the first user prompt when `customName` and `summary` are both nil, with a dedup guard per session
- Falls back silently when Foundation Models is unavailable — existing server-side OpenAI naming and display fallback chains remain untouched

## Changes

### Server (Rust)
- `session_mutations.rs` — new `set_summary()` mutation: applies `StateChanges` delta, broadcasts to session + list subscribers, persists via `PersistCommand::SetSummary`
- `session_lifecycle.rs` — new `PATCH /api/sessions/{id}/summary` HTTP handler with `SetSummaryRequest { summary: String }`
- `router.rs` — route registration under `session_write_routes()`
- `mod.rs` — export

### Swift Client
- `LocalConversationNamingService.swift` — Foundation Models naming service with availability gating (`#if canImport(FoundationModels)`, `@available(macOS 26.0, iOS 26.0, *)`), `@Generable` struct for structured output, and silent error handling
- `SessionsClient.swift` — `setSummary(_:summary:)` API method
- `SessionStore+Commands.swift` — `setSummary` command + `triggerLocalNamingIfNeeded` hook in `sendMessage`
- `SessionStore.swift` — `_localNamingClaimedSessions` dedup guard

## Design decisions

- **Separate endpoint from rename**: `PATCH .../summary` writes to `summary` while `PATCH .../name` writes to `custom_name`. This preserves the semantic distinction between AI-generated titles and manual user renames
- **One-shot generation**: Only triggers once per session (dedup guard), only when both `customName` and `summary` are nil. No re-generation on subsequent messages
- **Silent fallback**: If Foundation Models is unavailable (unsupported device, Apple Intelligence disabled, model not ready), no error is shown and existing fallback chains continue to work
- **Server-authoritative**: Client generates the title but persists it through the server — no direct SQLite writes

## Test plan

- [ ] On macOS 26+ with Apple Intelligence enabled, start a new conversation and verify a title appears after the first prompt
- [ ] Verify the generated title persists across app restart (server persistence)
- [ ] Verify manual rename still overrides the generated title
- [ ] Verify existing sessions with summaries don't get re-named
- [ ] On older macOS (< 26) or with Apple Intelligence disabled, verify no errors and existing fallback behavior works
- [ ] Verify server-side OpenAI naming still works for non-Apple clients