### PR TITLE
🐛 Fix acceptEdits permission mode mismatch across Claude tool aliases

### DIFF
--- a/orbitdock-server/crates/connector-claude/src/lib.rs
+++ b/orbitdock-server/crates/connector-claude/src/lib.rs
@@ -30,6 +30,34 @@ use session::{
 };
 
 // ---------------------------------------------------------------------------
+// acceptEdits tool policy
+// ---------------------------------------------------------------------------
+
+/// All tool names (canonical + Claude-specific aliases) that should be
+/// pre-approved when the permission mode is `acceptEdits`.
+///
+/// The Claude CLI can use any of these names interchangeably for file-edit
+/// operations.  We must include every alias in `--allowedTools` so the CLI
+/// doesn't route them through the permission-prompt-tool and cause spurious
+/// "Allow for session?" prompts.
+pub const ACCEPT_EDITS_TOOLS: &[&str] = &[
+    // Canonical names
+    "Edit",
+    "Write",
+    "NotebookEdit",
+    // Claude-specific aliases
+    "FileEdit",
+    "MultiEdit",
+    "FileWrite",
+];
+
+/// Returns `true` if `tool_name` is a file-edit tool that `acceptEdits` mode
+/// should auto-approve.
+pub fn is_accept_edits_tool(tool_name: &str) -> bool {
+    ACCEPT_EDITS_TOOLS.contains(&tool_name)
+}
+
+// ---------------------------------------------------------------------------
 // Tool classification
 // ---------------------------------------------------------------------------
 
@@ -647,14 +675,14 @@ impl ClaudeConnector {
             args.push("--allow-dangerously-skip-permissions");
         }
 
-        // When permission_mode is "acceptEdits", ensure edit tools are explicitly
-        // in the allowedTools list. The --permission-prompt-tool stdio flag routes
-        // ALL permission decisions through the control protocol, so the CLI's
-        // internal --permission-mode auto-accept logic may not fire. Passing them
-        // as --allowedTools guarantees the CLI pre-approves them.
+        // When permission_mode is "acceptEdits", ensure all edit tools (canonical
+        // + aliases) are in the allowedTools list.  The --permission-prompt-tool
+        // stdio flag routes ALL permission decisions through OrbitDock, so the
+        // CLI's internal --permission-mode auto-accept logic may not fire.
+        // Passing them as --allowedTools guarantees the CLI pre-approves them.
         let mut effective_allowed: Vec<String> = allowed_tools.to_vec();
         if permission_mode == Some("acceptEdits") {
-            for tool in ["Edit", "Write", "NotebookEdit"] {
+            for tool in ACCEPT_EDITS_TOOLS {
                 let tool_str = tool.to_string();
                 if !effective_allowed.contains(&tool_str) {
                     effective_allowed.push(tool_str);
@@ -1018,11 +1046,24 @@ impl ClaudeConnector {
     }
 
     /// Change permission mode mid-session.
+    ///
+    /// When switching to `acceptEdits`, this also injects the edit tool names
+    /// into the CLI's `allowedTools` via `apply_flag_settings`.  Without this,
+    /// the CLI would continue sending `can_use_tool` requests for edits because
+    /// `--allowedTools` was locked at spawn time.
     pub async fn set_permission_mode(&self, mode: &str) -> Result<(), ConnectorError> {
         self.send_control_request(ControlRequestBody::SetPermissionMode {
             mode: mode.to_string(),
         })
         .await?;
+
+        if mode == "acceptEdits" {
+            let tools: Vec<&str> = ACCEPT_EDITS_TOOLS.to_vec();
+            let settings = serde_json::json!({ "allowedTools": tools });
+            let _ = self
+                .send_control_request(ControlRequestBody::ApplyFlagSettings { settings })
+                .await;
+        }
         Ok(())
     }
 
@@ -2102,11 +2143,7 @@ impl ClaudeConnector {
     }
 
     fn patch_diff_for_tool_use(tool_name: Option<&str>, payload: &Value) -> Option<String> {
-        let is_patch_tool = matches!(
-            tool_name,
-            Some("Edit" | "Write" | "NotebookEdit" | "MultiEdit")
-        );
-        if !is_patch_tool {
+        if !tool_name.is_some_and(is_accept_edits_tool) {
             return None;
         }
 
@@ -2647,9 +2684,9 @@ impl ClaudeConnector {
             },
         );
 
-        // Classify approval type
+        // Classify approval type — include aliases so they get Patch treatment
         let approval_type = match tool_name.as_deref() {
-            Some("Edit" | "Write" | "NotebookEdit") => ApprovalType::Patch,
+            Some(name) if is_accept_edits_tool(name) => ApprovalType::Patch,
             Some("AskUserQuestion") => ApprovalType::Question,
             _ => ApprovalType::Exec,
         };
@@ -2738,7 +2775,7 @@ impl ClaudeConnector {
         payload: &Value,
         fallback_file_path: Option<&str>,
     ) -> Option<String> {
-        let is_patch_tool = matches!(tool_name, Some("Edit" | "Write" | "NotebookEdit"));
+        let is_patch_tool = tool_name.is_some_and(is_accept_edits_tool);
         if !is_patch_tool {
             return payload
                 .get("new_string")

--- a/orbitdock-server/crates/server/src/connectors/claude_hooks/approval.rs
+++ b/orbitdock-server/crates/server/src/connectors/claude_hooks/approval.rs
@@ -40,23 +40,27 @@ pub(crate) fn classify_permission_request(
     orbitdock_protocol::WorkStatus,
     &'static str,
 ) {
-    match tool_name {
-        "AskUserQuestion" => (
+    if tool_name == "AskUserQuestion" {
+        return (
             orbitdock_protocol::ApprovalType::Question,
             orbitdock_protocol::WorkStatus::Question,
             "awaitingQuestion",
-        ),
-        "Edit" | "Write" | "NotebookEdit" => (
+        );
+    }
+
+    if orbitdock_connector_claude::is_accept_edits_tool(tool_name) {
+        return (
             orbitdock_protocol::ApprovalType::Patch,
             orbitdock_protocol::WorkStatus::Permission,
             "awaitingPermission",
-        ),
-        _ => (
-            orbitdock_protocol::ApprovalType::Exec,
-            orbitdock_protocol::WorkStatus::Permission,
-            "awaitingPermission",
-        ),
+        );
     }
+
+    (
+        orbitdock_protocol::ApprovalType::Exec,
+        orbitdock_protocol::WorkStatus::Permission,
+        "awaitingPermission",
+    )
 }
 
 pub(crate) fn extract_question_from_tool_input(tool_input: Option<&Value>) -> Option<String> {


### PR DESCRIPTION
## Summary

Fixes the root cause of `acceptEdits` sessions still surfacing "Allow for session?" prompts even when the UI shows acceptEdits is active.

**Three bugs found and fixed:**

- **Incomplete tool alias coverage:** The spawn-time `--allowedTools` shim only injected `Edit`, `Write`, `NotebookEdit` — but the Claude CLI also uses `FileEdit`, `MultiEdit`, and `FileWrite` aliases for the same operations. Created a shared `ACCEPT_EDITS_TOOLS` constant covering all six names.

- **Mid-session mode changes don't update allowedTools (primary bug):** When a user changes permission mode to `acceptEdits` via the UI, `SetPermissionMode` updated the mode label but never injected edit tools into the running CLI's `allowedTools`. The tools were locked at spawn time. Now `set_permission_mode` also sends `apply_flag_settings` with the full edit tool list when switching to `acceptEdits`.

- **Approval classification missed aliases:** The approval type classifier and diff extractor only matched canonical tool names, so alias-named tools got `Exec` type instead of `Patch`. Updated all match sites to use the shared `is_accept_edits_tool()` helper.

## Changes

- `connector-claude/src/lib.rs`: Added `ACCEPT_EDITS_TOOLS` constant and `is_accept_edits_tool()` helper. Updated spawn shim, `set_permission_mode`, approval classification, and diff extraction to use them.
- `server/src/connectors/claude_hooks/approval.rs`: Updated `classify_permission_request` to use `is_accept_edits_tool()` for alias coverage.

## Non-obvious decisions

- The `apply_flag_settings` approach for mid-session tool injection was chosen over adding a new control request type. The Claude CLI's `apply_flag_settings` already supports `allowedTools` as a settable flag, and this avoids SDK protocol changes.
- Resume sessions already work for canonical names (the spawn-time shim fires because `permission_mode` is restored from DB), but now also cover aliases via the expanded constant.

## Test plan

- [x] `make rust-ci` passes (format, lint, 518 tests)
- [ ] Manual: Start a session with `default` mode, switch to `acceptEdits` mid-session → edit tools should auto-approve
- [ ] Manual: Start a session directly with `acceptEdits` → `FileEdit`/`MultiEdit`/`FileWrite` should not prompt
- [ ] Manual: Resume an `acceptEdits` session → edit tools should still auto-approve

Closes #101