### PR TITLE
♻️ Unify Mission Control iOS/iPad navigation chrome

### DIFF
--- a/OrbitDockNative/OrbitDock/Navigation/AppRouter.swift
+++ b/OrbitDockNative/OrbitDock/Navigation/AppRouter.swift
@@ -4,6 +4,14 @@ enum DashboardTab: String, CaseIterable {
   case missionControl
   case missions
   case library
+
+  var navigationTitle: String {
+    switch self {
+      case .missionControl: "Active"
+      case .missions: "Missions"
+      case .library: "Library"
+    }
+  }
 }
 
 enum NavigationSource: String, Sendable {

--- a/OrbitDockNative/OrbitDock/Views/Dashboard/Scene/DashboardView.swift
+++ b/OrbitDockNative/OrbitDock/Views/Dashboard/Scene/DashboardView.swift
@@ -75,6 +75,10 @@ struct DashboardView: View {
       .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
       .background(Color.backgroundPrimary)
     }
+    #if os(iOS)
+    .navigationTitle(router.dashboardTab.navigationTitle)
+    .navigationBarHidden(true)
+    #endif
   }
 
   // MARK: - Missions Tab

--- a/OrbitDockNative/OrbitDock/Views/MissionControl/MissionShowView.swift
+++ b/OrbitDockNative/OrbitDock/Views/MissionControl/MissionShowView.swift
@@ -23,8 +23,10 @@ struct MissionShowView: View {
 
   var body: some View {
     VStack(spacing: 0) {
-      navigationBar
-      Divider().foregroundStyle(Color.surfaceBorder)
+      #if os(macOS)
+        navigationBar
+        Divider().foregroundStyle(Color.surfaceBorder)
+      #endif
 
       Group {
         if viewModel.isLoading {
@@ -53,6 +55,17 @@ struct MissionShowView: View {
     .onChange(of: viewModel.liveState?.heartbeatRevision) { _, _ in
       viewModel.applyLiveHeartbeat()
     }
+    #if os(iOS)
+    .navigationTitle(viewModel.summary?.name ?? "Mission")
+    .navigationBarTitleDisplayMode(.inline)
+    .toolbar {
+      ToolbarItemGroup(placement: .topBarTrailing) {
+        if let summary = viewModel.summary {
+          iOSActionsMenu(summary)
+        }
+      }
+    }
+    #endif
     .alert(
       "Error",
       isPresented: Binding(get: { viewModel.actionError != nil }, set: { if !$0 { viewModel.actionError = nil } })
@@ -81,31 +94,33 @@ struct MissionShowView: View {
 
   // MARK: - Navigation Bar
 
-  private var navigationBar: some View {
-    HStack(spacing: Spacing.md) {
-      Button {
-        router.selectDashboardTab(.missions)
-      } label: {
-        HStack(spacing: Spacing.sm_) {
-          Image(systemName: "chevron.left")
-            .font(.system(size: 11, weight: .semibold))
-          Text("Missions")
-            .font(.system(size: TypeScale.caption, weight: .medium))
+  #if os(macOS)
+    private var navigationBar: some View {
+      HStack(spacing: Spacing.md) {
+        Button {
+          router.selectDashboardTab(.missions)
+        } label: {
+          HStack(spacing: Spacing.sm_) {
+            Image(systemName: "chevron.left")
+              .font(.system(size: 11, weight: .semibold))
+            Text("Missions")
+              .font(.system(size: TypeScale.caption, weight: .medium))
+          }
+          .foregroundStyle(Color.textSecondary)
         }
-        .foregroundStyle(Color.textSecondary)
-      }
-      .buttonStyle(.plain)
+        .buttonStyle(.plain)
 
-      Spacer()
+        Spacer()
 
-      if let summary = viewModel.summary {
-        missionActions(summary)
+        if let summary = viewModel.summary {
+          missionActions(summary)
+        }
       }
+      .padding(.horizontal, Spacing.lg)
+      .padding(.vertical, Spacing.md)
+      .background(Color.backgroundSecondary)
     }
-    .padding(.horizontal, Spacing.lg)
-    .padding(.vertical, Spacing.md)
-    .background(Color.backgroundSecondary)
-  }
+  #endif
 
   // MARK: - Content
 
@@ -289,45 +304,72 @@ struct MissionShowView: View {
 
   // MARK: - Actions
 
-  private func missionActions(_ mission: MissionSummary) -> some View {
-    Menu {
-      Button {
-        viewModel.showWorktreeCleanup = true
-        Task { await viewModel.loadMissionWorktrees() }
+  #if os(macOS)
+    private func missionActions(_ mission: MissionSummary) -> some View {
+      Menu {
+        missionActionMenuContent
       } label: {
-        Label("Clean Up Worktrees", systemImage: "arrow.3.trianglepath")
+        Image(systemName: "ellipsis")
+          .font(.system(size: 10, weight: .bold))
+          .foregroundStyle(Color.textTertiary)
+          .frame(width: 28, height: 28)
+          .background(
+            Color.backgroundTertiary.opacity(0.6),
+            in: RoundedRectangle(cornerRadius: Radius.sm_, style: .continuous)
+          )
       }
-
-      Divider()
-
-      Button(role: .destructive) {
-        viewModel.showDeleteConfirmation = true
-      } label: {
-        Label("Delete Mission", systemImage: "trash")
-      }
-    } label: {
-      Image(systemName: "ellipsis")
-        .font(.system(size: 10, weight: .bold))
-        .foregroundStyle(Color.textTertiary)
-        .frame(width: 28, height: 28)
-        .background(
-          Color.backgroundTertiary.opacity(0.6),
-          in: RoundedRectangle(cornerRadius: Radius.sm_, style: .continuous)
-        )
-    }
-    .menuStyle(.borderlessButton)
-    .fixedSize()
-    .alert("Delete Mission?", isPresented: $viewModel.showDeleteConfirmation) {
-      Button("Delete", role: .destructive) {
-        Task {
-          if await viewModel.deleteMission() {
-            router.selectDashboardTab(.missions)
+      .menuStyle(.borderlessButton)
+      .fixedSize()
+      .alert("Delete Mission?", isPresented: $viewModel.showDeleteConfirmation) {
+        Button("Delete", role: .destructive) {
+          Task {
+            if await viewModel.deleteMission() {
+              router.selectDashboardTab(.missions)
+            }
           }
         }
+        Button("Cancel", role: .cancel) {}
+      } message: {
+        Text("Are you sure you want to delete this mission? This cannot be undone.")
       }
-      Button("Cancel", role: .cancel) {}
-    } message: {
-      Text("Are you sure you want to delete this mission? This cannot be undone.")
+    }
+  #else
+    private func iOSActionsMenu(_ mission: MissionSummary) -> some View {
+      Menu {
+        missionActionMenuContent
+      } label: {
+        Image(systemName: "ellipsis.circle")
+      }
+      .alert("Delete Mission?", isPresented: $viewModel.showDeleteConfirmation) {
+        Button("Delete", role: .destructive) {
+          Task {
+            if await viewModel.deleteMission() {
+              router.selectDashboardTab(.missions)
+            }
+          }
+        }
+        Button("Cancel", role: .cancel) {}
+      } message: {
+        Text("Are you sure you want to delete this mission? This cannot be undone.")
+      }
+    }
+  #endif
+
+  @ViewBuilder
+  private var missionActionMenuContent: some View {
+    Button {
+      viewModel.showWorktreeCleanup = true
+      Task { await viewModel.loadMissionWorktrees() }
+    } label: {
+      Label("Clean Up Worktrees", systemImage: "arrow.3.trianglepath")
+    }
+
+    Divider()
+
+    Button(role: .destructive) {
+      viewModel.showDeleteConfirmation = true
+    } label: {
+      Label("Delete Mission", systemImage: "trash")
     }
   }
 


### PR DESCRIPTION
## Summary

Fixes #113

Mission Control's `MissionShowView` was rendering a custom navigation bar (with its own back button and actions menu) on **all platforms**, including iOS/iPad where it's pushed onto a `NavigationStack`. This created double back affordances on touch platforms — the native NavigationStack back button plus the custom "← Missions" button.

This PR follows the same platform-split pattern that `SessionDetailView` already uses:

- **macOS**: keeps the existing custom navigation bar (back button + ellipsis actions menu) since macOS uses `ContentView`'s route-based switching, not a NavigationStack
- **iOS/iPad**: removes the custom bar and uses native `.navigationTitle`, `.navigationBarTitleDisplayMode(.inline)`, and `.toolbar` with an `ellipsis.circle` actions menu — matching how `SessionDetailView` handles iOS chrome

## Changes

- **`MissionShowView`**: Gate custom `navigationBar` and `missionActions` behind `#if os(macOS)`. Add iOS native navigation title, inline display mode, and toolbar actions menu. Extract shared `missionActionMenuContent` to avoid duplicating menu items across platforms.
- **`DashboardView`**: Set `.navigationTitle` per active dashboard tab on iOS (hidden, but controls the back button text on pushed destinations). Now the back button on `MissionShowView` reads "Missions" instead of generic "Back".
- **`AppRouter`**: Add `navigationTitle` computed property to `DashboardTab` for the above.

## What's NOT changed

- No routing model changes — dashboard tabs and pushed destinations work exactly as before
- No macOS regression — custom chrome is preserved behind `#if os(macOS)`
- No changes to `SessionDetailView`, `ContentView`, or `OrbitDockWindowRoot`

## Test plan

- [ ] macOS: Mission list → tap mission row → verify custom back bar ("← Missions") and ellipsis menu still work
- [ ] iOS/iPhone: Missions tab → tap mission row → verify native back button says "Missions", inline title shows mission name, ellipsis.circle toolbar menu works
- [ ] iPad: Same as iPhone verification
- [ ] Verify delete mission from both macOS custom menu and iOS toolbar menu navigates back to missions tab
- [ ] Verify worktree cleanup sheet opens from both platform menus