### PR TITLE
♻️ Extend SessionDetailSnapshotProjection with diff/plan/turn fields

### DIFF
--- a/OrbitDockNative/OrbitDock/Services/Server/ServerTypeAdapters.swift
+++ b/OrbitDockNative/OrbitDock/Services/Server/ServerTypeAdapters.swift
@@ -86,6 +86,13 @@ extension ServerSessionState {
       isWorktree: isWorktree ?? false,
       worktreeId: worktreeId,
       unreadCount: unreadCount ?? 0,
+      currentDiff: currentDiff,
+      cumulativeDiff: cumulativeDiff,
+      currentPlan: currentPlan,
+      turnDiffs: turnDiffs,
+      currentTurnId: currentTurnId,
+      turnCount: turnCount,
+      subagents: subagents,
       missionId: missionId,
       issueIdentifier: issueIdentifier,
       allowBypassPermissions: allowBypassPermissions ?? false

--- a/OrbitDockNative/OrbitDock/Services/Server/SessionStateProjection.swift
+++ b/OrbitDockNative/OrbitDock/Services/Server/SessionStateProjection.swift
@@ -79,6 +79,13 @@ struct SessionDetailSnapshotProjection {
   let isWorktree: Bool
   let worktreeId: String?
   let unreadCount: UInt64
+  let currentDiff: String?
+  let cumulativeDiff: String?
+  let currentPlan: String?
+  let turnDiffs: [ServerTurnDiff]
+  let currentTurnId: String?
+  let turnCount: UInt64
+  let subagents: [ServerSubagentInfo]
   let missionId: String?
   let issueIdentifier: String?
   let allowBypassPermissions: Bool
@@ -141,6 +148,13 @@ struct SessionDetailSnapshotProjection {
       isWorktree: session.isWorktree,
       worktreeId: session.worktreeId,
       unreadCount: session.unreadCount,
+      currentDiff: session.currentDiff,
+      cumulativeDiff: session.cumulativeDiff,
+      currentPlan: nil,
+      turnDiffs: [],
+      currentTurnId: nil,
+      turnCount: 0,
+      subagents: [],
       missionId: session.missionId,
       issueIdentifier: session.issueIdentifier,
       allowBypassPermissions: false
@@ -461,6 +475,13 @@ extension SessionObservable {
     isWorktree = projection.isWorktree
     worktreeId = projection.worktreeId
     unreadCount = projection.unreadCount
+    diff = projection.currentDiff
+    cumulativeDiff = projection.cumulativeDiff
+    plan = projection.currentPlan
+    turnDiffs = projection.turnDiffs
+    currentTurnId = projection.currentTurnId
+    turnCount = projection.turnCount
+    subagents = projection.subagents
     missionId = projection.missionId
     issueIdentifier = projection.issueIdentifier
     allowBypassPermissions = projection.allowBypassPermissions

--- a/OrbitDockNative/OrbitDock/Services/Server/SessionStore+Events.swift
+++ b/OrbitDockNative/OrbitDock/Services/Server/SessionStore+Events.swift
@@ -247,13 +247,6 @@ extension SessionStore {
       isBootstrap: true
     )
     obs.applySnapshotProjection(state.toDetailSnapshotProjection())
-    obs.diff = state.currentDiff
-    obs.cumulativeDiff = state.cumulativeDiff
-    obs.plan = state.currentPlan
-    obs.turnDiffs = state.turnDiffs
-    obs.currentTurnId = state.currentTurnId
-    obs.turnCount = state.turnCount
-    obs.subagents = state.subagents
     let transition = SessionControlStateReducer.snapshotTransition(
       current: controlState(sessionId: state.id, observable: obs),
       snapshot: state,

--- a/OrbitDockNative/OrbitDockTests/Server/Sessions/SessionStateProjectionTests.swift
+++ b/OrbitDockNative/OrbitDockTests/Server/Sessions/SessionStateProjectionTests.swift
@@ -290,6 +290,116 @@ struct SessionStateProjectionTests {
     #expect(projection.unreadCount == 7)
   }
 
+  @Test func snapshotProjectionHydratesDiffPlanTurnAndSubagentFields() {
+    let observable = SessionObservable(id: "session-1")
+
+    let turnDiff = ServerTurnDiff(
+      turnId: "turn-42",
+      diff: "diff --git a/file.swift b/file.swift",
+      inputTokens: 10,
+      outputTokens: 5,
+      cachedTokens: 2,
+      contextWindow: 100_000
+    )
+    let subagent = ServerSubagentInfo(
+      id: "worker-1",
+      agentType: "worker",
+      startedAt: "2026-03-22T10:00:00Z",
+      endedAt: nil,
+      provider: .codex,
+      label: "Leibniz",
+      status: .running,
+      taskSummary: "Check Makefile",
+      resultSummary: nil,
+      errorSummary: nil,
+      parentSubagentId: nil,
+      model: "gpt-5.4",
+      lastActivityAt: "2026-03-22T10:00:01Z"
+    )
+
+    let projection = SessionDetailSnapshotProjection(
+      endpointId: nil,
+      endpointName: nil,
+      projectPath: "/tmp/project",
+      projectName: nil,
+      branch: nil,
+      model: nil,
+      effort: nil,
+      collaborationMode: nil,
+      multiAgent: nil,
+      personality: nil,
+      serviceTier: nil,
+      developerInstructions: nil,
+      codexConfigSource: nil,
+      codexConfigMode: nil,
+      codexConfigProfile: nil,
+      codexModelProvider: nil,
+      codexConfigOverrides: nil,
+      summary: nil,
+      customName: nil,
+      firstPrompt: nil,
+      lastMessage: nil,
+      transcriptPath: nil,
+      status: .active,
+      workStatus: .working,
+      attentionReason: .none,
+      lastActivityAt: nil,
+      lastFilesPersistedAt: nil,
+      lastTool: nil,
+      lastToolAt: nil,
+      inputTokens: nil,
+      outputTokens: nil,
+      cachedTokens: nil,
+      contextWindow: nil,
+      totalTokens: 0,
+      totalCostUSD: 0,
+      provider: .claude,
+      codexIntegrationMode: nil,
+      claudeIntegrationMode: .direct,
+      codexThreadId: nil,
+      pendingApprovalId: nil,
+      pendingToolName: nil,
+      pendingToolInput: nil,
+      pendingPermissionDetail: nil,
+      pendingQuestion: nil,
+      promptCount: 0,
+      toolCount: 0,
+      startedAt: nil,
+      endedAt: nil,
+      endReason: nil,
+      tokenUsageSnapshotKind: .lifetimeTotals,
+      gitSha: nil,
+      currentCwd: nil,
+      repositoryRoot: nil,
+      isWorktree: false,
+      worktreeId: nil,
+      unreadCount: 0,
+      currentDiff: "diff --git a/file.swift",
+      cumulativeDiff: "cumulative diff content",
+      currentPlan: #"[{"step":"Refactor","status":"inProgress"}]"#,
+      turnDiffs: [turnDiff],
+      currentTurnId: "turn-42",
+      turnCount: 3,
+      subagents: [subagent],
+      missionId: nil,
+      issueIdentifier: nil,
+      allowBypassPermissions: false
+    )
+
+    observable.applySnapshotProjection(projection)
+
+    #expect(observable.diff == "diff --git a/file.swift")
+    #expect(observable.cumulativeDiff == "cumulative diff content")
+    #expect(observable.plan == #"[{"step":"Refactor","status":"inProgress"}]"#)
+    #expect(observable.turnDiffs.count == 1)
+    #expect(observable.turnDiffs.first?.turnId == "turn-42")
+    #expect(observable.turnDiffs.first?.diff == "diff --git a/file.swift b/file.swift")
+    #expect(observable.currentTurnId == "turn-42")
+    #expect(observable.turnCount == 3)
+    #expect(observable.subagents.count == 1)
+    #expect(observable.subagents.first?.id == "worker-1")
+  }
+
   @Test func sessionObservableApprovalProjectionUsesQuestionTextAndClearsWithoutResettingAttentionByDefault() {
     let observable = SessionObservable(id: "session-1")
     let request = questionApprovalRequest()


### PR DESCRIPTION
## Summary

- Added `currentDiff`, `cumulativeDiff`, `currentPlan`, `turnDiffs`, `currentTurnId`, `turnCount`, and `subagents` to `SessionDetailSnapshotProjection`
- Updated `applySnapshotProjection` to assign these fields on `SessionObservable`
- Removed the direct workaround assignments in `handleConversationBootstrap` added in #66
- Added new test `snapshotProjectionHydratesDiffPlanTurnAndSubagentFields` verifying hydration through the projection path

## Why

These fields were missing from the projection struct, causing `handleConversationBootstrap` to assign them directly after `applySnapshotProjection`. This was inconsistent with how all other bootstrap data flows through projections.

## Test plan

- [x] All 15 `SessionStateProjectionTests` pass (14 existing + 1 new)
- [x] macOS scheme builds clean

Closes #67