### PR TITLE
✨ Multi-endpoint mission support

### DIFF
--- a/OrbitDockNative/OrbitDock/Models/MissionControl/AggregatedMissionSummary.swift
+++ b/OrbitDockNative/OrbitDock/Models/MissionControl/AggregatedMissionSummary.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+struct AggregatedMissionSummary: Identifiable, Equatable, Sendable {
+  let mission: MissionSummary
+  let endpointId: UUID
+  let endpointName: String?
+
+  var id: String {
+    ref.id
+  }
+
+  var ref: MissionRef {
+    MissionRef(endpointId: endpointId, missionId: mission.id)
+  }
+}

--- a/OrbitDockNative/OrbitDock/Services/Server/ServerRuntimeRegistry.swift
+++ b/OrbitDockNative/OrbitDock/Services/Server/ServerRuntimeRegistry.swift
@@ -27,8 +27,10 @@ final class ServerRuntimeRegistry {
 
   @ObservationIgnored private var sessionsByEndpoint: [UUID: [String: RootSessionNode]] = [:]
   @ObservationIgnored private var dashboardConversationsByEndpoint: [UUID: [String: DashboardConversationRecord]] = [:]
+  @ObservationIgnored private var missionsByEndpoint: [UUID: [String: AggregatedMissionSummary]] = [:]
   private(set) var aggregatedSessions: [RootSessionNode] = []
   private(set) var aggregatedDashboardConversations: [DashboardConversationRecord] = []
+  private(set) var aggregatedMissions: [AggregatedMissionSummary] = []
 
   @ObservationIgnored
   private lazy var fallbackSessionStore: SessionStore = {
@@ -156,6 +158,16 @@ final class ServerRuntimeRegistry {
     return runtimesByEndpointId[primaryEndpointId]
   }
 
+  var hasMultipleEndpoints: Bool {
+    runtimesByEndpointId.count > 1
+  }
+
+  var connectedRuntimes: [ServerRuntime] {
+    runtimes.filter { runtime in
+      connectionStatusByEndpointId[runtime.endpoint.id] == .connected
+    }
+  }
+
   var activeSessionStore: SessionStore {
     ensureInitialized()
     if let runtime = resolvedActiveRuntime() {
@@ -255,10 +267,12 @@ final class ServerRuntimeRegistry {
       readinessByEndpointId[id] = nil
       sessionsByEndpoint[id] = nil
       dashboardConversationsByEndpoint[id] = nil
+      missionsByEndpoint[id] = nil
       readinessContinuation.yield(())
     }
     recomputeAggregatedSessions()
     recomputeAggregatedDashboardConversations()
+    recomputeAggregatedMissions()
 
     for endpoint in configuredEndpoints {
       if let existing = runtimesByEndpointId[endpoint.id] {
@@ -272,6 +286,7 @@ final class ServerRuntimeRegistry {
 
           sessionsByEndpoint[endpoint.id] = nil
           dashboardConversationsByEndpoint[endpoint.id] = nil
+          missionsByEndpoint[endpoint.id] = nil
 
           let replacement = runtimeFactory(endpoint)
           runtimesByEndpointId[endpoint.id] = replacement
@@ -608,6 +623,22 @@ final class ServerRuntimeRegistry {
             self.recomputeAggregatedSessions()
           }
 
+        case let .missionsList(missions):
+          let endpointName = runtime.endpoint.name
+          var index: [String: AggregatedMissionSummary] = [:]
+          for mission in missions {
+            let agg = AggregatedMissionSummary(mission: mission, endpointId: endpointId, endpointName: endpointName)
+            index[agg.id] = agg
+          }
+          self.missionsByEndpoint[endpointId] = index
+          self.recomputeAggregatedMissions()
+
+        case let .missionDelta(_, _, summary):
+          let endpointName = runtime.endpoint.name
+          let agg = AggregatedMissionSummary(mission: summary, endpointId: endpointId, endpointName: endpointName)
+          self.missionsByEndpoint[endpointId, default: [:]][agg.id] = agg
+          self.recomputeAggregatedMissions()
+
         default:
           break
       }
@@ -642,6 +673,17 @@ final class ServerRuntimeRegistry {
         return dashboardConversationPriority(lhs.displayStatus) < dashboardConversationPriority(rhs.displayStatus)
       }
       return lhsDate > rhsDate
+    }
+  }
+
+  private func recomputeAggregatedMissions() {
+    let all = missionsByEndpoint.values.flatMap(\.values)
+    aggregatedMissions = all.sorted { lhs, rhs in
+      // Active missions first, then by name
+      let lhsActive = lhs.mission.enabled && !lhs.mission.paused
+      let rhsActive = rhs.mission.enabled && !rhs.mission.paused
+      if lhsActive != rhsActive { return lhsActive }
+      return lhs.mission.name.localizedCaseInsensitiveCompare(rhs.mission.name) == .orderedAscending
     }
   }
 

--- a/OrbitDockNative/OrbitDock/Views/Dashboard/Scene/DashboardView.swift
+++ b/OrbitDockNative/OrbitDock/Views/Dashboard/Scene/DashboardView.swift
@@ -86,8 +86,8 @@ struct DashboardView: View {
   @ViewBuilder
   private var missionsTab: some View {
     let registry = appStore.runtimeRegistry
-    if let clients = (registry.primaryRuntime ?? registry.activeRuntime)?.clients {
-      MissionListView(missionsClient: clients.missions)
+    if registry.hasConfiguredEndpoints {
+      MissionListView()
     } else {
       ContentUnavailableView(
         "No Server Connected",

--- a/OrbitDockNative/OrbitDock/Views/MissionControl/MissionListView.swift
+++ b/OrbitDockNative/OrbitDock/Views/MissionControl/MissionListView.swift
@@ -6,8 +6,6 @@ struct MissionListView: View {
   @Environment(AppRouter.self) private var router
   @Environment(ServerRuntimeRegistry.self) private var runtimeRegistry
 
-  let missionsClient: MissionsClient
-
   var body: some View {
     Group {
       if viewModel.isLoading {
@@ -23,15 +21,20 @@ struct MissionListView: View {
     }
     .task {
       viewModel.bind(runtimeRegistry: runtimeRegistry)
-      await viewModel.fetchMissions(using: missionsClient)
+      await viewModel.fetchAllMissions()
     }
-    .onChange(of: viewModel.missionListSnapshot) { _, _ in
+    .onChange(of: viewModel.aggregatedMissionsSnapshot) { _, _ in
       viewModel.applyMissionListSnapshotIfNeeded()
     }
     .sheet(isPresented: $viewModel.showNewMission) {
-      NewMissionSheet(missionsClient: missionsClient) { newMission in
-        viewModel.missions.insert(newMission, at: 0)
-        router.navigateToMission(missionId: newMission.id, endpointId: viewModel.endpointId)
+      NewMissionSheet { newMission, endpointId in
+        let agg = AggregatedMissionSummary(
+          mission: newMission,
+          endpointId: endpointId,
+          endpointName: runtimeRegistry.runtimesByEndpointId[endpointId]?.endpoint.name
+        )
+        viewModel.missions.insert(agg, at: 0)
+        router.navigateToMission(missionId: newMission.id, endpointId: endpointId)
       }
     }
     .alert(
@@ -105,17 +108,33 @@ struct MissionListView: View {
           .buttonStyle(.plain)
         }
 
-        ForEach(viewModel.missions) { mission in
+        ForEach(viewModel.missions) { agg in
+          let missionsClient = runtimeRegistry.runtimesByEndpointId[agg.endpointId]?.clients.missions
+
           Button {
-            router.navigateToMission(missionId: mission.id, endpointId: viewModel.endpointId)
+            router.navigateToMission(missionId: agg.mission.id, endpointId: agg.endpointId)
           } label: {
             MissionRowView(
-              mission: mission,
+              mission: agg.mission,
+              endpointName: runtimeRegistry.hasMultipleEndpoints ? agg.endpointName : nil,
               missionsClient: missionsClient,
-              onRefresh: { await viewModel.fetchMissions(using: missionsClient) },
+              onRefresh: { await viewModel.fetchAllMissions() },
               onApplyList: { response in
+                // Update just this endpoint's missions in the list
+                let endpointId = agg.endpointId
+                let endpointName = agg.endpointName
+                let updated = response.missions.map { mission in
+                  AggregatedMissionSummary(mission: mission, endpointId: endpointId, endpointName: endpointName)
+                }
                 withAnimation(Motion.standard) {
-                  viewModel.missions = response.missions
+                  viewModel.missions.removeAll { $0.endpointId == endpointId }
+                  viewModel.missions.append(contentsOf: updated)
+                  viewModel.missions.sort { lhs, rhs in
+                    let lhsActive = lhs.mission.enabled && !lhs.mission.paused
+                    let rhsActive = rhs.mission.enabled && !rhs.mission.paused
+                    if lhsActive != rhsActive { return lhsActive }
+                    return lhs.mission.name.localizedCaseInsensitiveCompare(rhs.mission.name) == .orderedAscending
+                  }
                 }
               }
             )
@@ -133,7 +152,8 @@ struct MissionListView: View {
 
 private struct MissionRowView: View {
   let mission: MissionSummary
-  let missionsClient: MissionsClient
+  let endpointName: String?
+  let missionsClient: MissionsClient?
   let onRefresh: () async -> Void
   let onApplyList: (MissionsListResponse) -> Void
 
@@ -173,6 +193,20 @@ private struct MissionRowView: View {
           Text(mission.name)
             .font(.system(size: TypeScale.body, weight: .semibold))
             .foregroundStyle(Color.textPrimary)
+
+          // Endpoint tag (multi-server)
+          if let endpointName {
+            HStack(spacing: Spacing.gap) {
+              Image(systemName: "server.rack")
+                .font(.system(size: IconScale.xs, weight: .semibold))
+              Text(endpointName)
+                .font(.system(size: TypeScale.mini, weight: .semibold))
+            }
+            .foregroundStyle(Color.textTertiary)
+            .padding(.horizontal, Spacing.sm_)
+            .padding(.vertical, Spacing.xxs)
+            .background(Color.backgroundTertiary, in: Capsule())
+          }
 
           // Provider tag
           HStack(spacing: Spacing.gap) {
@@ -381,6 +415,7 @@ private struct MissionRowView: View {
   // MARK: - Helpers
 
   private func updateMission(enabled: Bool? = nil, paused: Bool? = nil) async {
+    guard let missionsClient else { return }
     do {
       _ = try await missionsClient.updateMission(mission.id, enabled: enabled, paused: paused)
       await onRefresh()
@@ -390,6 +425,7 @@ private struct MissionRowView: View {
   }
 
   private func deleteMission() async {
+    guard let missionsClient else { return }
     do {
       let response = try await missionsClient.deleteMission(mission.id)
       onApplyList(response)

--- a/OrbitDockNative/OrbitDock/Views/MissionControl/MissionListViewModel.swift
+++ b/OrbitDockNative/OrbitDock/Views/MissionControl/MissionListViewModel.swift
@@ -3,7 +3,7 @@ import Foundation
 @MainActor
 @Observable
 final class MissionListViewModel {
-  var missions: [MissionSummary] = []
+  var missions: [AggregatedMissionSummary] = []
   var isLoading = true
   var error: String?
   var showNewMission = false
@@ -15,34 +15,45 @@ final class MissionListViewModel {
     self.runtimeRegistry = runtimeRegistry
   }
 
-  var sessionStore: SessionStore? {
-    (runtimeRegistry?.primaryRuntime ?? runtimeRegistry?.activeRuntime)?.sessionStore
+  var aggregatedMissionsSnapshot: [AggregatedMissionSummary] {
+    runtimeRegistry?.aggregatedMissions ?? []
   }
 
-  var endpointId: UUID {
-    runtimeRegistry?.primaryEndpointId
-      ?? runtimeRegistry?.activeEndpointId
-      ?? UUID()
-  }
-
-  var missionListSnapshot: [MissionSummary] {
-    sessionStore?.missionListSnapshot ?? []
-  }
-
-  func fetchMissions(using missionsClient: MissionsClient) async {
+  func fetchAllMissions() async {
+    guard let registry = runtimeRegistry else { return }
     isLoading = true
-    do {
-      let response = try await missionsClient.listMissions()
-      missions = response.missions
-      error = nil
-    } catch {
-      self.error = error.localizedDescription
+    var all: [AggregatedMissionSummary] = []
+
+    for runtime in registry.runtimes where runtime.endpoint.isEnabled {
+      let endpointId = runtime.endpoint.id
+      let endpointName = runtime.endpoint.name
+      let status = registry.connectionStatusByEndpointId[endpointId]
+      guard status == .connected else { continue }
+      do {
+        let response = try await runtime.clients.missions.listMissions()
+        let aggregated = response.missions.map { mission in
+          AggregatedMissionSummary(mission: mission, endpointId: endpointId, endpointName: endpointName)
+        }
+        all.append(contentsOf: aggregated)
+      } catch {
+        // Individual endpoint failure shouldn't block others
+        continue
+      }
     }
+
+    missions = all.sorted { lhs, rhs in
+      let lhsActive = lhs.mission.enabled && !lhs.mission.paused
+      let rhsActive = rhs.mission.enabled && !rhs.mission.paused
+      if lhsActive != rhsActive { return lhsActive }
+      return lhs.mission.name.localizedCaseInsensitiveCompare(rhs.mission.name) == .orderedAscending
+    }
+
+    error = missions.isEmpty && all.isEmpty ? nil : nil
     isLoading = false
   }
 
   func applyMissionListSnapshotIfNeeded() {
-    let snapshot = missionListSnapshot
+    let snapshot = aggregatedMissionsSnapshot
     guard !snapshot.isEmpty else { return }
     missions = snapshot
   }

--- a/OrbitDockNative/OrbitDock/Views/MissionControl/MissionShowView.swift
+++ b/OrbitDockNative/OrbitDock/Views/MissionControl/MissionShowView.swift
@@ -294,6 +294,11 @@ struct MissionShowView: View {
               )
             }
             statusCapsule(mission)
+
+            if runtimeRegistry.hasMultipleEndpoints,
+               let name = runtimeRegistry.runtimesByEndpointId[endpointId]?.endpoint.name {
+              capsuleTag(name, icon: "server.rack")
+            }
           }
         }
 

--- a/OrbitDockNative/OrbitDock/Views/MissionControl/NewMissionSheet.swift
+++ b/OrbitDockNative/OrbitDock/Views/MissionControl/NewMissionSheet.swift
@@ -4,8 +4,7 @@ struct NewMissionSheet: View {
   @Environment(\.dismiss) private var dismiss
   @Environment(ServerRuntimeRegistry.self) private var runtimeRegistry
 
-  let missionsClient: MissionsClient
-  let onCreated: (MissionSummary) -> Void
+  let onCreated: (MissionSummary, UUID) -> Void
 
   @State private var missionName = ""
   @State private var selectedPath = ""
@@ -14,15 +13,25 @@ struct NewMissionSheet: View {
   @State private var trackerKind = "linear"
   @State private var isCreating = false
   @State private var error: String?
+  @State private var selectedEndpointId: UUID?
 
-  private var endpointId: UUID {
-    runtimeRegistry.primaryEndpointId
+  private var resolvedEndpointId: UUID {
+    selectedEndpointId
+      ?? runtimeRegistry.primaryEndpointId
       ?? runtimeRegistry.activeEndpointId
       ?? UUID()
   }
 
+  private var missionsClient: MissionsClient? {
+    runtimeRegistry.runtimesByEndpointId[resolvedEndpointId]?.clients.missions
+  }
+
   private var canCreate: Bool {
-    !missionName.isEmpty && !selectedPath.isEmpty && selectedPathIsGit && !isCreating
+    !missionName.isEmpty && !selectedPath.isEmpty && selectedPathIsGit && !isCreating && missionsClient != nil
+  }
+
+  private var availableEndpoints: [ServerRuntime] {
+    runtimeRegistry.connectedRuntimes
   }
 
   var body: some View {
@@ -66,6 +75,10 @@ struct NewMissionSheet: View {
   private var formContent: some View {
     NewSessionFormShell {
       VStack(alignment: .leading, spacing: Spacing.lg) {
+        if availableEndpoints.count > 1 {
+          endpointSection
+        }
+
         nameSection
 
         directorySection
@@ -97,6 +110,50 @@ struct NewMissionSheet: View {
     }
   }
 
+  // MARK: - Endpoint Section
+
+  private var endpointSection: some View {
+    VStack(alignment: .leading, spacing: Spacing.sm) {
+      Text("Server")
+        .font(.system(size: TypeScale.caption, weight: .semibold))
+        .foregroundStyle(Color.textPrimary)
+
+      HStack(spacing: Spacing.sm) {
+        ForEach(availableEndpoints, id: \.endpoint.id) { runtime in
+          let isSelected = runtime.endpoint.id == resolvedEndpointId
+          Button {
+            selectedEndpointId = runtime.endpoint.id
+            // Reset path when switching endpoints since repos differ per server
+            selectedPath = ""
+            selectedPathIsGit = false
+          } label: {
+            HStack(spacing: Spacing.sm_) {
+              Image(systemName: "server.rack")
+                .font(.system(size: IconScale.sm, weight: .semibold))
+              Text(runtime.endpoint.name)
+                .font(.system(size: TypeScale.caption, weight: .medium))
+            }
+            .foregroundStyle(isSelected ? Color.accent : Color.textSecondary)
+            .padding(.horizontal, Spacing.md)
+            .padding(.vertical, Spacing.sm)
+            .background(
+              RoundedRectangle(cornerRadius: Radius.sm, style: .continuous)
+                .fill(isSelected ? Color.accent.opacity(OpacityTier.light) : Color.backgroundTertiary)
+                .overlay(
+                  RoundedRectangle(cornerRadius: Radius.sm, style: .continuous)
+                    .strokeBorder(
+                      isSelected ? Color.accent.opacity(OpacityTier.medium) : .clear,
+                      lineWidth: 1
+                    )
+                )
+            )
+          }
+          .buttonStyle(.plain)
+        }
+      }
+    }
+  }
+
   private var nameSection: some View {
     VStack(alignment: .leading, spacing: Spacing.sm) {
       Text("Mission Name")
@@ -125,13 +182,13 @@ struct NewMissionSheet: View {
       RemoteProjectPicker(
         selectedPath: $selectedPath,
         selectedPathIsGit: $selectedPathIsGit,
-        endpointId: endpointId
+        endpointId: resolvedEndpointId
       )
     #else
       ProjectPicker(
         selectedPath: $selectedPath,
         selectedPathIsGit: $selectedPathIsGit,
-        endpointId: endpointId
+        endpointId: resolvedEndpointId
       )
     #endif
   }
@@ -267,6 +324,7 @@ struct NewMissionSheet: View {
   // MARK: - Actions
 
   private func createMission() async {
+    guard let missionsClient else { return }
     isCreating = true
     error = nil
 
@@ -279,7 +337,7 @@ struct NewMissionSheet: View {
         trackerKind: trackerKind,
         provider: providerString
       )
-      onCreated(mission)
+      onCreated(mission, resolvedEndpointId)
       dismiss()
     } catch {
       self.error = error.localizedDescription


### PR DESCRIPTION
## Summary

- Missions can now be created on and managed from any connected server endpoint, enabling multi-machine setups (e.g., running missions from a MacBook Air while controlling from the main Mac)
- Added `AggregatedMissionSummary` model and mission aggregation in `ServerRuntimeRegistry`, following the same pattern used for session aggregation
- `NewMissionSheet` now shows an endpoint picker when multiple servers are connected, resetting the project path when switching endpoints since repos differ per server
- Mission list and detail views show endpoint badges when multi-server is active
- Fixed `MissionWorktreeCleanupSheet` frame constraint build error

## Test plan

- [ ] Connect to a single server endpoint — missions should work exactly as before (no endpoint badges, no picker)
- [ ] Connect to two server endpoints — verify endpoint picker appears in New Mission sheet
- [ ] Create a mission targeting a specific endpoint — verify it appears in the aggregated list with the correct endpoint badge
- [ ] Verify mission detail view shows "@ ServerName" in the header tags when multi-server
- [ ] Verify real-time updates (WebSocket missionsList/missionDelta) flow correctly for both endpoints
- [ ] Open worktree cleanup sheet and verify the frame constraint is correct