### PR TITLE
🐛 Fix passive session ending across platforms

### DIFF
--- a/OrbitDockNative/OrbitDock/Services/Server/ServerRuntimeRegistry.swift
+++ b/OrbitDockNative/OrbitDock/Services/Server/ServerRuntimeRegistry.swift
@@ -622,6 +622,8 @@ final class ServerRuntimeRegistry {
             self.sessionsByEndpoint[endpointId]?[scopedID] = existing.ended(reason: reason)
             self.recomputeAggregatedSessions()
           }
+          self.dashboardConversationsByEndpoint[endpointId]?[scopedID] = nil
+          self.recomputeAggregatedDashboardConversations()
 
         case let .missionsList(missions):
           let endpointName = runtime.endpoint.name

--- a/OrbitDockNative/OrbitDock/Views/Dashboard/Scene/MissionControlCommandDeck.swift
+++ b/OrbitDockNative/OrbitDock/Views/Dashboard/Scene/MissionControlCommandDeck.swift
@@ -803,7 +803,7 @@ private struct DashboardConversationActionsModifier: ViewModifier {
           Button(role: .destructive) {
             Task { await endConversation() }
           } label: {
-            Label("End Conversation", systemImage: "stop.circle")
+            Label("End Session", systemImage: "stop.circle")
           }
         }
       }

--- a/OrbitDockNative/OrbitDock/Views/Dashboard/Shared/FlatSessionRow.swift
+++ b/OrbitDockNative/OrbitDock/Views/Dashboard/Shared/FlatSessionRow.swift
@@ -104,7 +104,7 @@ struct FlatSessionRow: View {
         Label("Copy Resume Command", systemImage: "doc.on.doc")
       }
 
-      if session.isActive, session.isDirect {
+      if session.isActive {
         Divider()
         Button(role: .destructive) {
           Task { try? await endSession() }

--- a/OrbitDockNative/OrbitDock/Views/Dashboard/Stream/ActivityStreamCard.swift
+++ b/OrbitDockNative/OrbitDock/Views/Dashboard/Stream/ActivityStreamCard.swift
@@ -190,7 +190,7 @@ struct AttentionCard: View {
     .buttonStyle(.plain)
     .onHover { isHovering = $0 }
     .contextMenu { SessionCardHelpers.baseContextMenu(for: session)
-      if session.isActive, session.isDirect {
+      if session.isActive {
         Divider()
         Button(role: .destructive) {
           Task { await endSession() }
@@ -345,7 +345,7 @@ struct WorkingCard: View {
     .buttonStyle(.plain)
     .onHover { isHovering = $0 }
     .contextMenu { SessionCardHelpers.baseContextMenu(for: session)
-      if session.isActive, session.isDirect {
+      if session.isActive {
         Divider()
         Button(role: .destructive) {
           Task { await endSession() }
@@ -411,7 +411,7 @@ struct CompactSessionRow: View {
     .buttonStyle(.plain)
     .onHover { isHovering = $0 }
     .contextMenu { SessionCardHelpers.baseContextMenu(for: session)
-      if session.isActive, session.isDirect {
+      if session.isActive {
         Divider()
         Button(role: .destructive) {
           Task { await endSession() }

--- a/OrbitDockNative/OrbitDock/Views/QuickSwitcher/QuickSwitcherCommandCatalog.swift
+++ b/OrbitDockNative/OrbitDock/Views/QuickSwitcher/QuickSwitcherCommandCatalog.swift
@@ -80,7 +80,7 @@ enum QuickSwitcherCommandCatalog {
       ),
       QuickSwitcherCommand(
         id: "close",
-        name: "Close Session",
+        name: "End Session",
         icon: "xmark.circle",
         shortcut: nil,
         requiresSession: true,

--- a/OrbitDockNative/OrbitDock/Views/QuickSwitcher/QuickSwitcherSessionRow.swift
+++ b/OrbitDockNative/OrbitDock/Views/QuickSwitcher/QuickSwitcherSessionRow.swift
@@ -92,7 +92,7 @@ struct QuickSwitcherSessionRow: View {
             quickSwitcherActionButton(icon: "pencil", tooltip: "Rename", action: onRename)
             quickSwitcherActionButton(icon: "doc.on.doc", tooltip: "Copy Resume", action: onCopyResume)
             if let onClose {
-              quickSwitcherActionButton(icon: "xmark.circle", tooltip: "Close Session", action: onClose)
+              quickSwitcherActionButton(icon: "xmark.circle", tooltip: "End Session", action: onClose)
             }
           }
           .transition(.opacity.combined(with: .scale(scale: 0.9)))
@@ -133,7 +133,7 @@ struct QuickSwitcherSessionRow: View {
       if let onClose {
         Divider()
         Button(role: .destructive, action: onClose) {
-          Label("Close Session", systemImage: "xmark.circle")
+          Label("End Session", systemImage: "xmark.circle")
         }
       }
     })

--- a/OrbitDockNative/OrbitDock/Views/SessionDetail/Header/HeaderView.swift
+++ b/OrbitDockNative/OrbitDock/Views/SessionDetail/Header/HeaderView.swift
@@ -220,7 +220,7 @@ struct HeaderView: View {
     Menu {
       HeaderContinuationMenuSection(continuation: currentContinuation)
 
-      if presentation.isDirect, presentation.isActive, let onEnd = onEndSession {
+      if presentation.isActive, let onEnd = onEndSession {
         Divider()
         Button(role: .destructive) {
           onEnd()
@@ -261,7 +261,7 @@ struct HeaderView: View {
 
       HeaderContinuationMenuSection(continuation: currentContinuation)
 
-      if presentation.isDirect, presentation.isActive, let onEnd = onEndSession {
+      if presentation.isActive, let onEnd = onEndSession {
         Divider()
         Button(role: .destructive) {
           onEnd()

--- a/OrbitDockNative/OrbitDock/Views/SessionDetail/SessionDetailView.swift
+++ b/OrbitDockNative/OrbitDock/Views/SessionDetail/SessionDetailView.swift
@@ -44,7 +44,7 @@ struct SessionDetailView: View {
           endpointId: endpointId,
           presentation: screenPresentation,
           codexAccountStatus: scopedServerState.codexAccountStatus,
-          onEndSession: screenPresentation.isDirect ? { viewModel.endDirectSession() } : nil,
+          onEndSession: screenPresentation.isActive ? { viewModel.endSession() } : nil,
           layoutConfig: screenPresentation.isDirect ? $viewModel.layoutConfig : nil,
           chatViewMode: $chatViewMode,
           workerPanelVisible: $showWorkerPanel,
@@ -245,10 +245,10 @@ struct SessionDetailView: View {
           claudeIntegrationMode: screenPresentation.debugContext.claudeIntegrationMode
         )
 
-        if screenPresentation.isDirect, screenPresentation.isActive {
+        if screenPresentation.isActive {
           Divider()
           Button(role: .destructive) {
-            viewModel.endDirectSession()
+            viewModel.endSession()
           } label: {
             Label("End Session", systemImage: "stop.circle")
           }

--- a/OrbitDockNative/OrbitDock/Views/SessionDetail/SessionDetailViewModel.swift
+++ b/OrbitDockNative/OrbitDock/Views/SessionDetail/SessionDetailViewModel.swift
@@ -354,7 +354,7 @@ final class SessionDetailViewModel {
     }
   }
 
-  func endDirectSession() {
+  func endSession() {
     Task { try? await sessionStore.endSession(sessionId) }
   }
 

--- a/orbitdock-server/crates/server/src/runtime/session_registry.rs
+++ b/orbitdock-server/crates/server/src/runtime/session_registry.rs
@@ -354,6 +354,9 @@ impl SessionRegistry {
         let mut conversations: Vec<DashboardConversationItem> = self
             .sessions
             .iter()
+            .filter(|entry| {
+                entry.value().snapshot().status == orbitdock_protocol::SessionStatus::Active
+            })
             .map(|entry| {
                 let snap = entry.value().snapshot();
                 let display_title = SessionSummary::display_title_from_parts(
@@ -671,7 +674,9 @@ fn dashboard_diff_preview(diff: Option<&str>) -> Option<DashboardDiffPreview> {
 #[cfg(test)]
 mod tests {
     use super::SessionRegistry;
+    use crate::domain::sessions::session::SessionHandle;
     use crate::support::test_support::ensure_server_test_data_dir;
+    use orbitdock_protocol::{CodexIntegrationMode, Provider, SessionStatus, WorkStatus};
     use tokio::sync::mpsc;
 
     #[test]
@@ -684,5 +689,37 @@ mod tests {
         assert!(registry.clear_client_primary_claim(1));
         assert!(registry.active_client_primary_claims().is_empty());
         assert!(!registry.clear_client_primary_claim(1));
+    }
+
+    #[tokio::test]
+    async fn dashboard_conversations_only_include_active_sessions() {
+        ensure_server_test_data_dir();
+        let (persist_tx, _persist_rx) = mpsc::channel(8);
+        let registry = SessionRegistry::new_with_primary(persist_tx, true);
+
+        let mut active = SessionHandle::new(
+            "active-session".to_string(),
+            Provider::Codex,
+            "/tmp/orbitdock-active".to_string(),
+        );
+        active.set_codex_integration_mode(Some(CodexIntegrationMode::Passive));
+        active.set_work_status(WorkStatus::Waiting);
+        active.refresh_snapshot();
+        registry.add_session(active);
+
+        let mut ended = SessionHandle::new(
+            "ended-session".to_string(),
+            Provider::Codex,
+            "/tmp/orbitdock-ended".to_string(),
+        );
+        ended.set_codex_integration_mode(Some(CodexIntegrationMode::Passive));
+        ended.set_status(SessionStatus::Ended);
+        ended.set_work_status(WorkStatus::Ended);
+        ended.refresh_snapshot();
+        registry.add_session(ended);
+
+        let conversations = registry.get_dashboard_conversations();
+        assert_eq!(conversations.len(), 1);
+        assert_eq!(conversations[0].session_id, "active-session");
     }
 }


### PR DESCRIPTION
## Summary
- expose end session actions for active passive sessions across dashboard, quick switcher, and session detail surfaces
- remove ended sessions from the dock immediately on session end events
- keep the dashboard conversation feed active-only so passive sessions do not reappear after refresh

## Verification
- make rust-test
- make test-unit *(currently blocked by unrelated Swift 6 actor-isolation issues in existing markdown parser/tests)*