### PR TITLE
🐛 Fix Claude permission mode drift between session state and web UI

### DIFF
--- a/orbitdock-web/src/components/input/message-composer.jsx
+++ b/orbitdock-web/src/components/input/message-composer.jsx
@@ -512,8 +512,8 @@ const MessageComposer = ({
   isEnded,
   isConnected,
   provider,
-  approvalPolicy,
-  onApprovalPolicyChange,
+  permissionMode,
+  onPermissionModeChange,
   projectPath,
   skills,
   session,
@@ -1146,22 +1146,30 @@ const MessageComposer = ({
                   Disconnected
                 </span>
               )}
-              {provider === 'claude' && approvalPolicy && (
+              {provider === 'claude' && permissionMode && (
                 <button
                   type="button"
                   class={`${styles.statusItem} ${styles.statusPill} ${styles.statusPillClickable}`}
                   onClick={
-                    onApprovalPolicyChange
+                    onPermissionModeChange
                       ? () => {
-                          const policies = ['ask', 'auto-edit', 'auto-full']
-                          const idx = policies.indexOf(approvalPolicy)
-                          onApprovalPolicyChange(policies[(idx + 1) % policies.length])
+                          const modes = ['default', 'plan', 'acceptEdits', 'bypassPermissions']
+                          const idx = modes.indexOf(permissionMode)
+                          onPermissionModeChange(modes[(idx + 1) % modes.length])
                         }
                       : undefined
                   }
                   title="Click to cycle permission mode"
                 >
-                  {approvalPolicy === 'ask' ? 'Ask' : approvalPolicy === 'auto-edit' ? 'Auto-Edit' : 'Auto-Full'}
+                  {permissionMode === 'plan'
+                    ? 'Plan Mode'
+                    : permissionMode === 'acceptEdits'
+                      ? 'Accept Edits'
+                      : permissionMode === 'bypassPermissions'
+                        ? 'Bypass'
+                        : permissionMode === 'dontAsk'
+                          ? "Don't Ask"
+                          : 'Default'}
                 </button>
               )}
               {tokenInfo && (

--- a/orbitdock-web/src/components/input/provider-controls.jsx
+++ b/orbitdock-web/src/components/input/provider-controls.jsx
@@ -44,20 +44,21 @@ const CodexEffortPicker = ({ value, onChange }) => (
 )
 
 // ---------------------------------------------------------------------------
-// Claude permission policy picker
+// Claude permission mode picker
 // ---------------------------------------------------------------------------
 
-const POLICY_OPTIONS = [
-  { value: 'ask', label: 'Ask', description: 'Ask before every tool call' },
-  { value: 'auto-edit', label: 'Auto-Edit', description: 'Auto-approve file edits' },
-  { value: 'auto-full', label: 'Auto-Full', description: 'Auto-approve everything' },
+const PERMISSION_MODE_OPTIONS = [
+  { value: 'default', label: 'Default', description: 'Normal permission checking' },
+  { value: 'plan', label: 'Plan', description: 'Plan mode — propose changes without executing' },
+  { value: 'acceptEdits', label: 'Accept Edits', description: 'Auto-approve file edits' },
+  { value: 'bypassPermissions', label: 'Bypass', description: 'Bypass all permission checks' },
 ]
 
 const ClaudePermissionPicker = ({ value, onChange }) => (
   <div class={styles.control}>
     <span class={styles.label}>Permissions</span>
     <SegmentedControl
-      options={POLICY_OPTIONS}
+      options={PERMISSION_MODE_OPTIONS}
       value={value}
       onChange={onChange}
       colorVar="var(--color-provider-claude)"
@@ -69,13 +70,13 @@ const ClaudePermissionPicker = ({ value, onChange }) => (
 // ProviderControls — renders the right control based on provider
 // ---------------------------------------------------------------------------
 
-const ProviderControls = ({ provider, effort, onEffortChange, approvalPolicy, onApprovalPolicyChange }) => {
+const ProviderControls = ({ provider, effort, onEffortChange, permissionMode, onPermissionModeChange }) => {
   if (provider === 'codex') {
     return <CodexEffortPicker value={effort} onChange={onEffortChange} />
   }
 
   if (provider === 'claude') {
-    return <ClaudePermissionPicker value={approvalPolicy} onChange={onApprovalPolicyChange} />
+    return <ClaudePermissionPicker value={permissionMode} onChange={onPermissionModeChange} />
   }
 
   return null

--- a/orbitdock-web/src/pages/session.jsx
+++ b/orbitdock-web/src/pages/session.jsx
@@ -49,8 +49,8 @@ const SessionPage = () => {
   // Pending: true between send and the first WS user row that confirms receipt.
   const [isPending, setIsPending] = useState(false)
 
-  // Claude approval policy — initialised from session once it loads.
-  const [approvalPolicy, setApprovalPolicy] = useState('ask')
+  // Claude permission mode — initialised from session once it loads, updated via store deltas.
+  const [permissionMode, setPermissionMode] = useState('default')
 
   // Token usage from tokens_updated WS events.
   const [tokenUsage, setTokenUsage] = useState(null)
@@ -198,12 +198,13 @@ const SessionPage = () => {
     }
   }, [sessionId])
 
-  // Seed the local approval policy from the session object whenever the
+  // Seed the local permission mode from the session object whenever the
   // session loads or changes (e.g. navigating between sessions).
+  // The store is updated by WS session_delta events, so this stays in sync.
   useEffect(() => {
-    const policy = selected.value?.approval_policy
-    if (policy) setApprovalPolicy(policy)
-  }, [sessionId, selected.value?.approval_policy])
+    const mode = selected.value?.permission_mode
+    if (mode) setPermissionMode(mode)
+  }, [sessionId, selected.value?.permission_mode])
 
   if (!sessionId) return null
   if (isBootstrapping) return <SessionSkeleton />
@@ -225,12 +226,12 @@ const SessionPage = () => {
     })
   }
 
-  const handleApprovalPolicyChange = (policy) => {
-    const previousPolicy = approvalPolicy
-    setApprovalPolicy(policy)
-    http.patch(`/api/sessions/${sessionId}/config`, { approval_policy: policy }).catch((err) => {
-      console.warn('[session] approval policy update failed:', err.message)
-      setApprovalPolicy(previousPolicy)
+  const handlePermissionModeChange = (mode) => {
+    const previousMode = permissionMode
+    setPermissionMode(mode)
+    http.patch(`/api/sessions/${sessionId}/config`, { permission_mode: mode }).catch((err) => {
+      console.warn('[session] permission mode update failed:', err.message)
+      setPermissionMode(previousMode)
     })
   }
 
@@ -494,8 +495,8 @@ const SessionPage = () => {
           isEnded={isEnded}
           isConnected={connectionState.value === 'connected'}
           provider={session?.provider}
-          approvalPolicy={approvalPolicy}
-          onApprovalPolicyChange={handleApprovalPolicyChange}
+          permissionMode={permissionMode}
+          onPermissionModeChange={handlePermissionModeChange}
           projectPath={session?.project_path || session?.repository_root}
           skills={liveSkills}
           session={session}

--- a/orbitdock-web/src/stores/sessions.js
+++ b/orbitdock-web/src/stores/sessions.js
@@ -54,6 +54,7 @@ const handleSessionDelta = (sessionId, changes) => {
     updated.git_branch = changes.git_branch
     updated.branch = changes.git_branch
   }
+  if (changes.permission_mode !== undefined) updated.permission_mode = changes.permission_mode
   // Recompute display_title when the underlying name fields change
   if (changes.custom_name !== undefined || changes.summary !== undefined || changes.first_prompt !== undefined) {
     updated.display_title = updated.custom_name || updated.summary || updated.first_prompt || updated.display_title

--- a/orbitdock-web/tests/stores/sessions.test.js
+++ b/orbitdock-web/tests/stores/sessions.test.js
@@ -42,6 +42,24 @@ describe('sessions store', () => {
       handleSessionDelta('s1', { work_status: 'reply' })
       assert.strictEqual(sessions.value.get('s1').work_status, 'reply')
     })
+
+    it('applies permission_mode from delta', () => {
+      handleSessionsList([{ id: 's1', status: 'active', work_status: 'working', permission_mode: 'default' }])
+      handleSessionDelta('s1', { permission_mode: 'plan' })
+      assert.strictEqual(sessions.value.get('s1').permission_mode, 'plan')
+    })
+
+    it('clears permission_mode when delta sets null', () => {
+      handleSessionsList([{ id: 's1', status: 'active', work_status: 'working', permission_mode: 'plan' }])
+      handleSessionDelta('s1', { permission_mode: null })
+      assert.strictEqual(sessions.value.get('s1').permission_mode, null)
+    })
+
+    it('preserves permission_mode when delta does not include it', () => {
+      handleSessionsList([{ id: 's1', status: 'active', work_status: 'working', permission_mode: 'acceptEdits' }])
+      handleSessionDelta('s1', { work_status: 'reply' })
+      assert.strictEqual(sessions.value.get('s1').permission_mode, 'acceptEdits')
+    })
   })
 
   describe('handleSessionEnded', () => {
@@ -117,6 +135,19 @@ describe('sessions store', () => {
       const session = sessions.value.get('sess-1')
       assert.strictEqual(session.branch, 'feature/resume-fix')
       assert.strictEqual(session.git_branch, 'feature/resume-fix')
+    })
+
+    it('applies permission_mode from resume summary', () => {
+      handleSessionsList([endedSession()])
+
+      applyResumeSummary('sess-1', {
+        id: 'sess-1',
+        status: 'active',
+        work_status: 'working',
+        permission_mode: 'acceptEdits',
+      })
+
+      assert.strictEqual(sessions.value.get('sess-1').permission_mode, 'acceptEdits')
     })
   })
 })


### PR DESCRIPTION
## Summary

- The web UI was using `approvalPolicy` (Codex concept: `ask`/`auto-edit`/`auto-full`) to display Claude's permission mode pill, instead of the actual `permission_mode` (`default`/`plan`/`acceptEdits`/`bypassPermissions`/`dontAsk`) that the server already emits
- When Claude entered plan mode during a live session, the status pill would still show the old approval policy value — users couldn't tell which mode was actually active
- The server contract was already correct (emits `permission_mode` in both REST `SessionState` and WS `SessionDelta`), but the web frontend never consumed it

## Changes

- **`stores/sessions.js`** — Add `permission_mode` to `handleSessionDelta` so WS delta updates flow into the session store
- **`pages/session.jsx`** — Replace `approvalPolicy` local state with `permissionMode` seeded from `selected.value?.permission_mode` (updated via store deltas); PATCH `/api/sessions/:id/config` now sends `permission_mode` instead of `approval_policy`
- **`components/input/message-composer.jsx`** — Status pill now renders Claude permission modes with correct labels (Plan Mode, Default, Accept Edits, Bypass, Don't Ask) and cycles through real modes on click
- **`components/input/provider-controls.jsx`** — `ClaudePermissionPicker` options updated to match real Claude permission modes
- **`tests/stores/sessions.test.js`** — 4 new tests covering permission_mode delta application, null-clear, preservation when absent, and resume propagation

## What didn't change

- **No server changes** — the server already models permission_mode correctly through the connector event system, persistence, and broadcasts
- **No native (Swift) changes** — the Swift client already uses `permissionMode` throughout (reducer, store events, `ClaudePermissionPill` UI)

## Test plan

- [x] All 85 web unit tests pass (including 4 new permission_mode tests)
- [x] Lint passes on all changed files (0 new errors)
- [ ] Manual: start a Claude session, enter plan mode → verify the status pill updates to "Plan Mode"
- [ ] Manual: exit plan mode → verify the pill returns to the correct active mode
- [ ] Manual: reconnect/resume a session → verify the pill shows the correct current mode

Closes #135