### PR TITLE
🔬 Add Sparkle update channels and nightly macOS release publishing

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,98 @@
+name: Nightly macOS Release
+
+on:
+  schedule:
+    - cron: '0 6 * * *' # Daily at 06:00 UTC
+  workflow_dispatch:
+
+env:
+  APP_NAME: OrbitDock
+  CHANNEL: nightly
+
+permissions:
+  contents: write
+
+concurrency:
+  group: nightly-release
+  cancel-in-progress: true
+
+jobs:
+  nightly:
+    runs-on: macos-15
+    timeout-minutes: 45
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Xcode
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: '16.3'
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Compute nightly version
+        id: version
+        run: |
+          LATEST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "v0.0.0")
+          BASE_VERSION="${LATEST_TAG#v}"
+          DATE_STAMP=$(date -u +%Y%m%d)
+          NIGHTLY_VERSION="${BASE_VERSION}-nightly.${DATE_STAMP}"
+          BUILD_NUMBER="${DATE_STAMP}01"
+          echo "version=$NIGHTLY_VERSION" >> $GITHUB_OUTPUT
+          echo "build_number=$BUILD_NUMBER" >> $GITHUB_OUTPUT
+          echo "Nightly version: $NIGHTLY_VERSION (build $BUILD_NUMBER)"
+
+      - name: Set Xcode version numbers
+        run: |
+          cd OrbitDockNative
+          agvtool new-marketing-version "${{ steps.version.outputs.version }}"
+          agvtool new-version -all "${{ steps.version.outputs.build_number }}"
+
+      - name: Archive, notarize, and package
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+          CHANNEL: nightly
+          SPARKLE_PUBLIC_ED_KEY: ${{ secrets.SPARKLE_PUBLIC_ED_KEY }}
+          MACOS_DEVELOPMENT_TEAM: ${{ secrets.MACOS_DEVELOPMENT_TEAM }}
+          APPLE_NOTARY_KEY_ID: ${{ secrets.APPLE_NOTARY_KEY_ID }}
+          APPLE_NOTARY_ISSUER_ID: ${{ secrets.APPLE_NOTARY_ISSUER_ID }}
+          APPLE_NOTARY_PRIVATE_KEY: ${{ secrets.APPLE_NOTARY_PRIVATE_KEY }}
+        run: ./scripts/archive-macos-app-release.sh
+
+      - name: Generate nightly appcast
+        env:
+          SITE_DIR: ${{ github.workspace }}/dist
+          RELEASE_TAG: nightly
+          CHANNEL: nightly
+          SPARKLE_PRIVATE_ED_KEY: ${{ secrets.SPARKLE_PRIVATE_ED_KEY }}
+          DOWNLOAD_URL_PREFIX: https://github.com/${{ github.repository }}/releases/download/nightly/
+        run: ./scripts/generate-sparkle-appcast.sh
+
+      - name: Publish to nightly release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+
+          # Delete existing nightly release/tag if present
+          gh release delete nightly --yes 2>/dev/null || true
+          git push origin :refs/tags/nightly 2>/dev/null || true
+
+          # Create fresh nightly prerelease
+          gh release create nightly \
+            --title "$APP_NAME Nightly ($VERSION)" \
+            --notes "Automated nightly build from \`main\` at $(date -u +%Y-%m-%d).
+
+          **Version:** $VERSION
+          **Commit:** ${{ github.sha }}
+
+          > Nightly builds may be unstable. Use Stable or Beta channels for production." \
+            --prerelease \
+            dist/${APP_NAME}-${VERSION}.zip \
+            dist/${APP_NAME}-${VERSION}.zip.sha256 \
+            dist/appcast-nightly.xml

--- a/OrbitDockNative/OrbitDock/OrbitDockApp.swift
+++ b/OrbitDockNative/OrbitDock/OrbitDockApp.swift
@@ -55,7 +55,7 @@ struct OrbitDockApp: App {
       }
 
       Settings {
-        SettingsView()
+        SettingsView(appUpdater: appUpdater)
           .environment(\.serverManager, appRuntime.serverManager)
           .environment(appRuntime.runtimeRegistry.activeSessionStore)
           .environment(\.modelPricingService, modelPricingService)

--- a/OrbitDockNative/OrbitDock/Services/AppUpdate/AppUpdater.swift
+++ b/OrbitDockNative/OrbitDock/Services/AppUpdate/AppUpdater.swift
@@ -3,12 +3,81 @@ import Foundation
 #if os(macOS)
   import Sparkle
 
+  enum UpdateChannel: String, CaseIterable, Identifiable {
+    case stable
+    case beta
+    case nightly
+
+    var id: String { rawValue }
+
+    var displayName: String {
+      switch self {
+        case .stable: "Stable"
+        case .beta: "Beta"
+        case .nightly: "Nightly"
+      }
+    }
+
+    var description: String {
+      switch self {
+        case .stable:
+          "Production releases only."
+        case .beta:
+          "Pre-release builds for testing upcoming features."
+        case .nightly:
+          "Latest automated builds — may be unstable."
+      }
+    }
+
+    /// Sparkle channel identifiers sent via `allowedChannels(for:)`.
+    /// Stable returns empty (matches items with no channel tag).
+    var sparkleChannels: Set<String> {
+      switch self {
+        case .stable: []
+        case .beta: ["beta"]
+        case .nightly: ["nightly"]
+      }
+    }
+
+    /// The appcast filename for this channel.
+    var appcastFilename: String {
+      switch self {
+        case .stable: "appcast.xml"
+        case .beta: "appcast-beta.xml"
+        case .nightly: "appcast-nightly.xml"
+      }
+    }
+
+    /// Feed URL for this channel on GitHub Releases.
+    func feedURL(owner: String = "Robdel12", repo: String = "OrbitDock") -> URL? {
+      let base = "https://github.com/\(owner)/\(repo)/releases"
+      let urlString: String
+      switch self {
+        case .stable:
+          urlString = "\(base)/latest/download/\(appcastFilename)"
+        case .beta:
+          urlString = "\(base)/latest/download/\(appcastFilename)"
+        case .nightly:
+          urlString = "\(base)/download/nightly/\(appcastFilename)"
+      }
+      return URL(string: urlString)
+    }
+  }
+
   @MainActor
   @Observable
   final class AppUpdater {
     private(set) var isConfigured: Bool
 
+    var selectedChannel: UpdateChannel {
+      didSet {
+        UserDefaults.standard.set(selectedChannel.rawValue, forKey: "updateChannel")
+        applyChannelFeedURL()
+      }
+    }
+
     @ObservationIgnored private let updaterController: SPUStandardUpdaterController?
+    @ObservationIgnored private let updaterDelegate: AppUpdaterDelegate?
     @ObservationIgnored private var hasStarted = false
 
     init(bundle: Bundle = .main) {
@@ -17,13 +86,20 @@ import Foundation
       let isConfigured = !feedURL.isEmpty && !publicKey.isEmpty
       self.isConfigured = isConfigured
 
+      let storedChannel = UserDefaults.standard.string(forKey: "updateChannel") ?? "stable"
+      let channel = UpdateChannel(rawValue: storedChannel) ?? .stable
+      self.selectedChannel = channel
+
       if isConfigured {
+        let delegate = AppUpdaterDelegate(channel: channel)
+        self.updaterDelegate = delegate
         updaterController = SPUStandardUpdaterController(
           startingUpdater: false,
-          updaterDelegate: nil,
+          updaterDelegate: delegate,
           userDriverDelegate: nil
         )
       } else {
+        self.updaterDelegate = nil
         updaterController = nil
       }
     }
@@ -34,6 +110,7 @@ import Foundation
 
     func start() {
       guard !hasStarted, let updaterController else { return }
+      applyChannelFeedURL()
       hasStarted = true
       updaterController.startUpdater()
     }
@@ -43,11 +120,34 @@ import Foundation
       updaterController.checkForUpdates(nil)
     }
 
+    private func applyChannelFeedURL() {
+      updaterDelegate?.channel = selectedChannel
+    }
+
     private static func infoString(_ key: String, bundle: Bundle) -> String {
       guard let value = bundle.object(forInfoDictionaryKey: key) as? String else {
         return ""
       }
       return value.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+  }
+
+  // MARK: - Sparkle Delegate
+
+  final class AppUpdaterDelegate: NSObject, SPUUpdaterDelegate {
+    var channel: UpdateChannel
+
+    init(channel: UpdateChannel) {
+      self.channel = channel
+      super.init()
+    }
+
+    func allowedChannels(for updater: SPUUpdater) -> Set<String> {
+      channel.sparkleChannels
+    }
+
+    func feedURLString(for updater: SPUUpdater) -> String? {
+      channel.feedURL()?.absoluteString
     }
   }
 #endif

--- a/OrbitDockNative/OrbitDock/Views/Settings/SettingsGeneralView.swift
+++ b/OrbitDockNative/OrbitDock/Views/Settings/SettingsGeneralView.swift
@@ -1,11 +1,25 @@
 import SwiftUI
 
 struct GeneralSettingsView: View {
+  #if os(macOS)
+    let appUpdater: AppUpdater?
+  #endif
   @State private var openAiNamingModel = SettingsOpenAiNamingModel()
+
+  #if os(macOS)
+    init(appUpdater: AppUpdater? = nil) {
+      self.appUpdater = appUpdater
+    }
+  #endif
 
   var body: some View {
     ScrollView {
       VStack(spacing: Spacing.xl) {
+        #if os(macOS)
+          if let appUpdater {
+            SettingsUpdateChannelSection(appUpdater: appUpdater)
+          }
+        #endif
         SettingsEditorPreferencesSection()
         SettingsOpenAiNamingSection(model: openAiNamingModel)
         SettingsDictationSection()

--- a/OrbitDockNative/OrbitDock/Views/Settings/SettingsUpdateChannelSection.swift
+++ b/OrbitDockNative/OrbitDock/Views/Settings/SettingsUpdateChannelSection.swift
@@ -1,0 +1,50 @@
+import SwiftUI
+
+#if os(macOS)
+  struct SettingsUpdateChannelSection: View {
+    @Bindable var appUpdater: AppUpdater
+
+    var body: some View {
+      SettingsSection(title: "UPDATES", icon: "arrow.triangle.2.circlepath") {
+        VStack(alignment: .leading, spacing: Spacing.lg_) {
+          VStack(alignment: .leading, spacing: Spacing.sm_) {
+            HStack {
+              Text("Update Channel")
+                .font(.system(size: TypeScale.body))
+
+              Spacer()
+
+              Picker("", selection: $appUpdater.selectedChannel) {
+                ForEach(UpdateChannel.allCases) { channel in
+                  Text(channel.displayName).tag(channel)
+                }
+              }
+              .pickerStyle(.menu)
+              .frame(width: 140)
+              .tint(Color.accent)
+            }
+
+            Text(appUpdater.selectedChannel.description)
+              .font(.system(size: TypeScale.meta))
+              .foregroundStyle(Color.textTertiary)
+          }
+
+          if appUpdater.selectedChannel != .stable {
+            Divider()
+              .foregroundStyle(Color.panelBorder)
+
+            HStack(spacing: Spacing.sm) {
+              Image(systemName: "exclamationmark.triangle")
+                .foregroundStyle(Color.statusPermission)
+              Text(
+                "Non-stable channels may include incomplete features or breaking changes."
+              )
+              .font(.system(size: TypeScale.meta))
+              .foregroundStyle(Color.textTertiary)
+            }
+          }
+        }
+      }
+    }
+  }
+#endif

--- a/OrbitDockNative/OrbitDock/Views/Settings/SettingsView.swift
+++ b/OrbitDockNative/OrbitDock/Views/Settings/SettingsView.swift
@@ -39,7 +39,7 @@ private enum SettingsPane: String, CaseIterable, Identifiable {
   var subtitle: String {
     switch self {
       case .workspace:
-        "Editor, naming, and local dictation"
+        "Updates, editor, and local dictation"
       case .integrations:
         "Claude hooks and Codex account"
       case .missionControl:
@@ -78,12 +78,22 @@ struct SettingsView: View {
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
   #endif
 
+  #if os(macOS)
+    let appUpdater: AppUpdater?
+  #endif
   private let showsCloseButton: Bool
   @State private var selectedPane: SettingsPane = .workspace
 
-  init(showsCloseButton: Bool = false) {
-    self.showsCloseButton = showsCloseButton
-  }
+  #if os(macOS)
+    init(appUpdater: AppUpdater? = nil, showsCloseButton: Bool = false) {
+      self.appUpdater = appUpdater
+      self.showsCloseButton = showsCloseButton
+    }
+  #else
+    init(showsCloseButton: Bool = false) {
+      self.showsCloseButton = showsCloseButton
+    }
+  #endif
 
   private var endpointHealthSummary: SettingsEndpointHealthSummary {
     let endpointCount = runtimeRegistry.runtimes.count
@@ -271,7 +281,11 @@ struct SettingsView: View {
       Group {
         switch selectedPane {
           case .workspace:
-            GeneralSettingsView()
+            #if os(macOS)
+              GeneralSettingsView(appUpdater: appUpdater ?? nil)
+            #else
+              GeneralSettingsView()
+            #endif
           case .integrations:
             SetupSettingsView()
           case .missionControl:
@@ -319,7 +333,11 @@ struct SettingsView: View {
       Group {
         switch selectedPane {
           case .workspace:
-            GeneralSettingsView()
+            #if os(macOS)
+              GeneralSettingsView(appUpdater: appUpdater ?? nil)
+            #else
+              GeneralSettingsView()
+            #endif
           case .integrations:
             SetupSettingsView()
           case .missionControl:
@@ -339,8 +357,16 @@ struct SettingsView: View {
 
 // MARK: - Preview
 
-#Preview {
-  let preview = PreviewRuntime(scenario: .settings)
-  preview.inject(SettingsView())
-    .preferredColorScheme(.dark)
-}
+#if os(macOS)
+  #Preview {
+    let preview = PreviewRuntime(scenario: .settings)
+    preview.inject(SettingsView(appUpdater: AppUpdater()))
+      .preferredColorScheme(.dark)
+  }
+#else
+  #Preview {
+    let preview = PreviewRuntime(scenario: .settings)
+    preview.inject(SettingsView())
+      .preferredColorScheme(.dark)
+  }
+#endif

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -118,18 +118,23 @@ Use `ORBITDOCK_LINUX_DOCKER_CARGO_BUILD_JOBS=<n>` to cap Docker cargo parallelis
 
 ### macOS App Releases with Sparkle
 
-OrbitDock’s macOS app now uses Sparkle with an appcast attached directly to GitHub Releases:
+OrbitDock uses Sparkle for macOS app updates with three update channels:
 
-```text
-https://github.com/Robdel12/OrbitDock/releases/latest/download/appcast.xml
-```
+| Channel | Feed URL | Publishing |
+|---------|----------|------------|
+| **Stable** | `releases/latest/download/appcast.xml` | Manual (maintainer) |
+| **Beta** | `releases/latest/download/appcast-beta.xml` | Manual (maintainer) |
+| **Nightly** | `releases/download/nightly/appcast-nightly.xml` | Automated (CI) |
 
-Current maintainer flow is fully manual:
+Users choose their update channel in **Preferences → Workspace → Updates**. The default is Stable. Each channel has its own appcast so stable users never see non-stable builds.
+
+#### Stable / Beta releases (manual)
 
 1. Archive and notarize the macOS app locally:
 
 ```bash
 VERSION=0.4.0 \
+CHANNEL=stable \
 SPARKLE_PUBLIC_ED_KEY="<public key>" \
 MACOS_DEVELOPMENT_TEAM="<team id>" \
 APPLE_NOTARY_KEY_ID="<key id>" \
@@ -138,23 +143,47 @@ APPLE_NOTARY_PRIVATE_KEY="$(cat AuthKey_ABC123XYZ.p8)" \
 ./scripts/archive-macos-app-release.sh
 ```
 
+Set `CHANNEL=beta` for beta releases. This compiles the matching feed URL into the binary.
+
 2. Upload `dist/OrbitDock-<version>.zip` and `dist/OrbitDock-<version>.zip.sha256` to the matching GitHub Release.
-3. Generate `appcast.xml` locally:
+3. Generate the appcast locally:
 
 ```bash
 SITE_DIR=/tmp/orbitdock-release-assets \
 RELEASE_TAG=v0.4.0 \
+CHANNEL=stable \
 SPARKLE_PRIVATE_ED_KEY="<private key>" \
 ./scripts/generate-sparkle-appcast.sh
 ```
 
-4. Upload the generated `appcast.xml` to that same GitHub Release.
+Set `CHANNEL=beta` to generate `appcast-beta.xml` instead.
 
-Sparkle key notes:
+4. Upload the generated appcast to that same GitHub Release.
+
+#### Nightly releases (automated)
+
+The `.github/workflows/nightly.yml` workflow runs daily at 06:00 UTC (and on manual dispatch). It:
+
+1. Computes a nightly version like `0.4.0-nightly.20260324`
+2. Archives, notarizes, and signs the macOS app
+3. Generates `appcast-nightly.xml`
+4. Publishes everything to a rolling `nightly` GitHub prerelease
+
+Required repository secrets for the nightly workflow:
+
+- `SPARKLE_PUBLIC_ED_KEY` — compiled into the app
+- `SPARKLE_PRIVATE_ED_KEY` — signs the appcast
+- `MACOS_DEVELOPMENT_TEAM` — Apple team ID for code signing
+- `APPLE_NOTARY_KEY_ID` — App Store Connect API key ID
+- `APPLE_NOTARY_ISSUER_ID` — App Store Connect issuer ID
+- `APPLE_NOTARY_PRIVATE_KEY` — App Store Connect API private key (`.p8` contents)
+
+#### Sparkle key notes
 
 - `SPARKLE_PUBLIC_ED_KEY` is compiled into the app and used to verify updates.
-- `SPARKLE_PRIVATE_ED_KEY` is used to sign `appcast.xml`.
+- `SPARKLE_PRIVATE_ED_KEY` is used to sign appcast files.
 - Generate the keypair with Sparkle’s `generate_keys` tool. Export the private key for local publishing with `generate_keys -x private_key.txt`.
+- All channels share the same Sparkle keypair — the signing is per-appcast, not per-channel.
 
 ### Cloud Providers
 

--- a/scripts/archive-macos-app-release.sh
+++ b/scripts/archive-macos-app-release.sh
@@ -7,7 +7,20 @@ DIST_DIR="${DIST_DIR:-$ROOT_DIR/dist}"
 ARCHIVE_PATH="${ARCHIVE_PATH:-$DIST_DIR/OrbitDock.xcarchive}"
 APP_NAME="${APP_NAME:-OrbitDock}"
 VERSION="${VERSION:?VERSION is required}"
-SPARKLE_FEED_URL="${SPARKLE_FEED_URL:-https://github.com/Robdel12/OrbitDock/releases/latest/download/appcast.xml}"
+
+# Channel support: stable (default), beta, nightly.
+# Sets SPARKLE_FEED_URL automatically when not explicitly provided.
+CHANNEL="${CHANNEL:-stable}"
+case "$CHANNEL" in
+  stable)  _DEFAULT_FEED="https://github.com/Robdel12/OrbitDock/releases/latest/download/appcast.xml" ;;
+  beta)    _DEFAULT_FEED="https://github.com/Robdel12/OrbitDock/releases/latest/download/appcast-beta.xml" ;;
+  nightly) _DEFAULT_FEED="https://github.com/Robdel12/OrbitDock/releases/download/nightly/appcast-nightly.xml" ;;
+  *)
+    echo "error: unknown channel '$CHANNEL' (expected stable, beta, or nightly)"
+    exit 1
+    ;;
+esac
+SPARKLE_FEED_URL="${SPARKLE_FEED_URL:-$_DEFAULT_FEED}"
 SPARKLE_PUBLIC_ED_KEY="${SPARKLE_PUBLIC_ED_KEY:?SPARKLE_PUBLIC_ED_KEY is required}"
 MACOS_DEVELOPMENT_TEAM="${MACOS_DEVELOPMENT_TEAM:?MACOS_DEVELOPMENT_TEAM is required}"
 

--- a/scripts/generate-sparkle-appcast.sh
+++ b/scripts/generate-sparkle-appcast.sh
@@ -6,8 +6,21 @@ ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 SITE_DIR="${SITE_DIR:?SITE_DIR is required}"
 RELEASE_TAG="${RELEASE_TAG:?RELEASE_TAG is required}"
 SPARKLE_PRIVATE_ED_KEY="${SPARKLE_PRIVATE_ED_KEY:?SPARKLE_PRIVATE_ED_KEY is required}"
+
+# Channel support: stable (default), beta, nightly.
+# Sets APPCAST_FILENAME automatically when CHANNEL is provided.
+CHANNEL="${CHANNEL:-stable}"
+case "$CHANNEL" in
+  stable)  APPCAST_FILENAME="${APPCAST_FILENAME:-appcast.xml}" ;;
+  beta)    APPCAST_FILENAME="${APPCAST_FILENAME:-appcast-beta.xml}" ;;
+  nightly) APPCAST_FILENAME="${APPCAST_FILENAME:-appcast-nightly.xml}" ;;
+  *)
+    echo "error: unknown channel '$CHANNEL' (expected stable, beta, or nightly)"
+    exit 1
+    ;;
+esac
+
 DOWNLOAD_URL_PREFIX="${DOWNLOAD_URL_PREFIX:-https://github.com/Robdel12/OrbitDock/releases/download/${RELEASE_TAG}/}"
-APPCAST_FILENAME="${APPCAST_FILENAME:-appcast.xml}"
 
 VERSION="${RELEASE_TAG#v}"
 APP_NAME="${APP_NAME:-OrbitDock}"
@@ -43,4 +56,4 @@ printf '%s' "$SPARKLE_PRIVATE_ED_KEY" | "$SPARKLE_BIN_DIR/generate_appcast" \
   -o "$APPCAST_FILENAME" \
   "$SITE_DIR"
 
-echo "Generated $SITE_DIR/$APPCAST_FILENAME"
+echo "Generated $SITE_DIR/$APPCAST_FILENAME (channel=$CHANNEL)"


### PR DESCRIPTION
## Summary

Adds a channel-aware Sparkle update system for the macOS app with three channels: **stable**, **beta**, and **nightly**.

- **App-side channel model** — `UpdateChannel` enum with per-channel feed URLs, Sparkle channel IDs, and appcast filenames. `AppUpdaterDelegate` implements `feedURLString(for:)` and `allowedChannels(for:)` to route Sparkle to the correct feed at runtime.
- **Runtime channel selection** — Users choose their channel in Preferences → Workspace → Updates. Persisted in UserDefaults, applied immediately to Sparkle's delegate.
- **Separate appcasts** — Each channel has its own appcast file (`appcast.xml`, `appcast-beta.xml`, `appcast-nightly.xml`). Stable users never see non-stable builds.
- **Channel-aware scripts** — Both `archive-macos-app-release.sh` and `generate-sparkle-appcast.sh` accept a `CHANNEL` env var that auto-configures the correct feed URL and appcast filename.
- **Automated nightly workflow** — `.github/workflows/nightly.yml` runs daily at 06:00 UTC. Computes a date-stamped version (e.g. `0.4.0-nightly.20260324`), archives/notarizes the app, generates `appcast-nightly.xml`, and publishes to a rolling `nightly` GitHub prerelease.
- **Documentation** — Updated `docs/DEPLOYMENT.md` with the channel model, feed URLs, manual vs automated flows, and required repository secrets.

### Design decisions

- **Separate appcasts over single feed with channel tags** — Simpler, no Sparkle channel filtering needed, each feed generated independently.
- **Runtime channel switching, not build flavors** — One binary, user picks channel in preferences. The `SPUUpdaterDelegate.feedURLString(for:)` method returns the URL for the selected channel.
- **Nightly versioning** — `<base>-nightly.YYYYMMDD` with monotonically increasing build numbers. Sparkle sorts by build number, so nightlies sort correctly without breaking stable release progression.
- **macOS-only** — Beta/nightly channels are macOS-only for now. Linux/server release flows unchanged.

### Required secrets for nightly CI

The workflow needs these repository secrets configured before it will run:
`SPARKLE_PUBLIC_ED_KEY`, `SPARKLE_PRIVATE_ED_KEY`, `MACOS_DEVELOPMENT_TEAM`, `APPLE_NOTARY_KEY_ID`, `APPLE_NOTARY_ISSUER_ID`, `APPLE_NOTARY_PRIVATE_KEY`

## Test plan

- [x] macOS build succeeds (`xcodebuild build` — verified)
- [x] iOS build succeeds (`xcodebuild build` — verified)
- [ ] Manual: open Preferences → Workspace, verify "Updates" section with channel picker appears
- [ ] Manual: switch channel, quit/relaunch, verify channel persists
- [ ] Manual: run `CHANNEL=nightly ./scripts/generate-sparkle-appcast.sh` and verify `appcast-nightly.xml` output
- [ ] CI: nightly workflow runs successfully after secrets are configured

Closes #139