### PR TITLE
♻️ Collapse projection layers — consume server types directly

### DIFF
--- a/OrbitDockNative/OrbitDock/Models/Session.swift
+++ b/OrbitDockNative/OrbitDock/Models/Session.swift
@@ -585,25 +585,3 @@ struct Session: Identifiable, Hashable, Sendable {
   }
 }
 
-extension Session {
-  mutating func applyPendingApprovalSummary(_ request: ServerApprovalRequest) {
-    applyPendingApprovalProjection(SessionPendingApprovalProjection(request: request))
-  }
-
-  mutating func clearPendingApprovalSummary(resetAttention: Bool) {
-    pendingApprovalId = nil
-    pendingToolName = nil
-    pendingToolInput = nil
-    pendingPermissionDetail = nil
-    pendingQuestion = nil
-
-    guard resetAttention else { return }
-
-    if attentionReason == .awaitingPermission || attentionReason == .awaitingQuestion {
-      attentionReason = .none
-    }
-    if workStatus == .permission {
-      workStatus = .working
-    }
-  }
-}

--- a/OrbitDockNative/OrbitDock/PreviewRuntime.swift
+++ b/OrbitDockNative/OrbitDock/PreviewRuntime.swift
@@ -44,7 +44,7 @@ struct PreviewRuntime {
       endpointName: endpoint.name
     )
     for session in Self.previewSessions(endpoint: endpoint) {
-      sessionStore.session(session.id).applySnapshotProjection(SessionDetailSnapshotProjection.from(session))
+      sessionStore.session(session.id).populateFromPreviewSession(session)
     }
     sessionStore.codexModels = Self.previewCodexModels()
     sessionStore.codexAccountStatus = ServerCodexAccountStatus(

--- a/OrbitDockNative/OrbitDock/Services/DemoModeExperience.swift
+++ b/OrbitDockNative/OrbitDock/Services/DemoModeExperience.swift
@@ -126,7 +126,7 @@ diff --git a/OrbitDockNative/OrbitDock/Services/DemoModeExperience.swift b/Orbit
     endedSession.lastMessage = "Wrapped up with a short findings list and two follow-up suggestions."
 
     let reviewObservable = sessionStore.session(reviewSession.id)
-    reviewObservable.applySnapshotProjection(SessionDetailSnapshotProjection.from(reviewSession))
+    reviewObservable.populateFromPreviewSession(reviewSession)
     reviewObservable.applyConversationPage(
       rows: demoConversationRows(sessionId: reviewSession.id, projectPath: reviewSession.projectPath),
       hasMoreBefore: false,
@@ -135,7 +135,7 @@ diff --git a/OrbitDockNative/OrbitDock/Services/DemoModeExperience.swift b/Orbit
     )
 
     let endedObservable = sessionStore.session(endedSession.id)
-    endedObservable.applySnapshotProjection(SessionDetailSnapshotProjection.from(endedSession))
+    endedObservable.populateFromPreviewSession(endedSession)
     endedObservable.applyConversationPage(
       rows: endedConversationRows(sessionId: endedSession.id),
       hasMoreBefore: false,

--- a/OrbitDockNative/OrbitDock/Services/Server/ServerTypeAdapters.swift
+++ b/OrbitDockNative/OrbitDock/Services/Server/ServerTypeAdapters.swift
@@ -9,98 +9,7 @@
 
 import Foundation
 
-private enum RootSessionAdapterSupport {
-  static func provider(from provider: ServerProvider) -> Provider {
-    provider == .codex ? .codex : .claude
-  }
-
-  static func codexMode(provider: ServerProvider, mode: ServerCodexIntegrationMode?) -> CodexIntegrationMode? {
-    guard provider == .codex else { return nil }
-    return mode?.toSessionMode() ?? .direct
-  }
-
-  static func claudeMode(provider: ServerProvider, mode: ServerClaudeIntegrationMode?) -> ClaudeIntegrationMode? {
-    guard provider == .claude else { return nil }
-    return mode?.toSessionMode()
-  }
-}
-
-// MARK: - ServerSessionState → Detail Projection
-
-extension ServerSessionState {
-  func toDetailSnapshotProjection() -> SessionDetailSnapshotProjection {
-    SessionDetailSnapshotProjection(
-      endpointId: nil,
-      endpointName: nil,
-      projectPath: projectPath,
-      projectName: projectName,
-      branch: gitBranch,
-      model: model,
-      effort: effort,
-      collaborationMode: collaborationMode,
-      multiAgent: multiAgent,
-      personality: personality,
-      serviceTier: serviceTier,
-      developerInstructions: developerInstructions,
-      codexConfigSource: codexConfigSource,
-      codexConfigMode: codexConfigMode,
-      codexConfigProfile: codexConfigProfile,
-      codexModelProvider: codexModelProvider,
-      codexConfigOverrides: codexConfigOverrides,
-      summary: summary,
-      customName: customName,
-      firstPrompt: firstPrompt,
-      lastMessage: lastMessage,
-      transcriptPath: transcriptPath,
-      status: status == .active ? .active : .ended,
-      workStatus: workStatus.toSessionWorkStatus(),
-      steerable: steerable,
-      attentionReason: workStatus.toAttentionReason(),
-      lastActivityAt: parseServerTimestamp(lastActivityAt),
-      lastFilesPersistedAt: nil,
-      lastTool: nil,
-      lastToolAt: nil,
-      inputTokens: Int(tokenUsage.inputTokens),
-      outputTokens: Int(tokenUsage.outputTokens),
-      cachedTokens: Int(tokenUsage.cachedTokens),
-      contextWindow: Int(tokenUsage.contextWindow),
-      totalTokens: Int(tokenUsage.inputTokens + tokenUsage.outputTokens),
-      totalCostUSD: 0,
-      provider: RootSessionAdapterSupport.provider(from: provider),
-      codexIntegrationMode: RootSessionAdapterSupport.codexMode(provider: provider, mode: codexIntegrationMode),
-      claudeIntegrationMode: RootSessionAdapterSupport.claudeMode(provider: provider, mode: claudeIntegrationMode),
-      codexThreadId: nil,
-      pendingApprovalId: pendingApprovalId,
-      pendingToolName: pendingToolName,
-      pendingToolInput: pendingToolInput,
-      pendingPermissionDetail: nil,
-      pendingQuestion: pendingQuestion,
-      promptCount: 0,
-      toolCount: 0,
-      startedAt: parseServerTimestamp(startedAt),
-      endedAt: nil,
-      endReason: nil,
-      tokenUsageSnapshotKind: tokenUsageSnapshotKind,
-      gitSha: gitSha,
-      currentCwd: currentCwd,
-      repositoryRoot: repositoryRoot,
-      isWorktree: isWorktree ?? false,
-      worktreeId: worktreeId,
-      unreadCount: unreadCount ?? 0,
-      currentDiff: currentDiff,
-      cumulativeDiff: cumulativeDiff,
-      currentPlan: currentPlan,
-      turnDiffs: turnDiffs,
-      currentTurnId: currentTurnId,
-      turnCount: turnCount,
-      subagents: subagents,
-      missionId: missionId,
-      issueIdentifier: issueIdentifier,
-      allowBypassPermissions: allowBypassPermissions ?? false
-    )
-  }
-
-}
+// MARK: - ServerWorkStatus → Session types
 
 extension ServerCodexIntegrationMode {
   func toSessionMode() -> CodexIntegrationMode {
@@ -262,7 +171,7 @@ private func mimeTypeForExtension(_ ext: String) -> String {
 // MARK: - Timestamp Parsing
 
 /// Parse server timestamps (Unix seconds or ISO 8601)
-private func parseServerTimestamp(_ string: String?) -> Date? {
+func parseServerTimestamp(_ string: String?) -> Date? {
   guard let string, !string.isEmpty else { return nil }
 
   // Try Unix seconds first (what the Rust server sends: "1738800000Z")

--- a/OrbitDockNative/OrbitDock/Services/Server/SessionStateProjection.swift
+++ b/OrbitDockNative/OrbitDock/Services/Server/SessionStateProjection.swift
@@ -22,237 +22,6 @@ struct SessionPendingApprovalProjection {
   }
 }
 
-struct SessionDetailSnapshotProjection {
-  let endpointId: UUID?
-  let endpointName: String?
-  let projectPath: String
-  let projectName: String?
-  let branch: String?
-  let model: String?
-  let effort: String?
-  let collaborationMode: String?
-  let multiAgent: Bool?
-  let personality: String?
-  let serviceTier: String?
-  let developerInstructions: String?
-  let codexConfigSource: ServerCodexConfigSource?
-  let codexConfigMode: ServerCodexConfigMode?
-  let codexConfigProfile: String?
-  let codexModelProvider: String?
-  let codexConfigOverrides: ServerCodexSessionOverrides?
-  let summary: String?
-  let customName: String?
-  let firstPrompt: String?
-  let lastMessage: String?
-  let transcriptPath: String?
-  let status: Session.SessionStatus
-  let workStatus: Session.WorkStatus
-  var steerable: Bool = false
-  let attentionReason: Session.AttentionReason
-  let lastActivityAt: Date?
-  let lastFilesPersistedAt: Date?
-  let lastTool: String?
-  let lastToolAt: Date?
-  let inputTokens: Int?
-  let outputTokens: Int?
-  let cachedTokens: Int?
-  let contextWindow: Int?
-  let totalTokens: Int
-  let totalCostUSD: Double
-  let provider: Provider
-  let codexIntegrationMode: CodexIntegrationMode?
-  let claudeIntegrationMode: ClaudeIntegrationMode?
-  let codexThreadId: String?
-  let pendingApprovalId: String?
-  let pendingToolName: String?
-  let pendingToolInput: String?
-  let pendingPermissionDetail: String?
-  let pendingQuestion: String?
-  let promptCount: Int
-  let toolCount: Int
-  let startedAt: Date?
-  let endedAt: Date?
-  let endReason: String?
-  let tokenUsageSnapshotKind: ServerTokenUsageSnapshotKind
-  let gitSha: String?
-  let currentCwd: String?
-  let repositoryRoot: String?
-  let isWorktree: Bool
-  let worktreeId: String?
-  let unreadCount: UInt64
-  let currentDiff: String?
-  let cumulativeDiff: String?
-  let currentPlan: String?
-  let turnDiffs: [ServerTurnDiff]
-  let currentTurnId: String?
-  let turnCount: UInt64
-  let subagents: [ServerSubagentInfo]
-  let missionId: String?
-  let issueIdentifier: String?
-  let allowBypassPermissions: Bool
-
-  static func from(_ session: Session) -> SessionDetailSnapshotProjection {
-    SessionDetailSnapshotProjection(
-      endpointId: session.endpointId,
-      endpointName: session.endpointName,
-      projectPath: session.projectPath,
-      projectName: session.projectName,
-      branch: session.branch,
-      model: session.model,
-      effort: session.effort,
-      collaborationMode: session.collaborationMode,
-      multiAgent: session.multiAgent,
-      personality: session.personality,
-      serviceTier: session.serviceTier,
-      developerInstructions: session.developerInstructions,
-      codexConfigSource: session.codexConfigSource,
-      codexConfigMode: session.codexConfigMode,
-      codexConfigProfile: session.codexConfigProfile,
-      codexModelProvider: session.codexModelProvider,
-      codexConfigOverrides: session.codexConfigOverrides,
-      summary: session.summary,
-      customName: session.customName,
-      firstPrompt: session.firstPrompt,
-      lastMessage: session.lastMessage,
-      transcriptPath: session.transcriptPath,
-      status: session.status,
-      workStatus: session.workStatus,
-      steerable: session.steerable,
-      attentionReason: session.attentionReason,
-      lastActivityAt: session.lastActivityAt,
-      lastFilesPersistedAt: session.lastFilesPersistedAt,
-      lastTool: session.lastTool,
-      lastToolAt: session.lastToolAt,
-      inputTokens: session.inputTokens,
-      outputTokens: session.outputTokens,
-      cachedTokens: session.cachedTokens,
-      contextWindow: session.contextWindow,
-      totalTokens: session.totalTokens,
-      totalCostUSD: session.totalCostUSD,
-      provider: session.provider,
-      codexIntegrationMode: session.codexIntegrationMode,
-      claudeIntegrationMode: session.claudeIntegrationMode,
-      codexThreadId: session.codexThreadId,
-      pendingApprovalId: session.pendingApprovalId,
-      pendingToolName: session.pendingToolName,
-      pendingToolInput: session.pendingToolInput,
-      pendingPermissionDetail: session.pendingPermissionDetail,
-      pendingQuestion: session.pendingQuestion,
-      promptCount: session.promptCount,
-      toolCount: session.toolCount,
-      startedAt: session.startedAt,
-      endedAt: session.endedAt,
-      endReason: session.endReason,
-      tokenUsageSnapshotKind: session.tokenUsageSnapshotKind,
-      gitSha: session.gitSha,
-      currentCwd: session.currentCwd,
-      repositoryRoot: session.repositoryRoot,
-      isWorktree: session.isWorktree,
-      worktreeId: session.worktreeId,
-      unreadCount: session.unreadCount,
-      currentDiff: session.currentDiff,
-      cumulativeDiff: session.cumulativeDiff,
-      currentPlan: nil,
-      turnDiffs: [],
-      currentTurnId: nil,
-      turnCount: 0,
-      subagents: [],
-      missionId: session.missionId,
-      issueIdentifier: session.issueIdentifier,
-      allowBypassPermissions: false
-    )
-  }
-}
-
-struct SessionStateProjection {
-  let status: Session.SessionStatus?
-  let workStatus: Session.WorkStatus?
-  let steerable: Bool?
-  let attentionReason: Session.AttentionReason?
-  let tokenUsage: ServerTokenUsage?
-  let tokenUsageSnapshotKind: ServerTokenUsageSnapshotKind?
-  let currentDiff: String??
-  let cumulativeDiff: String??
-  let plan: String??
-  let customName: String??
-  let summary: String??
-  let firstPrompt: String??
-  let lastMessage: String??
-  let codexIntegrationMode: CodexIntegrationMode??
-  let claudeIntegrationMode: ClaudeIntegrationMode??
-  let currentTurnId: String??
-  let turnCount: UInt64?
-  let branch: String??
-  let gitSha: String??
-  let currentCwd: String??
-  let subagents: [ServerSubagentInfo]?
-  let model: String??
-  let effort: String??
-  let collaborationMode: String??
-  let multiAgent: Bool??
-  let personality: String??
-  let serviceTier: String??
-  let developerInstructions: String??
-  let codexConfigSource: ServerCodexConfigSource??
-  let codexConfigMode: ServerCodexConfigMode??
-  let codexConfigProfile: String??
-  let codexModelProvider: String??
-  let codexConfigOverrides: ServerCodexSessionOverrides??
-  let lastActivityAt: Date?
-  let repositoryRoot: String??
-  let isWorktree: Bool?
-  let unreadCount: UInt64?
-
-  static func from(_ changes: ServerStateChanges) -> SessionStateProjection {
-    SessionStateProjection(
-      status: changes.status.map { $0 == .active ? .active : .ended },
-      workStatus: changes.workStatus.map { $0.toSessionWorkStatus() },
-      steerable: changes.steerable,
-      attentionReason: changes.workStatus.map { $0.toAttentionReason() },
-      tokenUsage: changes.tokenUsage,
-      tokenUsageSnapshotKind: changes.tokenUsageSnapshotKind,
-      currentDiff: changes.currentDiff,
-      cumulativeDiff: changes.cumulativeDiff,
-      plan: changes.currentPlan,
-      customName: changes.customName,
-      summary: changes.summary,
-      firstPrompt: changes.firstPrompt,
-      lastMessage: changes.lastMessage,
-      codexIntegrationMode: changes.codexIntegrationMode.map { $0?.toSessionMode() },
-      claudeIntegrationMode: changes.claudeIntegrationMode.map { $0?.toSessionMode() },
-      currentTurnId: changes.currentTurnId,
-      turnCount: changes.turnCount,
-      branch: changes.gitBranch,
-      gitSha: changes.gitSha,
-      currentCwd: changes.currentCwd,
-      subagents: changes.subagents,
-      model: changes.model,
-      effort: changes.effort,
-      collaborationMode: changes.collaborationMode,
-      multiAgent: changes.multiAgent,
-      personality: changes.personality,
-      serviceTier: changes.serviceTier,
-      developerInstructions: changes.developerInstructions,
-      codexConfigSource: changes.codexConfigSource,
-      codexConfigMode: changes.codexConfigMode,
-      codexConfigProfile: changes.codexConfigProfile,
-      codexModelProvider: changes.codexModelProvider,
-      codexConfigOverrides: changes.codexConfigOverrides,
-      lastActivityAt: parseLastActivityAt(changes.lastActivityAt),
-      repositoryRoot: changes.repositoryRoot,
-      isWorktree: changes.isWorktree,
-      unreadCount: changes.unreadCount
-    )
-  }
-
-  private static func parseLastActivityAt(_ rawValue: String?) -> Date? {
-    guard let rawValue else { return nil }
-    let stripped = rawValue.hasSuffix("Z") ? String(rawValue.dropLast()) : rawValue
-    guard let secs = TimeInterval(stripped) else { return nil }
-    return Date(timeIntervalSince1970: secs)
-  }
-}
-
 struct SessionTurnDiffSnapshotProjection {
   let turnDiff: ServerTurnDiff?
   let usage: ServerTokenUsage?
@@ -287,213 +56,67 @@ struct SessionTurnDiffSnapshotProjection {
   }
 }
 
-extension Session {
-  mutating func applyPendingApprovalProjection(_ projection: SessionPendingApprovalProjection) {
-    pendingApprovalId = projection.id
-    pendingToolName = projection.toolName
-    pendingToolInput = projection.toolInput
-    pendingPermissionDetail = projection.permissionDetail
-    pendingQuestion = projection.question
-    attentionReason = projection.attentionReason
-    workStatus = projection.workStatus
-  }
-
-  mutating func applyProjection(_ projection: SessionStateProjection) {
-    if let status = projection.status {
-      self.status = status
-    }
-
-    if let workStatus = projection.workStatus {
-      self.workStatus = workStatus
-    }
-
-    if let steerable = projection.steerable {
-      self.steerable = steerable
-    }
-
-    if let attentionReason = projection.attentionReason {
-      self.attentionReason = attentionReason
-    }
-
-    if let tokenUsage = projection.tokenUsage {
-      applyTokenUsage(tokenUsage, snapshotKind: projection.tokenUsageSnapshotKind)
-    } else if let snapshotKind = projection.tokenUsageSnapshotKind {
-      tokenUsageSnapshotKind = snapshotKind
-    }
-
-    if let currentDiff = projection.currentDiff {
-      self.currentDiff = currentDiff
-    }
-    if let cumulativeDiff = projection.cumulativeDiff {
-      self.cumulativeDiff = cumulativeDiff
-    }
-
-    if let customName = projection.customName {
-      self.customName = customName
-    }
-    if let summary = projection.summary {
-      self.summary = summary
-    }
-    if let firstPrompt = projection.firstPrompt {
-      self.firstPrompt = firstPrompt
-    }
-    if let lastMessage = projection.lastMessage {
-      self.lastMessage = lastMessage
-    }
-    if let codexIntegrationMode = projection.codexIntegrationMode {
-      self.codexIntegrationMode = codexIntegrationMode
-    }
-    if let claudeIntegrationMode = projection.claudeIntegrationMode {
-      self.claudeIntegrationMode = claudeIntegrationMode
-    }
-    if let branch = projection.branch {
-      self.branch = branch
-    }
-    if let gitSha = projection.gitSha {
-      self.gitSha = gitSha
-    }
-    if let currentCwd = projection.currentCwd {
-      self.currentCwd = currentCwd
-    }
-    if let model = projection.model {
-      self.model = model
-    }
-    if let effort = projection.effort {
-      self.effort = effort
-    }
-    if let collaborationMode = projection.collaborationMode {
-      self.collaborationMode = collaborationMode
-    }
-    if let multiAgent = projection.multiAgent {
-      self.multiAgent = multiAgent
-    }
-    if let personality = projection.personality {
-      self.personality = personality
-    }
-    if let serviceTier = projection.serviceTier {
-      self.serviceTier = serviceTier
-    }
-    if let developerInstructions = projection.developerInstructions {
-      self.developerInstructions = developerInstructions
-    }
-    if let codexConfigMode = projection.codexConfigMode {
-      self.codexConfigMode = codexConfigMode
-    }
-    if let codexConfigProfile = projection.codexConfigProfile {
-      self.codexConfigProfile = codexConfigProfile
-    }
-    if let codexModelProvider = projection.codexModelProvider {
-      self.codexModelProvider = codexModelProvider
-    }
-    if let lastActivityAt = projection.lastActivityAt {
-      self.lastActivityAt = lastActivityAt
-    }
-    if let repositoryRoot = projection.repositoryRoot {
-      self.repositoryRoot = repositoryRoot
-    }
-    if let isWorktree = projection.isWorktree {
-      self.isWorktree = isWorktree
-    }
-    if let unreadCount = projection.unreadCount {
-      self.unreadCount = unreadCount
-    }
-
-    refreshDisplayProjection()
-  }
-
-  mutating func applyTokenUsage(
-    _ usage: ServerTokenUsage,
-    snapshotKind: ServerTokenUsageSnapshotKind? = nil
-  ) {
-    inputTokens = Int(usage.inputTokens)
-    outputTokens = Int(usage.outputTokens)
-    cachedTokens = Int(usage.cachedTokens)
-    contextWindow = Int(usage.contextWindow)
-    totalTokens = Int(usage.inputTokens + usage.outputTokens)
-    if let snapshotKind {
-      tokenUsageSnapshotKind = snapshotKind
-    }
-  }
-
-  mutating func applyTurnDiffSnapshot(_ projection: SessionTurnDiffSnapshotProjection) {
-    if let usage = projection.usage {
-      applyTokenUsage(usage, snapshotKind: projection.snapshotKind)
-    } else {
-      tokenUsageSnapshotKind = projection.snapshotKind
-    }
-  }
-}
+// MARK: - SessionObservable ← ServerSessionState (snapshot)
 
 @MainActor
 extension SessionObservable {
-  func applySnapshotProjection(_ projection: SessionDetailSnapshotProjection) {
-    endpointId = projection.endpointId
-    endpointName = projection.endpointName
-    projectPath = projection.projectPath
-    projectName = projection.projectName
-    branch = projection.branch
-    model = projection.model
-    effort = projection.effort
-    collaborationMode = projection.collaborationMode
-    multiAgent = projection.multiAgent
-    personality = projection.personality
-    serviceTier = projection.serviceTier
-    developerInstructions = projection.developerInstructions
-    codexConfigSource = projection.codexConfigSource
-    codexConfigMode = projection.codexConfigMode
-    codexConfigProfile = projection.codexConfigProfile
-    codexModelProvider = projection.codexModelProvider
-    codexConfigOverrides = projection.codexConfigOverrides
-    summary = projection.summary
-    customName = projection.customName
-    firstPrompt = projection.firstPrompt
-    lastMessage = projection.lastMessage
-    transcriptPath = projection.transcriptPath
-    status = projection.status
-    workStatus = projection.workStatus
-    steerable = projection.steerable
-    attentionReason = projection.attentionReason
-    lastActivityAt = projection.lastActivityAt
-    lastFilesPersistedAt = projection.lastFilesPersistedAt
-    lastTool = projection.lastTool
-    lastToolAt = projection.lastToolAt
-    inputTokens = projection.inputTokens
-    outputTokens = projection.outputTokens
-    cachedTokens = projection.cachedTokens
-    contextWindow = projection.contextWindow
-    totalTokens = projection.totalTokens
-    totalCostUSD = projection.totalCostUSD
-    provider = projection.provider
-    codexIntegrationMode = projection.codexIntegrationMode
-    claudeIntegrationMode = projection.claudeIntegrationMode
-    codexThreadId = projection.codexThreadId
-    pendingApprovalId = projection.pendingApprovalId
-    pendingToolName = projection.pendingToolName
-    pendingToolInput = projection.pendingToolInput
-    pendingPermissionDetail = projection.pendingPermissionDetail
-    pendingQuestion = projection.pendingQuestion
-    promptCount = projection.promptCount
-    toolCount = projection.toolCount
-    startedAt = projection.startedAt
-    endedAt = projection.endedAt
-    endReason = projection.endReason
-    tokenUsageSnapshotKind = projection.tokenUsageSnapshotKind
-    gitSha = projection.gitSha
-    currentCwd = projection.currentCwd
-    repositoryRoot = projection.repositoryRoot
-    isWorktree = projection.isWorktree
-    worktreeId = projection.worktreeId
-    unreadCount = projection.unreadCount
-    diff = projection.currentDiff
-    cumulativeDiff = projection.cumulativeDiff
-    plan = projection.currentPlan
-    turnDiffs = projection.turnDiffs
-    currentTurnId = projection.currentTurnId
-    turnCount = projection.turnCount
-    subagents = projection.subagents
-    missionId = projection.missionId
-    issueIdentifier = projection.issueIdentifier
-    allowBypassPermissions = projection.allowBypassPermissions
+  func applyServerSnapshot(_ state: ServerSessionState) {
+    let resolvedProvider = serverProvider(state.provider)
+    projectPath = state.projectPath
+    projectName = state.projectName
+    branch = state.gitBranch
+    model = state.model
+    effort = state.effort
+    collaborationMode = state.collaborationMode
+    multiAgent = state.multiAgent
+    personality = state.personality
+    serviceTier = state.serviceTier
+    developerInstructions = state.developerInstructions
+    codexConfigSource = state.codexConfigSource
+    codexConfigMode = state.codexConfigMode
+    codexConfigProfile = state.codexConfigProfile
+    codexModelProvider = state.codexModelProvider
+    codexConfigOverrides = state.codexConfigOverrides
+    summary = state.summary
+    customName = state.customName
+    firstPrompt = state.firstPrompt
+    lastMessage = state.lastMessage
+    transcriptPath = state.transcriptPath
+    status = state.status == .active ? .active : .ended
+    workStatus = state.workStatus.toSessionWorkStatus()
+    steerable = state.steerable
+    attentionReason = state.workStatus.toAttentionReason()
+    lastActivityAt = parseServerTimestamp(state.lastActivityAt)
+    inputTokens = Int(state.tokenUsage.inputTokens)
+    outputTokens = Int(state.tokenUsage.outputTokens)
+    cachedTokens = Int(state.tokenUsage.cachedTokens)
+    contextWindow = Int(state.tokenUsage.contextWindow)
+    totalTokens = Int(state.tokenUsage.inputTokens + state.tokenUsage.outputTokens)
+    provider = resolvedProvider
+    codexIntegrationMode = serverCodexMode(provider: state.provider, mode: state.codexIntegrationMode)
+    claudeIntegrationMode = serverClaudeMode(provider: state.provider, mode: state.claudeIntegrationMode)
+    pendingApprovalId = state.pendingApprovalId
+    pendingToolName = state.pendingToolName
+    pendingToolInput = state.pendingToolInput
+    pendingQuestion = state.pendingQuestion
+    startedAt = parseServerTimestamp(state.startedAt)
+    tokenUsageSnapshotKind = state.tokenUsageSnapshotKind
+    gitSha = state.gitSha
+    currentCwd = state.currentCwd
+    repositoryRoot = state.repositoryRoot
+    isWorktree = state.isWorktree ?? false
+    worktreeId = state.worktreeId
+    unreadCount = state.unreadCount ?? 0
+    diff = state.currentDiff
+    cumulativeDiff = state.cumulativeDiff
+    plan = state.currentPlan
+    turnDiffs = state.turnDiffs
+    currentTurnId = state.currentTurnId
+    turnCount = state.turnCount
+    subagents = state.subagents
+    missionId = state.missionId
+    issueIdentifier = state.issueIdentifier
+    allowBypassPermissions = state.allowBypassPermissions ?? false
   }
 
   /// Apply the session summary returned by the resume HTTP response.
@@ -512,124 +135,122 @@ extension SessionObservable {
     if let b = summary.gitBranch { branch = b }
   }
 
-  func applyProjection(_ projection: SessionStateProjection) {
-    if let status = projection.status {
-      self.status = status
+  /// Apply incremental state changes from a SessionDelta event.
+  func applyServerDelta(_ changes: ServerStateChanges) {
+    if let serverStatus = changes.status {
+      status = serverStatus == .active ? .active : .ended
     }
 
-    if let workStatus = projection.workStatus {
-      self.workStatus = workStatus
+    if let serverWorkStatus = changes.workStatus {
+      workStatus = serverWorkStatus.toSessionWorkStatus()
+      attentionReason = serverWorkStatus.toAttentionReason()
       if workStatus == .working {
         promptSuggestions.removeAll()
         rateLimitInfo = nil
       }
     }
 
-    if let steerable = projection.steerable {
+    if let steerable = changes.steerable {
       self.steerable = steerable
     }
 
-    if let attentionReason = projection.attentionReason {
-      self.attentionReason = attentionReason
-    }
-
-    if let tokenUsage = projection.tokenUsage {
-      applyTokenUsage(tokenUsage, snapshotKind: projection.tokenUsageSnapshotKind)
-    } else if let snapshotKind = projection.tokenUsageSnapshotKind {
+    if let tokenUsage = changes.tokenUsage {
+      applyTokenUsage(tokenUsage, snapshotKind: changes.tokenUsageSnapshotKind)
+    } else if let snapshotKind = changes.tokenUsageSnapshotKind {
       tokenUsageSnapshotKind = snapshotKind
     }
 
-    if let currentDiff = projection.currentDiff {
+    if let currentDiff = changes.currentDiff {
       diff = currentDiff
     }
-    if let cumulativeDiff = projection.cumulativeDiff {
+    if let cumulativeDiff = changes.cumulativeDiff {
       self.cumulativeDiff = cumulativeDiff
     }
-    if let plan = projection.plan {
+    if let plan = changes.currentPlan {
       self.plan = plan
     }
-    if let customName = projection.customName {
+    if let customName = changes.customName {
       self.customName = customName
     }
-    if let summary = projection.summary {
+    if let summary = changes.summary {
       self.summary = summary
     }
-    if let firstPrompt = projection.firstPrompt {
+    if let firstPrompt = changes.firstPrompt {
       self.firstPrompt = firstPrompt
     }
-    if let lastMessage = projection.lastMessage {
+    if let lastMessage = changes.lastMessage {
       self.lastMessage = lastMessage
     }
-    if let codexIntegrationMode = projection.codexIntegrationMode {
-      self.codexIntegrationMode = codexIntegrationMode
+    if let codexIntegrationMode = changes.codexIntegrationMode {
+      self.codexIntegrationMode = codexIntegrationMode.map { $0.toSessionMode() }
     }
-    if let claudeIntegrationMode = projection.claudeIntegrationMode {
-      self.claudeIntegrationMode = claudeIntegrationMode
+    if let claudeIntegrationMode = changes.claudeIntegrationMode {
+      self.claudeIntegrationMode = claudeIntegrationMode.map { $0.toSessionMode() }
     }
-    if let currentTurnId = projection.currentTurnId {
+    if let currentTurnId = changes.currentTurnId {
       self.currentTurnId = currentTurnId
     }
-    if let turnCount = projection.turnCount {
+    if let turnCount = changes.turnCount {
       self.turnCount = turnCount
     }
-    if let branch = projection.branch {
+    if let branch = changes.gitBranch {
       self.branch = branch
     }
-    if let gitSha = projection.gitSha {
+    if let gitSha = changes.gitSha {
       self.gitSha = gitSha
     }
-    if let currentCwd = projection.currentCwd {
+    if let currentCwd = changes.currentCwd {
       self.currentCwd = currentCwd
     }
-    if let subagents = projection.subagents {
+    if let subagents = changes.subagents {
       self.subagents = subagents
     }
-    if let model = projection.model {
+    if let model = changes.model {
       self.model = model
     }
-    if let effort = projection.effort {
+    if let effort = changes.effort {
       self.effort = effort
     }
-    if let collaborationMode = projection.collaborationMode {
+    if let collaborationMode = changes.collaborationMode {
       self.collaborationMode = collaborationMode
     }
-    if let multiAgent = projection.multiAgent {
+    if let multiAgent = changes.multiAgent {
       self.multiAgent = multiAgent
     }
-    if let personality = projection.personality {
+    if let personality = changes.personality {
       self.personality = personality
     }
-    if let serviceTier = projection.serviceTier {
+    if let serviceTier = changes.serviceTier {
       self.serviceTier = serviceTier
     }
-    if let developerInstructions = projection.developerInstructions {
+    if let developerInstructions = changes.developerInstructions {
       self.developerInstructions = developerInstructions
     }
-    if let codexConfigMode = projection.codexConfigMode {
+    if let codexConfigMode = changes.codexConfigMode {
       self.codexConfigMode = codexConfigMode
     }
-    if let codexConfigProfile = projection.codexConfigProfile {
+    if let codexConfigProfile = changes.codexConfigProfile {
       self.codexConfigProfile = codexConfigProfile
     }
-    if let codexModelProvider = projection.codexModelProvider {
+    if let codexModelProvider = changes.codexModelProvider {
       self.codexModelProvider = codexModelProvider
     }
-    if let codexConfigSource = projection.codexConfigSource {
+    if let codexConfigSource = changes.codexConfigSource {
       self.codexConfigSource = codexConfigSource
     }
-    if let codexConfigOverrides = projection.codexConfigOverrides {
+    if let codexConfigOverrides = changes.codexConfigOverrides {
       self.codexConfigOverrides = codexConfigOverrides
     }
-    if let lastActivityAt = projection.lastActivityAt {
-      self.lastActivityAt = lastActivityAt
+    if let lastActivityAt = changes.lastActivityAt {
+      self.lastActivityAt = parseServerTimestamp(lastActivityAt)
     }
-    if let repositoryRoot = projection.repositoryRoot {
+    if let repositoryRoot = changes.repositoryRoot {
       self.repositoryRoot = repositoryRoot
     }
-    if let isWorktree = projection.isWorktree {
+    if let isWorktree = changes.isWorktree {
       self.isWorktree = isWorktree
     }
-    if let unreadCount = projection.unreadCount {
+    if let unreadCount = changes.unreadCount {
       self.unreadCount = unreadCount
     }
   }
@@ -664,4 +285,93 @@ extension SessionObservable {
       tokenUsageSnapshotKind = projection.snapshotKind
     }
   }
+
+  /// Populate observable from a Session struct (preview/demo only).
+  func populateFromPreviewSession(_ session: Session) {
+    endpointId = session.endpointId
+    endpointName = session.endpointName
+    endpointConnectionStatus = session.endpointConnectionStatus
+    projectPath = session.projectPath
+    projectName = session.projectName
+    branch = session.branch
+    model = session.model
+    effort = session.effort
+    collaborationMode = session.collaborationMode
+    multiAgent = session.multiAgent
+    personality = session.personality
+    serviceTier = session.serviceTier
+    developerInstructions = session.developerInstructions
+    codexConfigSource = session.codexConfigSource
+    codexConfigMode = session.codexConfigMode
+    codexConfigProfile = session.codexConfigProfile
+    codexModelProvider = session.codexModelProvider
+    codexConfigOverrides = session.codexConfigOverrides
+    summary = session.summary
+    customName = session.customName
+    firstPrompt = session.firstPrompt
+    lastMessage = session.lastMessage
+    transcriptPath = session.transcriptPath
+    status = session.status
+    workStatus = session.workStatus
+    steerable = session.steerable
+    attentionReason = session.attentionReason
+    lastActivityAt = session.lastActivityAt
+    lastFilesPersistedAt = session.lastFilesPersistedAt
+    lastTool = session.lastTool
+    lastToolAt = session.lastToolAt
+    inputTokens = session.inputTokens
+    outputTokens = session.outputTokens
+    cachedTokens = session.cachedTokens
+    contextWindow = session.contextWindow
+    totalTokens = session.totalTokens
+    totalCostUSD = session.totalCostUSD
+    provider = session.provider
+    codexIntegrationMode = session.codexIntegrationMode
+    claudeIntegrationMode = session.claudeIntegrationMode
+    codexThreadId = session.codexThreadId
+    pendingApprovalId = session.pendingApprovalId
+    pendingToolName = session.pendingToolName
+    pendingToolInput = session.pendingToolInput
+    pendingPermissionDetail = session.pendingPermissionDetail
+    pendingQuestion = session.pendingQuestion
+    promptCount = session.promptCount
+    toolCount = session.toolCount
+    startedAt = session.startedAt
+    endedAt = session.endedAt
+    endReason = session.endReason
+    tokenUsageSnapshotKind = session.tokenUsageSnapshotKind
+    gitSha = session.gitSha
+    currentCwd = session.currentCwd
+    repositoryRoot = session.repositoryRoot
+    isWorktree = session.isWorktree
+    worktreeId = session.worktreeId
+    unreadCount = session.unreadCount
+    diff = session.currentDiff
+    cumulativeDiff = session.cumulativeDiff
+    missionId = session.missionId
+    issueIdentifier = session.issueIdentifier
+  }
 }
+
+// MARK: - Private Helpers
+
+private func serverProvider(_ provider: ServerProvider) -> Provider {
+  provider == .codex ? .codex : .claude
+}
+
+private func serverCodexMode(
+  provider: ServerProvider,
+  mode: ServerCodexIntegrationMode?
+) -> CodexIntegrationMode? {
+  guard provider == .codex else { return nil }
+  return mode?.toSessionMode() ?? .direct
+}
+
+private func serverClaudeMode(
+  provider: ServerProvider,
+  mode: ServerClaudeIntegrationMode?
+) -> ClaudeIntegrationMode? {
+  guard provider == .claude else { return nil }
+  return mode?.toSessionMode()
+}
+

--- a/OrbitDockNative/OrbitDock/Services/Server/SessionStore+Events.swift
+++ b/OrbitDockNative/OrbitDock/Services/Server/SessionStore+Events.swift
@@ -246,7 +246,7 @@ extension SessionStore {
       oldestSequence: conversation.oldestSequence,
       isBootstrap: true
     )
-    obs.applySnapshotProjection(state.toDetailSnapshotProjection())
+    obs.applyServerSnapshot(state)
     let transition = SessionControlStateReducer.snapshotTransition(
       current: controlState(sessionId: state.id, observable: obs),
       snapshot: state,
@@ -257,9 +257,8 @@ extension SessionStore {
 
   func handleSessionDelta(_ sessionId: String, _ changes: ServerStateChanges) {
     let obs = self.session(sessionId)
-    let projection = SessionStateProjection.from(changes)
 
-    obs.applyProjection(projection)
+    obs.applyServerDelta(changes)
     let summaryStillBlocked = obs.attentionReason == .awaitingPermission
       || obs.attentionReason == .awaitingQuestion
       || obs.workStatus == .permission

--- a/OrbitDockNative/OrbitDock/Theme.swift
+++ b/OrbitDockNative/OrbitDock/Theme.swift
@@ -482,22 +482,6 @@ enum SessionDisplayStatus: Sendable {
     }
   }
 
-  static func from(_ session: Session) -> SessionDisplayStatus {
-    guard session.isActive else { return .ended }
-
-    switch session.attentionReason {
-      case .awaitingPermission:
-        return .permission
-      case .awaitingQuestion:
-        return .question
-      case .awaitingReply:
-        return .reply
-      case .none:
-        // Fall back to work status
-        return session.workStatus == .working ? .working : .reply
-    }
-  }
-
 }
 
 extension SessionDisplayStatus: Equatable {
@@ -562,12 +546,6 @@ struct SessionStatusBadge: View {
     }
   }
 
-  init(session: Session, showIcon: Bool = true, size: BadgeSize = .regular) {
-    self.status = SessionDisplayStatus.from(session)
-    self.showIcon = showIcon
-    self.size = size
-  }
-
   init(status: SessionDisplayStatus, showIcon: Bool = true, size: BadgeSize = .regular) {
     self.status = status
     self.showIcon = showIcon
@@ -604,12 +582,6 @@ struct SessionStatusDot: View {
   let status: SessionDisplayStatus
   var size: CGFloat = IconScale.xs
   var showGlow: Bool = true
-
-  init(session: Session, size: CGFloat = IconScale.xs, showGlow: Bool = true) {
-    status = SessionDisplayStatus.from(session)
-    self.size = size
-    self.showGlow = showGlow
-  }
 
   init(status: SessionDisplayStatus, size: CGFloat = IconScale.xs, showGlow: Bool = true) {
     self.status = status

--- a/OrbitDockNative/OrbitDock/Views/Components/CapabilityBadge.swift
+++ b/OrbitDockNative/OrbitDock/Views/Components/CapabilityBadge.swift
@@ -72,27 +72,6 @@ enum SessionCapability: Identifiable {
     }
   }
 
-  /// Derive capabilities from a Session
-  static func capabilities(for session: Session) -> [SessionCapability] {
-    // Show capability badges for any direct session (Codex or Claude)
-    if session.isDirect {
-      var caps: [SessionCapability] = [.direct]
-      if session.isActive, session.workStatus == .working {
-        caps.append(.canSteer)
-      }
-      if session.canApprove {
-        caps.append(.canApprove)
-      }
-      return caps
-    }
-
-    // Codex passive sessions get a passive badge
-    if session.provider == .codex {
-      return [.passive]
-    }
-
-    return []
-  }
 }
 
 #Preview {

--- a/OrbitDockNative/OrbitDockTests/Server/Sessions/SessionStateProjectionTests.swift
+++ b/OrbitDockNative/OrbitDockTests/Server/Sessions/SessionStateProjectionTests.swift
@@ -4,54 +4,36 @@ import Testing
 
 @MainActor
 struct SessionStateProjectionTests {
-  @Test func sessionApplyPendingApprovalSummarySetsPermissionFieldsFromServerRequest() {
-    var session = Session(
-      id: "session-1",
-      projectPath: "/tmp/project",
-      status: .active,
-      workStatus: .working,
-      attentionReason: .none,
-      provider: .codex,
-      codexIntegrationMode: .direct
-    )
+  @Test func sessionObservableApplyPendingApprovalSetsPermissionFields() {
+    let observable = SessionObservable(id: "session-1")
 
-    session.applyPendingApprovalSummary(execApprovalRequest())
+    observable.applyPendingApproval(execApprovalRequest())
 
-    #expect(session.pendingApprovalId == "req-1")
-    #expect(session.pendingToolName == "Bash")
-    #expect(session.pendingToolInput == #"{"command":"git status"}"#)
-    #expect(session.pendingPermissionDetail == "git status")
-    #expect(session.pendingQuestion == nil)
-    #expect(session.attentionReason == .awaitingPermission)
-    #expect(session.workStatus == .permission)
+    #expect(observable.pendingApprovalId == "req-1")
+    #expect(observable.pendingToolName == "Bash")
+    #expect(observable.pendingToolInput == #"{"command":"git status"}"#)
+    #expect(observable.pendingPermissionDetail == "git status")
+    #expect(observable.pendingQuestion == nil)
+    #expect(observable.attentionReason == .awaitingPermission)
+    #expect(observable.workStatus == .permission)
   }
 
-  @Test func sessionClearPendingApprovalSummaryClearsFieldsAndResetsAttentionWhenRequested() {
-    var session = Session(
-      id: "session-1",
-      projectPath: "/tmp/project",
-      status: .active,
-      workStatus: .permission,
-      attentionReason: .awaitingQuestion,
-      pendingToolName: "AskUserQuestion",
-      pendingPermissionDetail: "Need input",
-      pendingQuestion: "Ship it?",
-      provider: .codex,
-      codexIntegrationMode: .direct,
-      pendingApprovalId: "req-q"
-    )
+  @Test func sessionObservableClearPendingApprovalResetsAttentionWhenRequested() {
+    let observable = SessionObservable(id: "session-1")
+    observable.applyPendingApproval(questionApprovalRequest())
 
-    session.clearPendingApprovalSummary(resetAttention: true)
+    observable.clearPendingApprovalDetails(resetAttention: true)
 
-    #expect(session.pendingApprovalId == nil)
-    #expect(session.pendingToolName == nil)
-    #expect(session.pendingPermissionDetail == nil)
-    #expect(session.pendingQuestion == nil)
-    #expect(session.attentionReason == .none)
-    #expect(session.workStatus == .working)
+    #expect(observable.pendingApproval == nil)
+    #expect(observable.pendingApprovalId == nil)
+    #expect(observable.pendingToolName == nil)
+    #expect(observable.pendingPermissionDetail == nil)
+    #expect(observable.pendingQuestion == nil)
+    #expect(observable.attentionReason == .none)
+    #expect(observable.workStatus == .working)
   }
 
-  @Test func sessionObservableApplySnapshotProjectionMirrorsDetailFields() {
+  @Test func sessionObservablePopulateFromPreviewSessionMirrorsDetailFields() {
     let observable = SessionObservable(id: "session-1")
     let session = Session(
       id: "session-1",
@@ -84,7 +66,7 @@ struct SessionStateProjectionTests {
       contextWindow: 200_000
     )
 
-    observable.applySnapshotProjection(SessionDetailSnapshotProjection.from(session))
+    observable.populateFromPreviewSession(session)
 
     #expect(observable.endpointName == "Primary")
     #expect(observable.projectPath == "/tmp/project")
@@ -102,7 +84,7 @@ struct SessionStateProjectionTests {
     #expect(observable.contextWindow == 200_000)
   }
 
-  @Test func sessionObservableApplyProjectionUpdatesSubagentsFromServerDelta() {
+  @Test func sessionObservableApplyServerDeltaUpdatesSubagents() {
     let observable = SessionObservable(id: "session-1")
     let worker = ServerSubagentInfo(
       id: "worker-1",
@@ -120,53 +102,16 @@ struct SessionStateProjectionTests {
       lastActivityAt: "2026-03-12T10:00:01Z"
     )
 
-    let projection = SessionStateProjection.from(
-      ServerStateChanges(
-        status: nil,
-        workStatus: nil,
-        pendingApproval: nil,
-        tokenUsage: nil,
-        tokenUsageSnapshotKind: nil,
-        currentDiff: nil,
-        currentPlan: nil,
-        customName: nil,
-        summary: nil,
-        codexIntegrationMode: nil,
-        claudeIntegrationMode: nil,
-        approvalPolicy: nil,
-        sandboxMode: nil,
-        collaborationMode: nil,
-        multiAgent: nil,
-        personality: nil,
-        serviceTier: nil,
-        developerInstructions: nil,
-        lastActivityAt: nil,
-        currentTurnId: nil,
-        turnCount: nil,
-        gitBranch: nil,
-        gitSha: nil,
-        currentCwd: nil,
-        subagents: [worker],
-        firstPrompt: nil,
-        lastMessage: nil,
-        model: nil,
-        effort: nil,
-        permissionMode: nil,
-        approvalVersion: nil,
-        repositoryRoot: nil,
-        isWorktree: nil,
-        unreadCount: nil
-      )
+    observable.applyServerDelta(
+      ServerStateChanges(subagents: [worker])
     )
-
-    observable.applyProjection(projection)
 
     #expect(observable.subagents.count == 1)
     #expect(observable.subagents.first?.id == "worker-1")
     #expect(observable.subagents.first?.status == .running)
   }
 
-  @Test func sessionObservableApplyProjectionPreservesInterruptedSubagentStatus() {
+  @Test func sessionObservableApplyServerDeltaPreservesInterruptedSubagentStatus() {
     let observable = SessionObservable(id: "session-1")
     let worker = ServerSubagentInfo(
       id: "worker-1",
@@ -184,209 +129,60 @@ struct SessionStateProjectionTests {
       lastActivityAt: "2026-03-12T10:00:01Z"
     )
 
-    let projection = SessionStateProjection.from(
-      ServerStateChanges(
-        status: nil,
-        workStatus: nil,
-        pendingApproval: nil,
-        tokenUsage: nil,
-        tokenUsageSnapshotKind: nil,
-        currentDiff: nil,
-        currentPlan: nil,
-        customName: nil,
-        summary: nil,
-        codexIntegrationMode: nil,
-        claudeIntegrationMode: nil,
-        approvalPolicy: nil,
-        sandboxMode: nil,
-        collaborationMode: nil,
-        multiAgent: nil,
-        personality: nil,
-        serviceTier: nil,
-        developerInstructions: nil,
-        lastActivityAt: nil,
-        currentTurnId: nil,
-        turnCount: nil,
-        gitBranch: nil,
-        gitSha: nil,
-        currentCwd: nil,
-        subagents: [worker],
-        firstPrompt: nil,
-        lastMessage: nil,
-        model: nil,
-        effort: nil,
-        permissionMode: nil,
-        approvalVersion: nil,
-        repositoryRoot: nil,
-        isWorktree: nil,
-        unreadCount: nil
-      )
+    observable.applyServerDelta(
+      ServerStateChanges(subagents: [worker])
     )
-
-    observable.applyProjection(projection)
 
     #expect(observable.subagents.first?.status == .interrupted)
   }
 
-  @Test func sessionDetailSnapshotProjectionCapturesDetailMirrorFields() {
-    var session = Session(
-      id: "session-1",
-      endpointId: UUID(uuidString: "11111111-1111-1111-1111-111111111111"),
-      endpointName: "Primary",
-      projectPath: "/tmp/project",
-      projectName: "project",
-      branch: "main",
-      model: "claude-opus",
-      transcriptPath: "/tmp/transcript.jsonl",
-      status: .active,
-      workStatus: .waiting,
-      startedAt: Date(timeIntervalSince1970: 100),
-      endReason: "completed",
-      totalTokens: 321,
-      lastActivityAt: Date(timeIntervalSince1970: 200),
-      attentionReason: .awaitingReply,
-      provider: .claude,
-      claudeIntegrationMode: .direct,
-      inputTokens: 120,
-      outputTokens: 201,
-      cachedTokens: 12,
-      contextWindow: 200_000
-    )
-    session.effort = "high"
-    session.summary = "Refactor session store"
-    session.customName = "Important Session"
-    session.firstPrompt = "Please refactor this"
-    session.lastMessage = "Latest message"
-    session.endedAt = Date(timeIntervalSince1970: 150)
-    session.totalCostUSD = 1.25
-    session.lastTool = "Bash"
-    session.lastToolAt = Date(timeIntervalSince1970: 201)
-    session.pendingToolName = "Bash"
-    session.pendingToolInput = #"{"command":"pwd"}"#
-    session.pendingPermissionDetail = "pwd"
-    session.pendingQuestion = "Continue?"
-    session.pendingApprovalId = "req-42"
-    session.promptCount = 3
-    session.toolCount = 9
-    session.gitSha = "abc123"
-    session.currentCwd = "/tmp/project/subdir"
-    session.repositoryRoot = "/tmp/project"
-    session.isWorktree = true
-    session.worktreeId = "wt-1"
-    session.unreadCount = 7
-
-    let projection = SessionDetailSnapshotProjection.from(session)
-
-    #expect(projection.endpointName == "Primary")
-    #expect(projection.projectPath == "/tmp/project")
-    #expect(projection.model == "claude-opus")
-    #expect(projection.pendingApprovalId == "req-42")
-    #expect(projection.pendingPermissionDetail == "pwd")
-    #expect(projection.totalTokens == 321)
-    #expect(projection.totalCostUSD == 1.25)
-    #expect(projection.repositoryRoot == "/tmp/project")
-    #expect(projection.isWorktree)
-    #expect(projection.worktreeId == "wt-1")
-    #expect(projection.unreadCount == 7)
-  }
-
-  @Test func snapshotProjectionHydratesDiffPlanTurnAndSubagentFields() {
+  @Test func sessionObservableApplyServerSnapshotHydratesDiffPlanTurnAndSubagentFields() throws {
     let observable = SessionObservable(id: "session-1")
 
-    let turnDiff = ServerTurnDiff(
-      turnId: "turn-42",
-      diff: "diff --git a/file.swift b/file.swift",
-      inputTokens: 10,
-      outputTokens: 5,
-      cachedTokens: 2,
-      contextWindow: 100_000
-    )
-    let subagent = ServerSubagentInfo(
-      id: "worker-1",
-      agentType: "worker",
-      startedAt: "2026-03-22T10:00:00Z",
-      endedAt: nil,
-      provider: .codex,
-      label: "Leibniz",
-      status: .running,
-      taskSummary: "Check Makefile",
-      resultSummary: nil,
-      errorSummary: nil,
-      parentSubagentId: nil,
-      model: "gpt-5.4",
-      lastActivityAt: "2026-03-22T10:00:01Z"
-    )
-
-    let projection = SessionDetailSnapshotProjection(
-      endpointId: nil,
-      endpointName: nil,
-      projectPath: "/tmp/project",
-      projectName: nil,
-      branch: nil,
-      model: nil,
-      effort: nil,
-      collaborationMode: nil,
-      multiAgent: nil,
-      personality: nil,
-      serviceTier: nil,
-      developerInstructions: nil,
-      codexConfigSource: nil,
-      codexConfigMode: nil,
-      codexConfigProfile: nil,
-      codexModelProvider: nil,
-      codexConfigOverrides: nil,
-      summary: nil,
-      customName: nil,
-      firstPrompt: nil,
-      lastMessage: nil,
-      transcriptPath: nil,
-      status: .active,
-      workStatus: .working,
-      attentionReason: .none,
-      lastActivityAt: nil,
-      lastFilesPersistedAt: nil,
-      lastTool: nil,
-      lastToolAt: nil,
-      inputTokens: nil,
-      outputTokens: nil,
-      cachedTokens: nil,
-      contextWindow: nil,
-      totalTokens: 0,
-      totalCostUSD: 0,
-      provider: .claude,
-      codexIntegrationMode: nil,
-      claudeIntegrationMode: .direct,
-      codexThreadId: nil,
-      pendingApprovalId: nil,
-      pendingToolName: nil,
-      pendingToolInput: nil,
-      pendingPermissionDetail: nil,
-      pendingQuestion: nil,
-      promptCount: 0,
-      toolCount: 0,
-      startedAt: nil,
-      endedAt: nil,
-      endReason: nil,
-      tokenUsageSnapshotKind: .lifetimeTotals,
-      gitSha: nil,
-      currentCwd: nil,
-      repositoryRoot: nil,
-      isWorktree: false,
-      worktreeId: nil,
-      unreadCount: 0,
-      currentDiff: "diff --git a/file.swift",
-      cumulativeDiff: "cumulative diff content",
-      currentPlan: #"[{"step":"Refactor","status":"inProgress"}]"#,
-      turnDiffs: [turnDiff],
-      currentTurnId: "turn-42",
-      turnCount: 3,
-      subagents: [subagent],
-      missionId: nil,
-      issueIdentifier: nil,
-      allowBypassPermissions: false
+    let state = try decodeServerSessionState(
+      """
+      {
+        "id": "session-1",
+        "provider": "claude",
+        "project_path": "/tmp/project",
+        "status": "active",
+        "work_status": "working",
+        "steerable": true,
+        "token_usage": {"input_tokens": 0, "output_tokens": 0, "cached_tokens": 0, "context_window": 0},
+        "token_usage_snapshot_kind": "lifetime_totals",
+        "turn_count": 3,
+        "current_turn_id": "turn-42",
+        "current_diff": "diff --git a/file.swift",
+        "cumulative_diff": "cumulative diff content",
+        "current_plan": "[{\\"step\\":\\"Refactor\\",\\"status\\":\\"inProgress\\"}]",
+        "turn_diffs": [
+          {
+            "turn_id": "turn-42",
+            "diff": "diff --git a/file.swift b/file.swift",
+            "input_tokens": 10,
+            "output_tokens": 5,
+            "cached_tokens": 2,
+            "context_window": 100000
+          }
+        ],
+        "subagents": [
+          {
+            "id": "worker-1",
+            "agent_type": "worker",
+            "started_at": "2026-03-22T10:00:00Z",
+            "provider": "codex",
+            "label": "Leibniz",
+            "status": "running",
+            "task_summary": "Check Makefile",
+            "model": "gpt-5.4",
+            "last_activity_at": "2026-03-22T10:00:01Z"
+          }
+        ]
+      }
+      """
     )
 
-    observable.applySnapshotProjection(projection)
+    observable.applyServerSnapshot(state)
 
     #expect(observable.diff == "diff --git a/file.swift")
     #expect(observable.cumulativeDiff == "cumulative diff content")
@@ -458,7 +254,7 @@ struct SessionStateProjectionTests {
     #expect(observable.pendingShellContext.isEmpty)
   }
 
-  @Test func sessionStateProjectionAppliesSharedDeltaFieldsToListAndDetail() throws {
+  @Test func sessionObservableApplyServerDeltaAppliesSharedFields() throws {
     let changes = try decodeChanges(
       """
       {
@@ -492,36 +288,11 @@ struct SessionStateProjectionTests {
       }
       """
     )
-    let projection = SessionStateProjection.from(changes)
 
-    var session = Session(
-      id: "session-1",
-      projectPath: "/tmp/project",
-      status: .active,
-      workStatus: .waiting,
-      attentionReason: .awaitingReply,
-      provider: .codex,
-      codexIntegrationMode: .direct
-    )
     let observable = SessionObservable(id: "session-1")
     observable.promptSuggestions = ["keep me?"]
 
-    session.applyProjection(projection)
-    observable.applyProjection(projection)
-
-    #expect(session.workStatus == .working)
-    #expect(session.attentionReason == .none)
-    #expect(session.totalTokens == 165)
-    #expect(session.tokenUsageSnapshotKind == .contextTurn)
-    #expect(session.currentDiff == "diff --git a/file.swift b/file.swift")
-    #expect(session.customName == "Pinned Session")
-    #expect(session.summary == "Refactor the client runtime")
-    #expect(session.branch == "main")
-    #expect(session.currentCwd == "/tmp/project")
-    #expect(session.repositoryRoot == "/tmp/repo")
-    #expect(session.isWorktree)
-    #expect(session.unreadCount == 7)
-    #expect(session.lastActivityAt == Date(timeIntervalSince1970: 1_234))
+    observable.applyServerDelta(changes)
 
     #expect(observable.workStatus == .working)
     #expect(observable.attentionReason == .none)
@@ -536,7 +307,7 @@ struct SessionStateProjectionTests {
     #expect(observable.unreadCount == 7)
   }
 
-  @Test func sessionAndObservableApplyTokenUsageKeepSnapshotKindInSync() {
+  @Test func sessionObservableApplyTokenUsageKeepsSnapshotKindInSync() {
     let usage = ServerTokenUsage(
       inputTokens: 50,
       outputTokens: 25,
@@ -544,26 +315,9 @@ struct SessionStateProjectionTests {
       contextWindow: 1_000
     )
 
-    var session = Session(
-      id: "session-1",
-      projectPath: "/tmp/project",
-      status: .active,
-      workStatus: .working,
-      attentionReason: .none,
-      provider: .claude,
-      claudeIntegrationMode: .direct
-    )
     let observable = SessionObservable(id: "session-1")
 
-    session.applyTokenUsage(usage, snapshotKind: .lifetimeTotals)
     observable.applyTokenUsage(usage, snapshotKind: .lifetimeTotals)
-
-    #expect(session.inputTokens == 50)
-    #expect(session.outputTokens == 25)
-    #expect(session.cachedTokens == 10)
-    #expect(session.contextWindow == 1_000)
-    #expect(session.totalTokens == 75)
-    #expect(session.tokenUsageSnapshotKind == .lifetimeTotals)
 
     #expect(observable.inputTokens == 50)
     #expect(observable.outputTokens == 25)
@@ -585,25 +339,9 @@ struct SessionStateProjectionTests {
       snapshotKind: .contextTurn
     )
 
-    var session = Session(
-      id: "session-1",
-      projectPath: "/tmp/project",
-      status: .active,
-      workStatus: .working,
-      attentionReason: .none,
-      provider: .claude,
-      claudeIntegrationMode: .direct
-    )
     let observable = SessionObservable(id: "session-1")
 
-    session.applyTurnDiffSnapshot(projection)
     observable.applyTurnDiffSnapshot(projection)
-
-    #expect(session.inputTokens == 40)
-    #expect(session.outputTokens == 15)
-    #expect(session.cachedTokens == 5)
-    #expect(session.contextWindow == 2_000)
-    #expect(session.tokenUsageSnapshotKind == .contextTurn)
 
     #expect(observable.turnDiffs.count == 1)
     #expect(observable.turnDiffs.first?.turnId == "turn-1")
@@ -649,7 +387,7 @@ struct SessionStateProjectionTests {
     #expect(observable.tokenUsageSnapshotKind == .lifetimeTotals)
   }
 
-  @Test func sessionAndObservableShareTokenUsageSemantics() {
+  @Test func sessionObservableTokenUsageSemanticsMatchSessionStruct() {
     let session = Session(
       id: "session-1",
       projectPath: "/tmp/project",
@@ -664,7 +402,7 @@ struct SessionStateProjectionTests {
     )
     let observable = SessionObservable(id: "session-1")
 
-    observable.applySnapshotProjection(SessionDetailSnapshotProjection.from(session))
+    observable.populateFromPreviewSession(session)
 
     #expect(observable.effectiveContextInputTokens == session.effectiveContextInputTokens)
     #expect(observable.contextFillPercent == session.contextFillPercent)
@@ -759,6 +497,10 @@ struct SessionStateProjectionTests {
 
   private func decodeChanges(_ json: String) throws -> ServerStateChanges {
     try JSONDecoder().decode(ServerStateChanges.self, from: Data(json.utf8))
+  }
+
+  private func decodeServerSessionState(_ json: String) throws -> ServerSessionState {
+    try JSONDecoder().decode(ServerSessionState.self, from: Data(json.utf8))
   }
 
   private func assistantRow(

--- a/OrbitDockNative/OrbitDockTests/Server/Sessions/SessionStatusConsistencyTests.swift
+++ b/OrbitDockNative/OrbitDockTests/Server/Sessions/SessionStatusConsistencyTests.swift
@@ -4,33 +4,45 @@ import Testing
 
 @MainActor
 struct SessionStatusConsistencyTests {
-  @Test func sessionDisplayStatusPrefersAttentionReasonOverWorkStatus() {
-    let permissionSession = Session(
+  @Test func rootSessionNodeDisplayStatusPrefersAttentionReasonOverWorkStatus() {
+    let permissionNode = makeRootSessionNode(from: Session(
       id: "permission-session",
+      endpointId: UUID(),
+      endpointName: nil,
+      endpointConnectionStatus: .connected,
       projectPath: "/tmp/project",
+      projectName: nil,
       status: .active,
       workStatus: .waiting,
       attentionReason: .awaitingPermission
-    )
-    #expect(SessionDisplayStatus.from(permissionSession) == .permission)
+    ))
+    #expect(permissionNode.displayStatus == .permission)
 
-    let questionSession = Session(
+    let questionNode = makeRootSessionNode(from: Session(
       id: "question-session",
+      endpointId: UUID(),
+      endpointName: nil,
+      endpointConnectionStatus: .connected,
       projectPath: "/tmp/project",
+      projectName: nil,
       status: .active,
       workStatus: .working,
       attentionReason: .awaitingQuestion
-    )
-    #expect(SessionDisplayStatus.from(questionSession) == .question)
+    ))
+    #expect(questionNode.displayStatus == .question)
 
-    let replySession = Session(
+    let replyNode = makeRootSessionNode(from: Session(
       id: "reply-session",
+      endpointId: UUID(),
+      endpointName: nil,
+      endpointConnectionStatus: .connected,
       projectPath: "/tmp/project",
+      projectName: nil,
       status: .active,
       workStatus: .working,
       attentionReason: .awaitingReply
-    )
-    #expect(SessionDisplayStatus.from(replySession) == .reply)
+    ))
+    #expect(replyNode.displayStatus == .reply)
   }
 
   @Test func notificationMessagesFollowDisplayStatusInsteadOfRawWorkStatus() {


### PR DESCRIPTION
## Summary

- Remove `SessionDetailSnapshotProjection` and `SessionStateProjection` intermediary structs that only copied fields between server wire types and `SessionObservable`
- `SessionObservable` now consumes `ServerSessionState` (snapshot) and `ServerStateChanges` (delta) directly via `applyServerSnapshot()` and `applyServerDelta()`
- Remove dead `Session` mutation methods (`applyProjection`, `applyTokenUsage`, `applyPendingApprovalSummary`, etc.) and unused `Session`-based convenience initializers in Theme/CapabilityBadge
- Net removal of ~700 lines of structural-copy boilerplate

## Test plan

- [x] Full macOS test suite passes (all projection, status consistency, and existing tests green)
- [x] Preview/demo code paths updated to use `populateFromPreviewSession()`
- [x] Build compiles clean on macOS

Closes #119