### PR TITLE
🐛 Fix silent FK constraint violations in persistence layer

### DIFF
--- a/orbitdock-server/crates/server/src/infrastructure/migration_runner.rs
+++ b/orbitdock-server/crates/server/src/infrastructure/migration_runner.rs
@@ -27,7 +27,8 @@ pub fn run_migrations(conn: &mut Connection) -> anyhow::Result<()> {
     conn.execute_batch(
         "PRAGMA journal_mode = WAL;
          PRAGMA busy_timeout = 5000;
-         PRAGMA synchronous = NORMAL;",
+         PRAGMA synchronous = NORMAL;
+         PRAGMA foreign_keys = ON;",
     )?;
 
     import_legacy_history(conn)?;

--- a/orbitdock-server/crates/server/src/infrastructure/persistence/commands.rs
+++ b/orbitdock-server/crates/server/src/infrastructure/persistence/commands.rs
@@ -428,6 +428,66 @@ pub enum PersistCommand {
 }
 
 impl PersistCommand {
+    /// Short label for structured logging.
+    pub fn type_name(&self) -> &'static str {
+        match self {
+            PersistCommand::SessionCreate(_) => "SessionCreate",
+            PersistCommand::SessionUpdate { .. } => "SessionUpdate",
+            PersistCommand::SessionEnd { .. } => "SessionEnd",
+            PersistCommand::RowAppend { .. } => "RowAppend",
+            PersistCommand::RowUpsert { .. } => "RowUpsert",
+            PersistCommand::TokensUpdate { .. } => "TokensUpdate",
+            PersistCommand::TurnStateUpdate { .. } => "TurnStateUpdate",
+            PersistCommand::TurnDiffInsert { .. } => "TurnDiffInsert",
+            PersistCommand::SetThreadId { .. } => "SetThreadId",
+            PersistCommand::CleanupThreadShadowSession { .. } => "CleanupThreadShadowSession",
+            PersistCommand::SetClaudeSdkSessionId { .. } => "SetClaudeSdkSessionId",
+            PersistCommand::CleanupClaudeShadowSession { .. } => "CleanupClaudeShadowSession",
+            PersistCommand::SetCustomName { .. } => "SetCustomName",
+            PersistCommand::SetSummary { .. } => "SetSummary",
+            PersistCommand::SetSessionConfig { .. } => "SetSessionConfig",
+            PersistCommand::MarkSessionRead { .. } => "MarkSessionRead",
+            PersistCommand::ReactivateSession { .. } => "ReactivateSession",
+            PersistCommand::ClaudeSessionUpsert { .. } => "ClaudeSessionUpsert",
+            PersistCommand::ClaudeSessionUpdate { .. } => "ClaudeSessionUpdate",
+            PersistCommand::ClaudeSessionEnd { .. } => "ClaudeSessionEnd",
+            PersistCommand::ClaudePromptIncrement { .. } => "ClaudePromptIncrement",
+            PersistCommand::ClaudeToolIncrement { .. } => "ClaudeToolIncrement",
+            PersistCommand::ToolCountIncrement { .. } => "ToolCountIncrement",
+            PersistCommand::ModelUpdate { .. } => "ModelUpdate",
+            PersistCommand::EffortUpdate { .. } => "EffortUpdate",
+            PersistCommand::ClaudeSubagentStart { .. } => "ClaudeSubagentStart",
+            PersistCommand::ClaudeSubagentEnd { .. } => "ClaudeSubagentEnd",
+            PersistCommand::UpsertSubagent { .. } => "UpsertSubagent",
+            PersistCommand::UpsertSubagents { .. } => "UpsertSubagents",
+            PersistCommand::RolloutSessionUpsert { .. } => "RolloutSessionUpsert",
+            PersistCommand::RolloutSessionUpdate { .. } => "RolloutSessionUpdate",
+            PersistCommand::RolloutPromptIncrement { .. } => "RolloutPromptIncrement",
+            PersistCommand::CodexPromptIncrement { .. } => "CodexPromptIncrement",
+            PersistCommand::RolloutToolIncrement { .. } => "RolloutToolIncrement",
+            PersistCommand::UpsertRolloutCheckpoint { .. } => "UpsertRolloutCheckpoint",
+            PersistCommand::DeleteRolloutCheckpoint { .. } => "DeleteRolloutCheckpoint",
+            PersistCommand::ApprovalRequested(_) => "ApprovalRequested",
+            PersistCommand::ApprovalDecision { .. } => "ApprovalDecision",
+            PersistCommand::ReviewCommentCreate { .. } => "ReviewCommentCreate",
+            PersistCommand::ReviewCommentUpdate { .. } => "ReviewCommentUpdate",
+            PersistCommand::ReviewCommentDelete { .. } => "ReviewCommentDelete",
+            PersistCommand::SetIntegrationMode { .. } => "SetIntegrationMode",
+            PersistCommand::EnvironmentUpdate { .. } => "EnvironmentUpdate",
+            PersistCommand::SetConfig { .. } => "SetConfig",
+            PersistCommand::WorktreeCreate { .. } => "WorktreeCreate",
+            PersistCommand::WorktreeUpdateStatus { .. } => "WorktreeUpdateStatus",
+            PersistCommand::MissionCreate { .. } => "MissionCreate",
+            PersistCommand::MissionUpdate { .. } => "MissionUpdate",
+            PersistCommand::MissionSetTrackerKey { .. } => "MissionSetTrackerKey",
+            PersistCommand::MissionDelete { .. } => "MissionDelete",
+            PersistCommand::MissionIssueUpsert { .. } => "MissionIssueUpsert",
+            PersistCommand::MissionIssueUpdateState { .. } => "MissionIssueUpdateState",
+            PersistCommand::MissionIssueSetPrUrl { .. } => "MissionIssueSetPrUrl",
+            PersistCommand::RowsTurnStatusUpdate { .. } => "RowsTurnStatusUpdate",
+        }
+    }
+
     /// Returns true if this command has a response channel that the caller is awaiting.
     /// The writer should flush immediately when any batched command needs a response.
     pub fn has_response_channel(&self) -> bool {

--- a/orbitdock-server/crates/server/src/infrastructure/persistence/mod.rs
+++ b/orbitdock-server/crates/server/src/infrastructure/persistence/mod.rs
@@ -412,11 +412,14 @@ pub(super) fn execute_command(
             let is_user = entry.row.is_user_input();
 
             // DB computes sequence as MAX(sequence)+1 — single source of truth.
+            // ON CONFLICT(id) DO NOTHING deduplicates by PK only — FK violations
+            // on session_id still bubble up (unlike INSERT OR IGNORE which swallows all).
             conn.execute(
-                "INSERT OR IGNORE INTO messages (id, session_id, type, content, timestamp, sequence, row_data, turn_status)
+                "INSERT INTO messages (id, session_id, type, content, timestamp, sequence, row_data, turn_status)
                  VALUES (?1, ?2, ?3, ?4, ?5, COALESCE(?6,
                    (SELECT MAX(sequence) + 1 FROM messages WHERE session_id = ?2), 0),
-                   ?7, ?8)",
+                   ?7, ?8)
+                 ON CONFLICT(id) DO NOTHING",
                 params![
                     row_id,
                     session_id,

--- a/orbitdock-server/crates/server/src/infrastructure/persistence/tests.rs
+++ b/orbitdock-server/crates/server/src/infrastructure/persistence/tests.rs
@@ -33,6 +33,7 @@ fn setup_test_db() -> (
         "PRAGMA journal_mode = WAL;
          PRAGMA busy_timeout = 5000;
          PRAGMA synchronous = NORMAL;
+         PRAGMA foreign_keys = ON;
 
          CREATE TABLE IF NOT EXISTS sessions (
            id TEXT PRIMARY KEY,
@@ -114,7 +115,7 @@ fn setup_test_db() -> (
 
          CREATE TABLE IF NOT EXISTS messages (
            id TEXT PRIMARY KEY,
-           session_id TEXT NOT NULL,
+           session_id TEXT NOT NULL REFERENCES sessions(id),
            type TEXT NOT NULL DEFAULT '',
            content TEXT NOT NULL DEFAULT '',
            timestamp TEXT,
@@ -128,7 +129,7 @@ fn setup_test_db() -> (
            ON messages(session_id, sequence);
 
          CREATE TABLE IF NOT EXISTS turn_diffs (
-           session_id TEXT NOT NULL,
+           session_id TEXT NOT NULL REFERENCES sessions(id),
            turn_id TEXT NOT NULL,
            diff TEXT NOT NULL,
            input_tokens INTEGER NOT NULL DEFAULT 0,
@@ -519,7 +520,7 @@ fn row_append_ignore_deduplicates_by_id() {
     let (conn, db_path, _dir, _guard) = setup_test_db();
     drop(conn);
 
-    // INSERT OR IGNORE means second insert with same id is silently dropped
+    // ON CONFLICT(id) DO NOTHING means second insert with same id is silently dropped
     let batch = vec![
         PersistCommand::RowAppend {
             session_id: "test-session".to_string(),
@@ -542,11 +543,11 @@ fn row_append_ignore_deduplicates_by_id() {
     let conn = Connection::open(&db_path).unwrap();
     let rows = load_messages_from_db(&conn, "test-session").unwrap();
 
-    // Only one row should exist — the first one wins with INSERT OR IGNORE
+    // Only one row should exist — the first one wins with ON CONFLICT(id) DO NOTHING
     assert_eq!(rows.len(), 1);
     assert_eq!(
         rows[0].sequence, 0,
-        "first insert wins with INSERT OR IGNORE"
+        "first insert wins with ON CONFLICT(id) DO NOTHING"
     );
 }
 
@@ -1083,5 +1084,47 @@ fn mission_clear_tracker_key() {
     assert!(
         key.is_none(),
         "tracker_api_key should be NULL after clearing"
+    );
+}
+
+#[test]
+fn row_append_fk_violation_rejects_orphan_message() {
+    let (conn, db_path, _dir, _guard) = setup_test_db();
+    drop(conn);
+
+    // Mix a valid command with an FK-violating one (ghost-session doesn't exist).
+    // The batch should succeed overall — the orphan is skipped, the valid one persists.
+    let batch = vec![
+        PersistCommand::RowAppend {
+            session_id: "test-session".to_string(),
+            viewer_present: false,
+            assigned_sequence: None,
+            sequence_tx: None,
+            entry: user_entry("valid-msg", 0),
+        },
+        PersistCommand::RowAppend {
+            session_id: "ghost-session".to_string(),
+            viewer_present: false,
+            assigned_sequence: None,
+            sequence_tx: None,
+            entry: {
+                let mut e = user_entry("orphan-msg", 0);
+                e.session_id = "ghost-session".to_string();
+                e
+            },
+        },
+    ];
+
+    super::writer::flush_batch_for_test(&db_path, batch).unwrap();
+
+    let conn = Connection::open(&db_path).unwrap();
+    let valid_rows = load_messages_from_db(&conn, "test-session").unwrap();
+    assert_eq!(valid_rows.len(), 1, "valid message should be persisted");
+
+    let ghost_rows = load_messages_from_db(&conn, "ghost-session").unwrap();
+    assert_eq!(
+        ghost_rows.len(),
+        0,
+        "orphan message must NOT be persisted (FK violation)"
     );
 }

--- a/orbitdock-server/crates/server/src/infrastructure/persistence/writer.rs
+++ b/orbitdock-server/crates/server/src/infrastructure/persistence/writer.rs
@@ -163,7 +163,8 @@ pub(crate) fn flush_batch(
     conn.execute_batch(
         "PRAGMA journal_mode = WAL;
          PRAGMA busy_timeout = 5000;
-         PRAGMA synchronous = NORMAL;",
+         PRAGMA synchronous = NORMAL;
+         PRAGMA foreign_keys = ON;",
     )?;
 
     let count = batch.len();
@@ -171,14 +172,26 @@ pub(crate) fn flush_batch(
     let mut sync_commands = Vec::new();
 
     for cmd in batch {
+        let cmd_type = cmd.type_name();
         let sync_plan = SyncPlan::from_command(&cmd);
         if let Err(error) = super::execute_command(&tx, cmd) {
-            error!(
-                component = "persistence",
-                event = "persistence.command.failed",
-                error = %error,
-                "Failed to execute persistence command"
-            );
+            if is_foreign_key_violation(&error) {
+                warn!(
+                    component = "persistence",
+                    event = "persistence.command.fk_violation",
+                    error = %error,
+                    command_type = cmd_type,
+                    "FK constraint violation — parent row may not exist"
+                );
+            } else {
+                error!(
+                    component = "persistence",
+                    event = "persistence.command.failed",
+                    error = %error,
+                    command_type = cmd_type,
+                    "Failed to execute persistence command"
+                );
+            }
             continue;
         }
 
@@ -204,6 +217,19 @@ pub(crate) fn flush_batch(
         command_count: count,
         sync_commands,
     })
+}
+
+fn is_foreign_key_violation(error: &rusqlite::Error) -> bool {
+    matches!(
+        error,
+        rusqlite::Error::SqliteFailure(
+            rusqlite::ffi::Error {
+                extended_code: rusqlite::ffi::SQLITE_CONSTRAINT_FOREIGNKEY,
+                ..
+            },
+            _
+        )
+    )
 }
 
 #[cfg(test)]

--- a/orbitdock-server/crates/server/src/transport/http/sync.rs
+++ b/orbitdock-server/crates/server/src/transport/http/sync.rs
@@ -61,7 +61,8 @@ pub async fn post_sync_batch(
         conn.execute_batch(
             "PRAGMA journal_mode = WAL;
              PRAGMA busy_timeout = 5000;
-             PRAGMA synchronous = NORMAL;",
+             PRAGMA synchronous = NORMAL;
+             PRAGMA foreign_keys = ON;",
         )?;
 
         let target = resolve_workspace_sync_target(&conn, &token_id_clone)?


### PR DESCRIPTION
## Summary

- `libsqlite3-sys` compiles SQLite with `-DSQLITE_DEFAULT_FOREIGN_KEYS=1`, meaning FK enforcement has been silently active on every connection. We were writing code assuming FKs were off — they weren't.
- `INSERT OR IGNORE` on `RowAppend` was swallowing FK violations alongside legitimate PK dedup, causing messages to **silently vanish** when the parent session row didn't exist yet (e.g., failed session creation, hook timing races).
- Replaces `INSERT OR IGNORE` with `ON CONFLICT(id) DO NOTHING` so only PK duplicates are suppressed; FK violations now surface as errors.
- Classifies FK violations distinctly in `flush_batch` with a `persistence.command.fk_violation` warn event and `command_type` label for observability.
- Makes FK enforcement explicit with `PRAGMA foreign_keys = ON` in the writer and migration runner.
- Fixes test schema to include FK constraints matching production and adds a FK violation regression test.

Addresses the server-side root cause behind #159.

## Test plan

- [x] All 411 existing tests pass (`make rust-ci` clean)
- [x] New `row_append_fk_violation_rejects_orphan_message` test validates orphan messages are rejected
- [x] Existing dedup test confirms `ON CONFLICT(id) DO NOTHING` preserves replay idempotency
- [ ] Monitor `persistence.command.fk_violation` log events after deploy to gauge real-world frequency