### PR TITLE
🐛 Fix Codex provider-scoped session routing

### DIFF
--- a/OrbitDockNative/OrbitDock/PreviewRuntime.swift
+++ b/OrbitDockNative/OrbitDock/PreviewRuntime.swift
@@ -101,7 +101,6 @@ struct PreviewRuntime {
     self.appStore.router = router
   }
 
-  @ViewBuilder
   func inject(_ content: some View) -> some View {
     content
       .environment(sessionStore)

--- a/OrbitDockNative/OrbitDock/Views/NewSession/CodexConfigManagerSheet.swift
+++ b/OrbitDockNative/OrbitDock/Views/NewSession/CodexConfigManagerSheet.swift
@@ -1133,4 +1133,5 @@ private struct CodexProviderDraft {
     }
     return ""
   }
+
 }

--- a/OrbitDockNative/OrbitDock/Views/NewSession/NewSessionConfigurationCard.swift
+++ b/OrbitDockNative/OrbitDock/Views/NewSession/NewSessionConfigurationCard.swift
@@ -25,6 +25,9 @@ struct NewSessionConfigurationCard: View {
   let codexCatalog: SessionsClient.CodexConfigCatalogResponse?
   let codexCatalogLoading: Bool
   let codexCatalogError: String?
+  let codexScopedModelProvider: String?
+  let codexScopedModelsLoading: Bool
+  let codexScopedModelError: String?
   let onInspectCodexConfig: (() -> Void)?
   let onManageCodexConfig: (() -> Void)?
 
@@ -88,6 +91,31 @@ struct NewSessionConfigurationCard: View {
 
   private var usesCustomCodexConfig: Bool {
     codexConfigMode == .custom
+  }
+
+  private var codexScopedModelNotice: String? {
+    guard usesCustomCodexConfig,
+          let provider = codexScopedModelProvider?.trimmingCharacters(in: .whitespacesAndNewlines),
+          !provider.isEmpty
+    else {
+      return nil
+    }
+
+    if codexScopedModelsLoading {
+      return "Loading provider-scoped models for \(provider)…"
+    }
+
+    if let codexScopedModelError, !codexScopedModelError.isEmpty {
+      return
+        "Couldn’t load models for \(provider). OrbitDock is hiding the generic Codex list here so you only pick provider-compatible models. You can still type a model ID manually."
+    }
+
+    if codexModels.isEmpty {
+      return
+        "No suggested models were returned for \(provider). OrbitDock is hiding the generic Codex list here so you don’t pick an incompatible model."
+    }
+
+    return nil
   }
 
   private var codexResolvedProfileLabel: String {
@@ -392,9 +420,11 @@ struct NewSessionConfigurationCard: View {
     .onChange(of: codexConfigMode) { _, newValue in
       switch newValue {
         case .inherit:
+          codexModel = ""
           codexConfigProfile = ""
           codexModelProvider = ""
         case .profile:
+          codexModel = ""
           codexModelProvider = ""
           if codexConfigProfile.isEmpty {
             codexConfigProfile = profileOptions.first?.name ?? ""
@@ -755,8 +785,14 @@ struct NewSessionConfigurationCard: View {
               }
             }
           } description: {
-            Text(currentCodexModelOption?
-              .description ?? "Enter any Codex model ID, or pick one of the discovered suggestions.")
+            VStack(alignment: .leading, spacing: Spacing.sm) {
+              Text(currentCodexModelOption?
+                .description ?? "Enter any Codex model ID, or pick one of the discovered suggestions.")
+
+              if let codexScopedModelNotice {
+                codexScopedModelNoticeView(codexScopedModelNotice)
+              }
+            }
           }
         }
 
@@ -799,8 +835,14 @@ struct NewSessionConfigurationCard: View {
               }
             }
           } description: {
-            Text(currentCodexModelOption?
-              .description ?? "Enter any Codex model ID, or pick one of the discovered suggestions.")
+            VStack(alignment: .leading, spacing: Spacing.sm) {
+              Text(currentCodexModelOption?
+                .description ?? "Enter any Codex model ID, or pick one of the discovered suggestions.")
+
+              if let codexScopedModelNotice {
+                codexScopedModelNoticeView(codexScopedModelNotice)
+              }
+            }
           }
         }
       }
@@ -842,6 +884,24 @@ struct NewSessionConfigurationCard: View {
       RoundedRectangle(cornerRadius: Radius.md, style: .continuous)
         .stroke(Color.surfaceBorder.opacity(OpacityTier.light), lineWidth: 1)
     )
+  }
+
+  private func codexScopedModelNoticeView(_ message: String) -> some View {
+    HStack(alignment: .top, spacing: Spacing.sm) {
+      if codexScopedModelsLoading {
+        ProgressView()
+          .controlSize(.small)
+      } else {
+        Image(systemName: "exclamationmark.triangle.fill")
+          .font(.system(size: TypeScale.micro, weight: .semibold))
+          .foregroundStyle(Color.feedbackCaution)
+      }
+
+      Text(message)
+        .font(.system(size: TypeScale.micro))
+        .foregroundStyle(Color.textTertiary)
+        .fixedSize(horizontal: false, vertical: true)
+    }
   }
 
   private var customProviderRow: some View {

--- a/OrbitDockNative/OrbitDock/Views/NewSession/NewSessionSheet.swift
+++ b/OrbitDockNative/OrbitDock/Views/NewSession/NewSessionSheet.swift
@@ -30,6 +30,8 @@ struct NewSessionSheet: View {
   @State private var codexConfigCatalogLoading = false
   @State private var codexConfigCatalogRequestID = 0
   @State private var codexScopedModels: [ServerCodexModelOption]?
+  @State private var codexScopedModelsLoading = false
+  @State private var codexScopedModelsError: String?
   @State private var codexScopedModelsRequestID = 0
 
   @MainActor
@@ -85,7 +87,10 @@ struct NewSessionSheet: View {
   }
 
   private var codexModels: [ServerCodexModelOption] {
-    codexScopedModels ?? endpointAppState.codexModels
+    if scopedCodexModelProvider != nil {
+      return codexScopedModels ?? []
+    }
+    return endpointAppState.codexModels
   }
 
   private var resolvedClaudeModel: String? {
@@ -478,6 +483,9 @@ struct NewSessionSheet: View {
       codexCatalog: codexConfigCatalog,
       codexCatalogLoading: codexConfigCatalogLoading,
       codexCatalogError: codexConfigCatalogError,
+      codexScopedModelProvider: scopedCodexModelProvider,
+      codexScopedModelsLoading: codexScopedModelsLoading,
+      codexScopedModelError: codexScopedModelsError,
       onInspectCodexConfig: inspectCodexConfig,
       onManageCodexConfig: openCodexConfigManager
     )
@@ -609,23 +617,39 @@ struct NewSessionSheet: View {
   private func refreshScopedCodexModelsIfNeeded(force _: Bool = false) {
     guard model.provider == .codex else {
       codexScopedModels = nil
+      codexScopedModelsLoading = false
+      codexScopedModelsError = nil
       return
     }
 
     guard model.codexConfigMode == .custom else {
       codexScopedModels = nil
+      codexScopedModelsLoading = false
+      codexScopedModelsError = nil
       return
     }
 
     let cwd = model.selectedPath.trimmingCharacters(in: .whitespacesAndNewlines)
     guard !cwd.isEmpty else {
       codexScopedModels = nil
+      codexScopedModelsLoading = false
+      codexScopedModelsError = nil
       return
     }
 
     let modelProvider = scopedCodexModelProvider
+    guard modelProvider != nil else {
+      codexScopedModels = nil
+      codexScopedModelsLoading = false
+      codexScopedModelsError = nil
+      return
+    }
+
     codexScopedModelsRequestID += 1
     let requestID = codexScopedModelsRequestID
+    codexScopedModelsLoading = true
+    codexScopedModelsError = nil
+    codexScopedModels = nil
 
     Task {
       do {
@@ -641,11 +665,15 @@ struct NewSessionSheet: View {
                 scopedCodexModelProvider == modelProvider
           else { return }
           codexScopedModels = models
+          codexScopedModelsLoading = false
+          codexScopedModelsError = nil
         }
       } catch {
         await MainActor.run {
           guard requestID == codexScopedModelsRequestID else { return }
           codexScopedModels = nil
+          codexScopedModelsLoading = false
+          codexScopedModelsError = error.localizedDescription
         }
       }
     }

--- a/OrbitDockNative/OrbitDock/Views/Providers/Codex/ModelEffortPicker.swift
+++ b/OrbitDockNative/OrbitDock/Views/Providers/Codex/ModelEffortPicker.swift
@@ -14,6 +14,10 @@ struct ModelEffortPopover: View {
   @Binding var selectedModel: String
   @Binding var selectedEffort: EffortLevel
   let models: [ServerCodexModelOption]
+  let currentModel: String?
+  let allowsModelSelection: Bool
+  let noticeMessage: String?
+  let noticeIsLoading: Bool
 
   @Environment(\.dismiss) private var dismiss
   @State private var showModelPicker = false
@@ -26,11 +30,30 @@ struct ModelEffortPopover: View {
   }
 
   private var selectedModelOption: ServerCodexModelOption? {
-    availableModels.first { $0.model == selectedModel }
+    availableModels.first { $0.model == activeModelSelection }
+  }
+
+  private var activeModelSelection: String {
+    let trimmedSelectedModel = selectedModel.trimmingCharacters(in: .whitespacesAndNewlines)
+    if !trimmedSelectedModel.isEmpty {
+      return trimmedSelectedModel
+    }
+    return currentModel?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+  }
+
+  private var fallbackModelLabel: String {
+    let trimmedCurrentModel = currentModel?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+    if let selectedModelOption {
+      return selectedModelOption.displayName
+    }
+    if !trimmedCurrentModel.isEmpty {
+      return trimmedCurrentModel
+    }
+    return "No model selected"
   }
 
   private var selectedProviderTitle: String {
-    guard let selectedModelOption else { return "Unknown" }
+    guard let selectedModelOption else { return allowsModelSelection ? "Unknown" : "Session" }
     return providerKey(for: selectedModelOption).title
   }
 
@@ -146,58 +169,48 @@ struct ModelEffortPopover: View {
           .background(Color.backgroundTertiary, in: Capsule())
       }
 
-      Button {
-        withAnimation(Motion.standard) {
-          showModelPicker.toggle()
-          if !showModelPicker { searchQuery = "" }
+      Group {
+        if allowsModelSelection {
+          Button {
+            withAnimation(Motion.standard) {
+              showModelPicker.toggle()
+              if !showModelPicker { searchQuery = "" }
+            }
+          } label: {
+            modelSummaryCard(showsChevron: true)
+          }
+          .buttonStyle(.plain)
+        } else {
+          modelSummaryCard(showsChevron: false)
         }
-      } label: {
-        HStack(alignment: .center, spacing: Spacing.sm) {
-          VStack(alignment: .leading, spacing: 2) {
-            HStack(spacing: Spacing.sm) {
-              Text(selectedModelOption?.displayName ?? "No model selected")
-                .font(.system(size: TypeScale.body, weight: .semibold))
-                .foregroundStyle(Color.textSecondary)
-                .lineLimit(1)
+      }
 
-              if selectedModelOption?.isDefault == true {
-                Text("DEFAULT")
-                  .font(.system(size: 7, weight: .bold, design: .rounded))
-                  .foregroundStyle(Color.providerCodex)
-                  .padding(.horizontal, Spacing.xs)
-                  .padding(.vertical, 1)
-                  .background(Color.providerCodex.opacity(OpacityTier.light), in: Capsule())
-              }
-            }
+      if !allowsModelSelection {
+        Text("This session’s model comes from its active Codex profile or inherited config.")
+          .font(.system(size: TypeScale.caption))
+          .foregroundStyle(Color.textTertiary)
+          .fixedSize(horizontal: false, vertical: true)
+      }
 
-            if !showModelPicker, let description = selectedModelOption?.description, !description.isEmpty {
-              Text(description)
-                .font(.system(size: TypeScale.caption))
-                .foregroundStyle(Color.textTertiary)
-                .lineLimit(1)
-            }
+      if let noticeMessage, !noticeMessage.isEmpty {
+        HStack(spacing: Spacing.sm) {
+          if noticeIsLoading {
+            ProgressView()
+              .controlSize(.small)
+          } else {
+            Image(systemName: "exclamationmark.triangle.fill")
+              .font(.system(size: TypeScale.caption, weight: .semibold))
+              .foregroundStyle(Color.feedbackCaution)
           }
 
-          Spacer(minLength: 0)
-
-          Image(systemName: showModelPicker ? "chevron.up" : "chevron.down")
-            .font(.system(size: TypeScale.caption, weight: .semibold))
-            .foregroundStyle(Color.textQuaternary)
+          Text(noticeMessage)
+            .font(.system(size: TypeScale.caption))
+            .foregroundStyle(Color.textTertiary)
+            .fixedSize(horizontal: false, vertical: true)
         }
-        .padding(.horizontal, Spacing.md)
-        .padding(.vertical, Spacing.sm)
-        .background(
-          RoundedRectangle(cornerRadius: Radius.md, style: .continuous)
-            .fill(Color.backgroundPrimary.opacity(0.28))
-        )
-        .overlay(
-          RoundedRectangle(cornerRadius: Radius.md, style: .continuous)
-            .strokeBorder(Color.surfaceBorder.opacity(0.45), lineWidth: 1)
-        )
       }
-      .buttonStyle(.plain)
 
-      if showModelPicker {
+      if allowsModelSelection, showModelPicker {
         if showSearch {
           searchBar
         }
@@ -209,6 +222,60 @@ struct ModelEffortPopover: View {
     .padding(.horizontal, Spacing.lg)
     .padding(.vertical, Spacing.md)
     .layoutPriority(showModelPicker ? 1 : 0)
+  }
+
+  private func modelSummaryCard(showsChevron: Bool) -> some View {
+    HStack(alignment: .center, spacing: Spacing.sm) {
+      VStack(alignment: .leading, spacing: 2) {
+        HStack(spacing: Spacing.sm) {
+          Text(fallbackModelLabel)
+            .font(.system(size: TypeScale.body, weight: .semibold))
+            .foregroundStyle(Color.textSecondary)
+            .lineLimit(1)
+
+          if selectedModelOption?.isDefault == true {
+            Text("DEFAULT")
+              .font(.system(size: 7, weight: .bold, design: .rounded))
+              .foregroundStyle(Color.providerCodex)
+              .padding(.horizontal, Spacing.xs)
+              .padding(.vertical, 1)
+              .background(Color.providerCodex.opacity(OpacityTier.light), in: Capsule())
+          }
+        }
+
+        if !showModelPicker, let description = selectedModelOption?.description, !description.isEmpty {
+          Text(description)
+            .font(.system(size: TypeScale.caption))
+            .foregroundStyle(Color.textTertiary)
+            .lineLimit(1)
+        } else if !showModelPicker, let currentModel,
+                  !currentModel.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        {
+          Text(currentModel)
+            .font(.system(size: TypeScale.caption, design: .monospaced))
+            .foregroundStyle(Color.textTertiary)
+            .lineLimit(1)
+        }
+      }
+
+      Spacer(minLength: 0)
+
+      if showsChevron {
+        Image(systemName: showModelPicker ? "chevron.up" : "chevron.down")
+          .font(.system(size: TypeScale.caption, weight: .semibold))
+          .foregroundStyle(Color.textQuaternary)
+      }
+    }
+    .padding(.horizontal, Spacing.md)
+    .padding(.vertical, Spacing.sm)
+    .background(
+      RoundedRectangle(cornerRadius: Radius.md, style: .continuous)
+        .fill(Color.backgroundPrimary.opacity(0.28))
+    )
+    .overlay(
+      RoundedRectangle(cornerRadius: Radius.md, style: .continuous)
+        .strokeBorder(Color.surfaceBorder.opacity(0.45), lineWidth: 1)
+    )
   }
 
   private var searchBar: some View {
@@ -376,8 +443,8 @@ struct ModelEffortPopover: View {
   }
 
   private func compareModels(_ lhs: ServerCodexModelOption, _ rhs: ServerCodexModelOption) -> Bool {
-    if lhs.model == selectedModel { return true }
-    if rhs.model == selectedModel { return false }
+    if lhs.model == activeModelSelection { return true }
+    if rhs.model == activeModelSelection { return false }
     if lhs.isDefault != rhs.isDefault { return lhs.isDefault && !rhs.isDefault }
     return lhs.displayName.localizedCaseInsensitiveCompare(rhs.displayName) == .orderedAscending
   }
@@ -640,6 +707,10 @@ private extension ProviderKey {
         isDefault: false,
         supportedReasoningEfforts: ["low", "medium", "high"]
       ),
-    ]
+    ],
+    currentModel: "openai/gpt-5.3-codex",
+    allowsModelSelection: true,
+    noticeMessage: nil,
+    noticeIsLoading: false
   )
 }

--- a/OrbitDockNative/OrbitDock/Views/Sessions/Composer/DirectSessionComposer+Footer.swift
+++ b/OrbitDockNative/OrbitDock/Views/Sessions/Composer/DirectSessionComposer+Footer.swift
@@ -166,12 +166,12 @@ extension DirectSessionComposer {
 
   @ViewBuilder
   var footerModelLabel: some View {
-    if obs.isDirectCodex, !selectedModel.isEmpty {
+    if obs.isDirectCodex, !effectiveCodexModel.isEmpty {
       Text(footerModelSummary)
         .font(.system(size: TypeScale.micro, weight: .medium, design: .monospaced))
         .foregroundStyle(Color.textTertiary)
         .lineLimit(1)
-        .help("Model: \(selectedModel)\nEffort: \(selectedEffort.displayName)")
+        .help("Model: \(effectiveCodexModel)\nEffort: \(selectedEffort.displayName)")
     } else if obs.isDirectClaude, !effectiveClaudeModel.isEmpty {
       Text(footerModelSummary)
         .font(.system(size: TypeScale.micro, weight: .medium, design: .monospaced))
@@ -183,7 +183,7 @@ extension DirectSessionComposer {
 
   private var footerModelSummary: String {
     let modelName = if obs.isDirectCodex {
-      DirectSessionComposerProviderPlanner.compactModelName(selectedModel)
+      DirectSessionComposerProviderPlanner.compactModelName(effectiveCodexModel)
     } else {
       DirectSessionComposerProviderPlanner.compactModelName(effectiveClaudeModel)
     }

--- a/OrbitDockNative/OrbitDock/Views/Sessions/Composer/DirectSessionComposer+Helpers.swift
+++ b/OrbitDockNative/OrbitDock/Views/Sessions/Composer/DirectSessionComposer+Helpers.swift
@@ -154,7 +154,7 @@ extension DirectSessionComposer {
       isSending: isSending,
       isConnected: isConnected,
       providerMode: providerMode,
-      selectedCodexModel: selectedModel,
+      selectedCodexModel: codexSelectedModelOverride,
       selectedClaudeModel: effectiveClaudeModel,
       inheritedModel: obs.model,
       effort: selectedEffort.serialized ?? ""
@@ -334,6 +334,66 @@ extension DirectSessionComposer {
     guard let value else { return nil }
     let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
     return trimmed.isEmpty ? nil : trimmed
+  }
+
+  func refreshScopedCodexModelsIfNeeded() {
+    guard obs.isDirectCodex else {
+      scopedCodexModels = nil
+      scopedCodexModelsLoading = false
+      scopedCodexModelsError = nil
+      return
+    }
+
+    guard let projectPath else {
+      scopedCodexModels = nil
+      scopedCodexModelsLoading = false
+      scopedCodexModelsError = nil
+      return
+    }
+
+    let provider = currentCodexModelProvider?.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard let provider, !provider.isEmpty else {
+      scopedCodexModels = nil
+      scopedCodexModelsLoading = false
+      scopedCodexModelsError = nil
+      return
+    }
+
+    scopedCodexModelsRequestID &+= 1
+    let requestID = scopedCodexModelsRequestID
+    let scopedPath = projectPath
+    let scopedProvider = provider
+    scopedCodexModelsLoading = true
+    scopedCodexModelsError = nil
+    scopedCodexModels = nil
+
+    Task {
+      do {
+        let models = try await viewModel.fetchCodexModels(
+          cwd: scopedPath,
+          modelProvider: scopedProvider
+        )
+        guard !Task.isCancelled else { return }
+        await MainActor.run {
+          guard requestID == scopedCodexModelsRequestID,
+                obs.isDirectCodex,
+                projectPath == scopedPath,
+                currentCodexModelProvider == scopedProvider
+          else { return }
+          scopedCodexModels = models
+          scopedCodexModelsLoading = false
+          scopedCodexModelsError = nil
+        }
+      } catch {
+        guard !Task.isCancelled else { return }
+        await MainActor.run {
+          guard requestID == scopedCodexModelsRequestID else { return }
+          scopedCodexModels = nil
+          scopedCodexModelsLoading = false
+          scopedCodexModelsError = error.localizedDescription
+        }
+      }
+    }
   }
 
   func inspectCodexConfig() {

--- a/OrbitDockNative/OrbitDock/Views/Sessions/Composer/DirectSessionComposer+StatusBar.swift
+++ b/OrbitDockNative/OrbitDock/Views/Sessions/Composer/DirectSessionComposer+StatusBar.swift
@@ -179,6 +179,31 @@ extension DirectSessionComposer {
     .padding(.bottom, Spacing.xs)
   }
 
+  func codexScopedModelNoticeRow(_ message: String, isLoading: Bool) -> some View {
+    let tint = isLoading ? Color.feedbackCaution : Color.providerCodex
+
+    return HStack(spacing: Spacing.sm_) {
+      if isLoading {
+        ProgressView()
+          .controlSize(.small)
+          .tint(tint)
+      } else {
+        Image(systemName: "exclamationmark.triangle.fill")
+          .font(.system(size: TypeScale.micro, weight: .semibold))
+          .foregroundStyle(tint)
+      }
+
+      Text(message)
+        .font(.system(size: TypeScale.caption))
+        .foregroundStyle(Color.textSecondary)
+        .lineLimit(3)
+
+      Spacer(minLength: 0)
+    }
+    .padding(.horizontal, Spacing.md_)
+    .padding(.bottom, Spacing.xs)
+  }
+
   func statusBarCwdLabel(_ cwd: String) -> some View {
     let display = (cwd as NSString).lastPathComponent
     return HStack(spacing: Spacing.xxs) {

--- a/OrbitDockNative/OrbitDock/Views/Sessions/Composer/DirectSessionComposer.swift
+++ b/OrbitDockNative/OrbitDock/Views/Sessions/Composer/DirectSessionComposer.swift
@@ -33,6 +33,10 @@ struct DirectSessionComposer: View {
   @State var codexInspectorError: String?
   @State var codexInspectorLoading = false
   @State var showCodexInspector = false
+  @State var scopedCodexModels: [ServerCodexModelOption]?
+  @State var scopedCodexModelsLoading = false
+  @State var scopedCodexModelsError: String?
+  @State var scopedCodexModelsRequestID = 0
 
   /// Attachments
   @State var attachmentState = DirectSessionComposerAttachmentState()
@@ -273,11 +277,13 @@ struct DirectSessionComposer: View {
       viewModel.bind(sessionId: sessionId, sessionStore: sessionStore)
     }
     .task(id: sessionId) {
+      selectedModel = ""
+      selectedClaudeModel = ""
+      selectedEffort = .default
+
       if obs.isDirectCodex {
         viewModel.refreshCodexModels()
-        if selectedModel.isEmpty {
-          selectedModel = defaultCodexModelSelection
-        }
+        refreshScopedCodexModelsIfNeeded()
         // Restore persisted effort level from server state
         if let saved = obs.effort, let level = EffortLevel(rawValue: saved) {
           selectedEffort = level
@@ -302,6 +308,9 @@ struct DirectSessionComposer: View {
     .task(id: projectPath) {
       guard let path = projectPath else { return }
       await fileIndex.loadIfNeeded(path)
+    }
+    .task(id: codexModelScopeSignature) {
+      refreshScopedCodexModelsIfNeeded()
     }
     .onChange(of: message) { _, newValue in
       ComposerDraftStore.save(newValue, for: draftStorageKey)
@@ -331,8 +340,18 @@ struct DirectSessionComposer: View {
     }
     .onChange(of: codexModelOptionsSignature) { _, _ in
       guard obs.isDirectCodex else { return }
-      if selectedModel.isEmpty || !codexModelOptions.contains(where: { $0.model == selectedModel }) {
-        selectedModel = defaultCodexModelSelection
+      guard codexAllowsModelSelection else {
+        selectedModel = ""
+        return
+      }
+      if !selectedModel.isEmpty, !codexModelOptions.contains(where: { $0.model == selectedModel }) {
+        selectedModel = ""
+      }
+    }
+    .onChange(of: currentCodexConfigMode) { _, newValue in
+      guard obs.isDirectCodex else { return }
+      if newValue != .custom {
+        selectedModel = ""
       }
     }
     .onChange(of: claudeModelOptionsSignature) { _, _ in
@@ -487,7 +506,7 @@ struct DirectSessionComposer: View {
       isDirectClaude: obs.isDirectClaude,
       isSessionWorking: isSessionWorking,
       hasTokenUsage: obs.hasTokenUsage,
-      selectedCodexModel: selectedModel,
+      selectedCodexModel: effectiveCodexModel,
       effectiveClaudeModel: effectiveClaudeModel,
       branch: obs.branch,
       projectPath: obs.projectPath
@@ -555,6 +574,11 @@ struct DirectSessionComposer: View {
 
     if let notice = connectionNoticeMessage {
       connectionNoticeRow(notice)
+        .padding(.top, Spacing.xxs)
+    }
+
+    if let notice = codexScopedModelNoticeMessage {
+      codexScopedModelNoticeRow(notice, isLoading: scopedCodexModelsLoading)
         .padding(.top, Spacing.xxs)
     }
   }

--- a/OrbitDockNative/OrbitDock/Views/Sessions/Composer/DirectSessionComposerActions.swift
+++ b/OrbitDockNative/OrbitDock/Views/Sessions/Composer/DirectSessionComposerActions.swift
@@ -28,7 +28,7 @@ nonisolated struct DirectSessionComposerSendContext: Sendable {
   let isSending: Bool
   let isConnected: Bool
   let providerMode: ComposerProviderMode
-  let selectedCodexModel: String
+  let selectedCodexModel: String?
   let selectedClaudeModel: String
   let inheritedModel: String?
   let effort: String
@@ -48,7 +48,7 @@ nonisolated enum DirectSessionComposerSendPlan: Equatable, Sendable {
   case missingModel(String)
   case executeShell(command: String, exitsShellMode: Bool)
   case steer(content: String)
-  case send(content: String, model: String, effort: String)
+  case send(content: String, model: String?, effort: String)
 }
 
 nonisolated enum DirectSessionComposerActionPlanner {
@@ -68,7 +68,7 @@ nonisolated enum DirectSessionComposerActionPlanner {
         }
         switch context.providerMode {
           case .directCodex:
-            return !context.selectedCodexModel.isEmpty
+            return true
           case .directClaude:
             return !context.selectedClaudeModel.isEmpty
           case .inherited:
@@ -102,13 +102,10 @@ nonisolated enum DirectSessionComposerActionPlanner {
       return .steer(content: context.trimmedMessage)
     }
 
-    let model: String
+    let model: String?
     switch context.providerMode {
       case .directCodex:
-        guard !context.selectedCodexModel.isEmpty else {
-          return .missingModel("No model available yet. Wait for model list to load.")
-        }
-        model = context.selectedCodexModel
+        model = normalizedModelOverride(context.selectedCodexModel)
       case .directClaude:
         guard !context.selectedClaudeModel.isEmpty else {
           return .missingModel("No Claude model available yet. Wait for model list to load.")
@@ -122,5 +119,12 @@ nonisolated enum DirectSessionComposerActionPlanner {
     }
 
     return .send(content: context.trimmedMessage, model: model, effort: context.effort)
+  }
+
+  private static func normalizedModelOverride(_ model: String?) -> String? {
+    guard let trimmed = model?.trimmingCharacters(in: .whitespacesAndNewlines), !trimmed.isEmpty else {
+      return nil
+    }
+    return trimmed
   }
 }

--- a/OrbitDockNative/OrbitDock/Views/Sessions/Composer/DirectSessionComposerExecutionPlanner.swift
+++ b/OrbitDockNative/OrbitDock/Views/Sessions/Composer/DirectSessionComposerExecutionPlanner.swift
@@ -17,7 +17,7 @@ struct DirectSessionComposerPreparedSteerRequest: Equatable {
 
 struct DirectSessionComposerPreparedSendRequest: Equatable {
   let content: String
-  let model: String
+  let model: String?
   let effort: String
   let skills: [ServerSkillInput]
   let mentions: [ServerMentionInput]

--- a/OrbitDockNative/OrbitDock/Views/Sessions/Composer/DirectSessionComposerProviderControls.swift
+++ b/OrbitDockNative/OrbitDock/Views/Sessions/Composer/DirectSessionComposerProviderControls.swift
@@ -16,7 +16,11 @@ extension DirectSessionComposer {
           ModelEffortPopover(
             selectedModel: $composerState.selectedModel,
             selectedEffort: $composerState.selectedEffort,
-            models: codexModelOptions
+            models: codexModelOptions,
+            currentModel: effectiveCodexModel,
+            allowsModelSelection: codexAllowsModelSelection,
+            noticeMessage: codexScopedModelNoticeMessage,
+            noticeIsLoading: scopedCodexModelsLoading
           )
           .toolbar {
             ToolbarItem(placement: .confirmationAction) {
@@ -28,7 +32,11 @@ extension DirectSessionComposer {
         ModelEffortPopover(
           selectedModel: $composerState.selectedModel,
           selectedEffort: $composerState.selectedEffort,
-          models: codexModelOptions
+          models: codexModelOptions,
+          currentModel: effectiveCodexModel,
+          allowsModelSelection: codexAllowsModelSelection,
+          noticeMessage: codexScopedModelNoticeMessage,
+          noticeIsLoading: scopedCodexModelsLoading
         )
       #endif
     }

--- a/OrbitDockNative/OrbitDock/Views/Sessions/Composer/DirectSessionComposerProviderPlanner.swift
+++ b/OrbitDockNative/OrbitDock/Views/Sessions/Composer/DirectSessionComposerProviderPlanner.swift
@@ -8,6 +8,21 @@
 import Foundation
 
 enum DirectSessionComposerProviderPlanner {
+  static func activeCodexModelOptions(
+    scopedOptions: [ServerCodexModelOption]?,
+    fallbackOptions: [ServerCodexModelOption],
+    isScopedProviderActive: Bool
+  ) -> [ServerCodexModelOption] {
+    let normalizedScoped = (scopedOptions ?? []).filter { !$0.model.isEmpty }
+    if !normalizedScoped.isEmpty {
+      return normalizedScoped
+    }
+    if isScopedProviderActive {
+      return []
+    }
+    return fallbackOptions
+  }
+
   static func defaultCodexModelSelection(
     currentModel: String?,
     options: [ServerCodexModelOption]
@@ -47,7 +62,7 @@ enum DirectSessionComposerProviderPlanner {
 
   static func hasOverrides(
     providerMode: ComposerProviderMode,
-    selectedCodexModel: String,
+    selectedCodexModel: String?,
     selectedClaudeModel: String,
     currentModel: String?,
     selectedEffort: EffortLevel,
@@ -56,8 +71,10 @@ enum DirectSessionComposerProviderPlanner {
   ) -> Bool {
     switch providerMode {
       case .directCodex:
+        let normalizedOverride = selectedCodexModel?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        let normalizedCurrentModel = currentModel?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
         return selectedEffort != .default
-          || selectedCodexModel != defaultCodexModelSelection(currentModel: currentModel, options: codexOptions)
+          || (!normalizedOverride.isEmpty && normalizedOverride != normalizedCurrentModel)
       case .directClaude:
         guard !selectedClaudeModel.isEmpty else { return false }
         return selectedClaudeModel

--- a/OrbitDockNative/OrbitDock/Views/Sessions/Composer/DirectSessionComposerViewModel.swift
+++ b/OrbitDockNative/OrbitDock/Views/Sessions/Composer/DirectSessionComposerViewModel.swift
@@ -91,6 +91,16 @@ final class DirectSessionComposerViewModel {
     currentSessionStore.refreshCodexModels()
   }
 
+  func fetchCodexModels(
+    cwd: String? = nil,
+    modelProvider: String? = nil
+  ) async throws -> [ServerCodexModelOption] {
+    try await currentSessionStore.clients.usage.listCodexModels(
+      cwd: cwd,
+      modelProvider: modelProvider
+    )
+  }
+
   func loadPermissionRules() async throws {
     _ = try await currentSessionStore.loadPermissionRules(sessionId: resolvedSessionId)
   }

--- a/OrbitDockNative/OrbitDock/Views/Sessions/Composer/DirectSessionComposerViewState.swift
+++ b/OrbitDockNative/OrbitDock/Views/Sessions/Composer/DirectSessionComposerViewState.swift
@@ -144,7 +144,7 @@ extension DirectSessionComposer {
   var hasOverrides: Bool {
     DirectSessionComposerProviderPlanner.hasOverrides(
       providerMode: providerMode,
-      selectedCodexModel: selectedModel,
+      selectedCodexModel: codexSelectedModelOverride,
       selectedClaudeModel: selectedClaudeModel,
       currentModel: obs.model,
       selectedEffort: selectedEffort,
@@ -175,12 +175,20 @@ extension DirectSessionComposer {
   }
 
   var codexModelOptions: [ServerCodexModelOption] {
-    viewModel.codexModels
+    DirectSessionComposerProviderPlanner.activeCodexModelOptions(
+      scopedOptions: scopedCodexModels,
+      fallbackOptions: viewModel.codexModels,
+      isScopedProviderActive: isScopedCodexProviderActive
+    )
+  }
+
+  var isScopedCodexProviderActive: Bool {
+    obs.isDirectCodex && currentCodexModelProvider != nil
   }
 
   var currentCodexModelOption: ServerCodexModelOption? {
     codexModelOptions
-      .first(where: { $0.model == (composerState.selectedModel.isEmpty ? obs.model : composerState.selectedModel) })
+      .first(where: { $0.model == effectiveCodexModel })
       ?? codexModelOptions.first(where: { $0.model == obs.model })
       ?? codexModelOptions.first(where: \.isDefault)
       ?? codexModelOptions.first
@@ -208,6 +216,10 @@ extension DirectSessionComposer {
 
   var currentCodexConfigMode: ServerCodexConfigMode {
     obs.codexConfigMode ?? .inherit
+  }
+
+  var codexAllowsModelSelection: Bool {
+    obs.isDirectCodex && currentCodexConfigMode == .custom
   }
 
   var currentCodexConfigProfile: String? {
@@ -279,6 +291,42 @@ extension DirectSessionComposer {
 
   var codexModelOptionsSignature: String {
     codexModelOptions.map(\.model).joined(separator: "|")
+  }
+
+  var codexModelScopeSignature: String {
+    let path = projectPath ?? ""
+    let provider = currentCodexModelProvider ?? ""
+    let mode = obs.isDirectCodex ? "codex" : "other"
+    return [mode, path, provider].joined(separator: "|")
+  }
+
+  var codexSelectedModelOverride: String? {
+    guard codexAllowsModelSelection else { return nil }
+    let trimmed = selectedModel.trimmingCharacters(in: .whitespacesAndNewlines)
+    return trimmed.isEmpty ? nil : trimmed
+  }
+
+  var effectiveCodexModel: String {
+    if let selected = codexSelectedModelOverride {
+      return selected
+    }
+    return obs.model?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+  }
+
+  var codexScopedModelNoticeMessage: String? {
+    guard isScopedCodexProviderActive, let provider = currentCodexModelProvider else { return nil }
+    if scopedCodexModelsLoading {
+      return "Loading models for \(provider)…"
+    }
+    if let error = scopedCodexModelsError, !error.isEmpty {
+      return
+        "Couldn’t load models for \(provider). OrbitDock is hiding the generic Codex list here so you only see provider-compatible models. Current error: \(error)"
+    }
+    if !scopedCodexModelsLoading, codexModelOptions.isEmpty {
+      return
+        "No models were discovered for \(provider). OrbitDock is hiding the generic Codex list here so you don’t pick an incompatible model."
+    }
+    return nil
   }
 
   var claudeModelOptions: [ServerClaudeModelOption] {

--- a/OrbitDockNative/OrbitDockTests/Composer/DirectSessionComposerActionPlannerTests.swift
+++ b/OrbitDockNative/OrbitDockTests/Composer/DirectSessionComposerActionPlannerTests.swift
@@ -2,7 +2,7 @@
 import Testing
 
 struct DirectSessionComposerActionPlannerTests {
-  @Test func canSendRequiresModelForDirectCodexPrompts() {
+  @Test func directCodexPromptsDoNotRequireLocalModelOverride() {
     let context = DirectSessionComposerSendContext(
       inputMode: .prompt,
       rawMessage: "Ship it",
@@ -11,16 +11,60 @@ struct DirectSessionComposerActionPlannerTests {
       isSending: false,
       isConnected: true,
       providerMode: .directCodex,
-      selectedCodexModel: "",
+      selectedCodexModel: nil,
       selectedClaudeModel: "",
       inheritedModel: nil,
       effort: "default"
     )
 
-    #expect(!DirectSessionComposerActionPlanner.canSend(context))
+    #expect(DirectSessionComposerActionPlanner.canSend(context))
     #expect(
       DirectSessionComposerActionPlanner.planSend(context)
-        == .missingModel("No model available yet. Wait for model list to load.")
+        == .send(content: "Ship it", model: nil, effort: "default")
+    )
+  }
+
+  @Test func directCodexPromptsDoNotTurnInheritedModelIntoOverride() {
+    let context = DirectSessionComposerSendContext(
+      inputMode: .prompt,
+      rawMessage: "Hi there",
+      hasAttachments: false,
+      hasMentions: false,
+      isSending: false,
+      isConnected: true,
+      providerMode: .directCodex,
+      selectedCodexModel: nil,
+      selectedClaudeModel: "",
+      inheritedModel: "qwen/qwen3-coder-next",
+      effort: "high"
+    )
+
+    #expect(DirectSessionComposerActionPlanner.canSend(context))
+    #expect(
+      DirectSessionComposerActionPlanner.planSend(context)
+        == .send(content: "Hi there", model: nil, effort: "high")
+    )
+  }
+
+  @Test func directCodexPromptsKeepExplicitCustomOverride() {
+    let context = DirectSessionComposerSendContext(
+      inputMode: .prompt,
+      rawMessage: "Hi there",
+      hasAttachments: false,
+      hasMentions: false,
+      isSending: false,
+      isConnected: true,
+      providerMode: .directCodex,
+      selectedCodexModel: "qwen/qwen3-coder-next",
+      selectedClaudeModel: "",
+      inheritedModel: "qwen/qwen3-coder-next",
+      effort: "high"
+    )
+
+    #expect(DirectSessionComposerActionPlanner.canSend(context))
+    #expect(
+      DirectSessionComposerActionPlanner.planSend(context)
+        == .send(content: "Hi there", model: "qwen/qwen3-coder-next", effort: "high")
     )
   }
 
@@ -33,7 +77,7 @@ struct DirectSessionComposerActionPlannerTests {
       isSending: false,
       isConnected: false,
       providerMode: .inherited,
-      selectedCodexModel: "",
+      selectedCodexModel: nil,
       selectedClaudeModel: "",
       inheritedModel: "claude-opus",
       effort: "default"
@@ -51,7 +95,7 @@ struct DirectSessionComposerActionPlannerTests {
       isSending: false,
       isConnected: true,
       providerMode: .inherited,
-      selectedCodexModel: "",
+      selectedCodexModel: nil,
       selectedClaudeModel: "",
       inheritedModel: "claude-opus",
       effort: "default"
@@ -71,7 +115,7 @@ struct DirectSessionComposerActionPlannerTests {
       isSending: false,
       isConnected: true,
       providerMode: .inherited,
-      selectedCodexModel: "",
+      selectedCodexModel: nil,
       selectedClaudeModel: "",
       inheritedModel: "claude-opus",
       effort: "default"
@@ -92,7 +136,7 @@ struct DirectSessionComposerActionPlannerTests {
       isSending: false,
       isConnected: true,
       providerMode: .inherited,
-      selectedCodexModel: "",
+      selectedCodexModel: nil,
       selectedClaudeModel: "",
       inheritedModel: "claude-opus",
       effort: "default"
@@ -111,7 +155,7 @@ struct DirectSessionComposerActionPlannerTests {
       isSending: false,
       isConnected: true,
       providerMode: .inherited,
-      selectedCodexModel: "",
+      selectedCodexModel: nil,
       selectedClaudeModel: "",
       inheritedModel: "claude-opus",
       effort: "high"

--- a/OrbitDockNative/OrbitDockTests/Composer/DirectSessionComposerExecutionPlannerTests.swift
+++ b/OrbitDockNative/OrbitDockTests/Composer/DirectSessionComposerExecutionPlannerTests.swift
@@ -42,6 +42,26 @@ struct DirectSessionComposerExecutionPlannerTests {
     #expect(request.localImages.isEmpty)
   }
 
+  @Test func sendPreparationKeepsCodexModelNilWhenNoOverrideWasChosen() {
+    let action = DirectSessionComposerExecutionPlanner.prepare(
+      sendPlan: .send(content: "Keep session model", model: nil, effort: "high"),
+      message: "Keep session model",
+      attachments: DirectSessionComposerAttachmentState(),
+      shellContext: nil,
+      selectedSkillPaths: [],
+      availableSkills: []
+    )
+
+    guard case let .send(request) = action else {
+      Issue.record("Expected send action, got \(action)")
+      return
+    }
+
+    #expect(request.content == "Keep session model")
+    #expect(request.model == nil)
+    #expect(request.effort == "high")
+  }
+
   @Test func steerPreparationPreservesMentionsAndImagesWithoutShellContext() {
     let image = AttachedImage(
       id: "img-1",

--- a/OrbitDockNative/OrbitDockTests/Composer/DirectSessionComposerProviderPlannerTests.swift
+++ b/OrbitDockNative/OrbitDockTests/Composer/DirectSessionComposerProviderPlannerTests.swift
@@ -2,6 +2,58 @@
 import Testing
 
 struct DirectSessionComposerProviderPlannerTests {
+  @Test func activeCodexModelOptionsPreferScopedProviderList() {
+    let fallback = [
+      ServerCodexModelOption(
+        id: "openai-gpt-5.4",
+        model: "gpt-5.4",
+        displayName: "GPT-5.4",
+        description: "OpenAI default",
+        isDefault: true,
+        supportedReasoningEfforts: ["low", "medium", "high"]
+      ),
+    ]
+    let scoped = [
+      ServerCodexModelOption(
+        id: "qwen",
+        model: "qwen/qwen3-coder-next",
+        displayName: "Qwen 3 Coder Next",
+        description: "Scoped OpenRouter model",
+        isDefault: true,
+        supportedReasoningEfforts: ["low", "medium", "high"]
+      ),
+    ]
+
+    let options = DirectSessionComposerProviderPlanner.activeCodexModelOptions(
+      scopedOptions: scoped,
+      fallbackOptions: fallback,
+      isScopedProviderActive: true
+    )
+
+    #expect(options.map(\.model) == ["qwen/qwen3-coder-next"])
+  }
+
+  @Test func activeCodexModelOptionsDoNotFallbackWhenScopedProviderIsActive() {
+    let fallback = [
+      ServerCodexModelOption(
+        id: "openai-gpt-5.4",
+        model: "gpt-5.4",
+        displayName: "GPT-5.4",
+        description: "OpenAI default",
+        isDefault: true,
+        supportedReasoningEfforts: ["low", "medium", "high"]
+      ),
+    ]
+
+    let options = DirectSessionComposerProviderPlanner.activeCodexModelOptions(
+      scopedOptions: nil,
+      fallbackOptions: fallback,
+      isScopedProviderActive: true
+    )
+
+    #expect(options.isEmpty)
+  }
+
   @Test func codexDefaultModelPrefersCurrentWhenAvailable() {
     let options = [
       ServerCodexModelOption(
@@ -86,7 +138,7 @@ struct DirectSessionComposerProviderPlannerTests {
         providerMode: .directCodex,
         selectedCodexModel: "openai/o4-mini",
         selectedClaudeModel: "",
-        currentModel: nil,
+        currentModel: "openai/o4-mini",
         selectedEffort: .default,
         codexOptions: codexOptions,
         claudeOptions: claudeOptions
@@ -96,7 +148,7 @@ struct DirectSessionComposerProviderPlannerTests {
     #expect(
       DirectSessionComposerProviderPlanner.hasOverrides(
         providerMode: .directCodex,
-        selectedCodexModel: "openai/o4-mini",
+        selectedCodexModel: nil,
         selectedClaudeModel: "",
         currentModel: nil,
         selectedEffort: .high,

--- a/OrbitDockNative/OrbitDockTests/NewSession/NewSessionRequestPlannerTests.swift
+++ b/OrbitDockNative/OrbitDockTests/NewSession/NewSessionRequestPlannerTests.swift
@@ -170,6 +170,70 @@ struct NewSessionRequestPlannerTests {
     }
   }
 
+  @Test func codexProfileLaunchPlanOmitsModelOverrides() {
+    let plan = NewSessionRequestPlanner.planLaunch(
+      selectedPath: "/tmp/repo",
+      useWorktree: false,
+      worktreeBranch: "",
+      worktreeBaseBranch: "",
+      providerConfiguration: NewSessionProviderConfiguration(
+        provider: .codex,
+        claudeModel: nil,
+        claudePermissionMode: .default,
+        claudeAllowBypassPermissions: false,
+        allowedToolsText: "",
+        disallowedToolsText: "",
+        claudeEffort: nil,
+        codexModel: "gpt-5.4",
+        codexConfigMode: .profile,
+        codexConfigProfile: " qwen ",
+        codexModelProvider: " openrouter ",
+        codexAutonomy: .autonomous,
+        codexCollaborationMode: "plan",
+        codexMultiAgentEnabled: true,
+        codexPersonality: "friendly",
+        codexServiceTier: "priority",
+        codexInstructions: "Stay focused"
+      ),
+      bootstrapPrompt: nil
+    )
+
+    guard let plan else {
+      Issue.record("Expected a launch plan")
+      return
+    }
+
+    if case let .codex(
+      configMode,
+      configProfile,
+      modelProvider,
+      model,
+      approvalPolicy,
+      approvalPolicyDetails,
+      sandboxMode,
+      collaborationMode,
+      multiAgent,
+      personality,
+      serviceTier,
+      developerInstructions
+    ) = plan.requestTemplate {
+      #expect(configMode == .profile)
+      #expect(configProfile == "qwen")
+      #expect(modelProvider == nil)
+      #expect(model == nil)
+      #expect(approvalPolicy == nil)
+      #expect(approvalPolicyDetails == nil)
+      #expect(sandboxMode == nil)
+      #expect(collaborationMode == nil)
+      #expect(multiAgent == nil)
+      #expect(personality == nil)
+      #expect(serviceTier == nil)
+      #expect(developerInstructions == nil)
+    } else {
+      Issue.record("Expected a Codex request template")
+    }
+  }
+
   @Test func blankWorktreeBranchFallsBackToDirectLaunch() {
     let plan = NewSessionRequestPlanner.planLaunch(
       selectedPath: "/tmp/repo",

--- a/orbitdock-server/crates/connector-codex/src/config.rs
+++ b/orbitdock-server/crates/connector-codex/src/config.rs
@@ -1,15 +1,20 @@
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use codex_core::auth::AuthCredentialsStoreMode;
 use codex_core::config::{find_codex_home, Config, ConfigOverrides};
 use codex_core::models_manager::collaboration_mode_presets::CollaborationModesConfig;
 use codex_core::models_manager::manager::RefreshStrategy;
-use codex_core::{AuthManager, ThreadManager};
+use codex_core::{AuthManager, ModelProviderInfo, ThreadManager};
 use codex_protocol::config_types::{
   CollaborationMode, CollaborationModeMask, ModeKind, Personality, ReasoningSummary, ServiceTier,
   Settings,
 };
-use codex_protocol::openai_models::ReasoningEffort;
+use codex_protocol::openai_models::{
+  default_input_modalities, ConfigShellToolType, ModelInfo, ModelInstructionsVariables,
+  ModelMessages, ModelVisibility, ModelsResponse, ReasoningEffort, TruncationPolicyConfig,
+  WebSearchToolType,
+};
 use codex_protocol::protocol::{Op, SessionSource};
 use tracing::{info, warn};
 
@@ -24,6 +29,26 @@ const ENV_CODEX_SHOW_RAW_REASONING: &str = "ORBITDOCK_CODEX_SHOW_RAW_REASONING";
 const ENV_CODEX_HIDE_REASONING: &str = "ORBITDOCK_CODEX_HIDE_REASONING";
 const ENV_CODEX_REASONING_SUMMARY: &str = "ORBITDOCK_CODEX_REASONING_SUMMARY";
 const ORBITDOCK_CODEX_AUTH_STORE_MODE: AuthCredentialsStoreMode = AuthCredentialsStoreMode::File;
+const ORBITDOCK_OPENROUTER_SITE_URL: &str = "https://orbitdock.dev";
+const ORBITDOCK_OPENROUTER_TITLE: &str = "OrbitDock";
+const ORBITDOCK_EXTERNAL_MODEL_BASE_INSTRUCTIONS: &str = "You are a coding assistant running in OrbitDock. Help the user with software tasks in the terminal. Do not claim to be a specific branded assistant, company, foundation model, or hosted service unless the active session configuration explicitly says so. If the user asks which model or provider is active, answer using the current session configuration when known.";
+const ORBITDOCK_EXTERNAL_MODEL_PERSONALITY_PLACEHOLDER: &str = "{{ personality }}";
+const ORBITDOCK_EXTERNAL_MODEL_FRIENDLY_TEMPLATE: &str =
+  "You optimize for team morale and being a supportive teammate as much as code quality.";
+const ORBITDOCK_EXTERNAL_MODEL_PRAGMATIC_TEMPLATE: &str =
+  "You are a deeply pragmatic, effective software engineer.";
+
+struct ProviderRouteDebugInfo {
+  provider_id: String,
+  provider_name: Option<String>,
+  base_url: Option<String>,
+  wire_api: String,
+  query_param_keys: Vec<String>,
+  http_header_names: Vec<String>,
+  env_http_header_names: Vec<String>,
+  has_orbitdock_openrouter_referer: bool,
+  has_orbitdock_openrouter_title: bool,
+}
 
 impl CodexConnector {
   pub async fn new(
@@ -156,6 +181,7 @@ impl CodexConnector {
       CollaborationModesConfig::default(),
     ));
     Self::finalize_reasoning_summary(&mut config, thread_manager.as_ref()).await;
+    log_provider_route("start", cwd, &config);
 
     let configured_model = config.model.clone();
     let new_thread = thread_manager
@@ -280,6 +306,7 @@ impl CodexConnector {
       CollaborationModesConfig::default(),
     ));
     Self::finalize_reasoning_summary(&mut config, thread_manager.as_ref()).await;
+    log_provider_route("resume", cwd, &config);
 
     let configured_model = config.model.clone();
     let new_thread = thread_manager
@@ -390,9 +417,13 @@ impl CodexConnector {
       ..Default::default()
     };
 
-    Config::load_with_cli_overrides_and_harness_overrides(cli_overrides, harness_overrides)
-      .await
-      .map_err(|e| ConnectorError::ProviderError(format!("Failed to load config: {}", e)))
+    let mut config =
+      Config::load_with_cli_overrides_and_harness_overrides(cli_overrides, harness_overrides)
+        .await
+        .map_err(|e| ConnectorError::ProviderError(format!("Failed to load config: {}", e)))?;
+    apply_orbitdock_provider_defaults(&mut config);
+    apply_orbitdock_external_model_defaults(&mut config);
+    Ok(config)
   }
 
   pub(crate) async fn finalize_reasoning_summary(
@@ -479,7 +510,7 @@ pub async fn discover_models_for_context(
     model_provider: model_provider.map(str::to_string),
     ..Default::default()
   };
-  let base_config =
+  let mut base_config =
     Config::load_with_cli_overrides_and_harness_overrides(Vec::new(), harness_overrides)
       .await
       .or_else(|err| {
@@ -492,6 +523,8 @@ pub async fn discover_models_for_context(
       .map_err(|e| {
         ConnectorError::ProviderError(format!("Failed to load config for model discovery: {}", e))
       })?;
+  apply_orbitdock_provider_defaults(&mut base_config);
+  log_provider_route("discover_models", cwd.unwrap_or(""), &base_config);
   let thread_manager = Arc::new(ThreadManager::new(
     &base_config,
     auth_manager,
@@ -534,6 +567,179 @@ pub async fn discover_models_for_context(
   }
 
   Ok(models)
+}
+
+pub(crate) fn apply_orbitdock_provider_defaults(config: &mut Config) {
+  let provider_id = config.model_provider_id.clone();
+  let Some(provider) = config.model_providers.get_mut(&provider_id) else {
+    return;
+  };
+
+  if !is_openrouter_provider(&provider_id, provider) {
+    return;
+  }
+
+  let headers = provider.http_headers.get_or_insert_with(HashMap::new);
+  headers
+    .entry("HTTP-Referer".to_string())
+    .or_insert_with(|| ORBITDOCK_OPENROUTER_SITE_URL.to_string());
+
+  if !headers.contains_key("X-OpenRouter-Title") && !headers.contains_key("X-Title") {
+    headers.insert(
+      "X-OpenRouter-Title".to_string(),
+      ORBITDOCK_OPENROUTER_TITLE.to_string(),
+    );
+  }
+}
+
+pub(crate) fn apply_orbitdock_external_model_defaults(config: &mut Config) {
+  let Some(model_slug) = config.model.clone() else {
+    return;
+  };
+
+  if config.model_provider_id.eq_ignore_ascii_case("openai") || config.model_provider.is_openai() {
+    return;
+  }
+
+  let catalog = config
+    .model_catalog
+    .get_or_insert_with(|| ModelsResponse { models: Vec::new() });
+  if catalog
+    .models
+    .iter()
+    .any(|candidate| model_slug.starts_with(&candidate.slug))
+  {
+    return;
+  }
+
+  catalog.models.push(synthetic_external_model_info(
+    &model_slug,
+    &config.model_provider_id,
+  ));
+}
+
+fn synthetic_external_model_info(model_slug: &str, provider_id: &str) -> ModelInfo {
+  ModelInfo {
+    slug: model_slug.to_string(),
+    display_name: model_slug.to_string(),
+    description: Some(format!(
+      "OrbitDock synthetic metadata for external provider `{provider_id}`."
+    )),
+    default_reasoning_level: None,
+    supported_reasoning_levels: Vec::new(),
+    shell_type: ConfigShellToolType::ShellCommand,
+    visibility: ModelVisibility::None,
+    supported_in_api: true,
+    priority: 99,
+    availability_nux: None,
+    upgrade: None,
+    base_instructions: ORBITDOCK_EXTERNAL_MODEL_BASE_INSTRUCTIONS.to_string(),
+    model_messages: Some(ModelMessages {
+      instructions_template: Some(format!(
+        "{}\n\n{}",
+        ORBITDOCK_EXTERNAL_MODEL_BASE_INSTRUCTIONS,
+        ORBITDOCK_EXTERNAL_MODEL_PERSONALITY_PLACEHOLDER
+      )),
+      instructions_variables: Some(ModelInstructionsVariables {
+        personality_default: Some(String::new()),
+        personality_friendly: Some(ORBITDOCK_EXTERNAL_MODEL_FRIENDLY_TEMPLATE.to_string()),
+        personality_pragmatic: Some(ORBITDOCK_EXTERNAL_MODEL_PRAGMATIC_TEMPLATE.to_string()),
+      }),
+    }),
+    supports_reasoning_summaries: false,
+    default_reasoning_summary: ReasoningSummary::Auto,
+    support_verbosity: false,
+    default_verbosity: None,
+    apply_patch_tool_type: None,
+    web_search_tool_type: WebSearchToolType::Text,
+    truncation_policy: TruncationPolicyConfig::bytes(10_000),
+    supports_parallel_tool_calls: false,
+    supports_image_detail_original: false,
+    context_window: Some(272_000),
+    auto_compact_token_limit: None,
+    effective_context_window_percent: 95,
+    experimental_supported_tools: Vec::new(),
+    input_modalities: default_input_modalities(),
+    used_fallback_model_metadata: false,
+    supports_search_tool: false,
+  }
+}
+
+fn log_provider_route(phase: &str, cwd: &str, config: &Config) {
+  let info = provider_route_debug_info(config);
+  info!(
+    event = "codex.connector.route_resolved",
+    phase,
+    cwd,
+    model = ?config.model,
+    model_provider_id = %info.provider_id,
+    provider_name = ?info.provider_name,
+    provider_base_url = ?info.base_url,
+    wire_api = %info.wire_api,
+    query_param_keys = ?info.query_param_keys,
+    http_header_names = ?info.http_header_names,
+    env_http_header_names = ?info.env_http_header_names,
+    has_orbitdock_openrouter_referer = info.has_orbitdock_openrouter_referer,
+    has_orbitdock_openrouter_title = info.has_orbitdock_openrouter_title,
+  );
+}
+
+fn provider_route_debug_info(config: &Config) -> ProviderRouteDebugInfo {
+  let provider_id = config.model_provider_id.clone();
+  let provider = config.model_providers.get(&provider_id);
+
+  let mut query_param_keys = provider
+    .and_then(|value| value.query_params.as_ref())
+    .map(|value| value.keys().cloned().collect::<Vec<_>>())
+    .unwrap_or_default();
+  query_param_keys.sort();
+
+  let mut http_header_names = provider
+    .and_then(|value| value.http_headers.as_ref())
+    .map(|value| value.keys().cloned().collect::<Vec<_>>())
+    .unwrap_or_default();
+  http_header_names.sort();
+
+  let mut env_http_header_names = provider
+    .and_then(|value| value.env_http_headers.as_ref())
+    .map(|value| value.keys().cloned().collect::<Vec<_>>())
+    .unwrap_or_default();
+  env_http_header_names.sort();
+
+  let has_orbitdock_openrouter_referer = provider
+    .and_then(|value| value.http_headers.as_ref())
+    .and_then(|value| value.get("HTTP-Referer"))
+    .map(|value| value == ORBITDOCK_OPENROUTER_SITE_URL)
+    .unwrap_or(false);
+
+  let has_orbitdock_openrouter_title = provider
+    .and_then(|value| value.http_headers.as_ref())
+    .and_then(|value| value.get("X-OpenRouter-Title"))
+    .map(|value| value == ORBITDOCK_OPENROUTER_TITLE)
+    .unwrap_or(false);
+
+  ProviderRouteDebugInfo {
+    provider_id,
+    provider_name: provider.map(|value| value.name.clone()),
+    base_url: provider.and_then(|value| value.base_url.clone()),
+    wire_api: provider
+      .map(|value| format!("{:?}", value.wire_api))
+      .unwrap_or_else(|| "unknown".to_string()),
+    query_param_keys,
+    http_header_names,
+    env_http_header_names,
+    has_orbitdock_openrouter_referer,
+    has_orbitdock_openrouter_title,
+  }
+}
+
+pub(crate) fn is_openrouter_provider(provider_id: &str, provider: &ModelProviderInfo) -> bool {
+  provider_id.eq_ignore_ascii_case("openrouter")
+    || provider.name.eq_ignore_ascii_case("openrouter")
+    || provider
+      .base_url
+      .as_ref()
+      .is_some_and(|value| value.to_ascii_lowercase().contains("openrouter.ai"))
 }
 
 pub(crate) fn parse_bool_env(name: &str) -> Option<bool> {

--- a/orbitdock-server/crates/connector-codex/src/event_mapping/runtime_signals.rs
+++ b/orbitdock-server/crates/connector-codex/src/event_mapping/runtime_signals.rs
@@ -24,6 +24,7 @@ use serde_json::json;
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
+use tracing::warn;
 
 fn tool_row_entry(row: ToolRow) -> ConversationRowEntry {
   let row = with_display(row);
@@ -154,6 +155,14 @@ pub(crate) fn handle_warning(
   event: WarningEvent,
   msg_counter: &AtomicU64,
 ) -> Vec<ConnectorEvent> {
+  if is_suppressed_runtime_warning(&event.message) {
+    warn!(
+      event_id,
+      message = %event.message,
+      "suppressing Codex runtime warning from timeline"
+    );
+    return vec![];
+  }
   let seq = msg_counter.fetch_add(1, Ordering::SeqCst);
   let entry = row_entry(ConversationRow::Assistant(MessageRowContent {
     id: format!("warning-{}-{}", event_id, seq),
@@ -166,6 +175,10 @@ pub(crate) fn handle_warning(
     delivery_status: None,
   }));
   vec![ConnectorEvent::ConversationRowCreated(entry)]
+}
+
+pub(crate) fn is_suppressed_runtime_warning(message: &str) -> bool {
+  message.starts_with("Model metadata for `") && message.contains("Defaulting to fallback metadata")
 }
 
 pub(crate) async fn handle_model_reroute(

--- a/orbitdock-server/crates/connector-codex/src/tests.rs
+++ b/orbitdock-server/crates/connector-codex/src/tests.rs
@@ -1,4 +1,5 @@
 use super::config::{
+  apply_orbitdock_external_model_defaults, apply_orbitdock_provider_defaults,
   collaboration_mode_from_name_or_mode, collaboration_mode_from_permission_mode,
   model_rejects_reasoning_summary, parse_personality, parse_reasoning_summary,
   parse_service_tier_override, reasoning_summary_for_model, should_disable_reasoning_summary,
@@ -11,17 +12,20 @@ use super::timeline::{
 };
 use super::workers::{build_authoritative_codex_subagent, build_inflight_codex_subagent};
 use super::workers::{build_codex_subagent_for_status, build_running_codex_subagent};
+use codex_core::config::Config as CoreConfig;
+use codex_core::{ModelProviderInfo, WireApi};
 use codex_protocol::config_types::{ModeKind, ReasoningSummary, ServiceTier};
 use codex_protocol::models::{FunctionCallOutputPayload, ResponseItem};
 use codex_protocol::openai_models::ReasoningEffort;
 use codex_protocol::protocol::{
   AgentStatus, CodexErrorInfo, HookEventName, HookExecutionMode, HookHandlerType, HookOutputEntry,
   HookOutputEntryKind, HookRunStatus, HookRunSummary, HookScope, RawResponseItemEvent,
-  RealtimeHandoffRequested, RealtimeTranscriptEntry, StreamErrorEvent,
+  RealtimeHandoffRequested, RealtimeTranscriptEntry, StreamErrorEvent, WarningEvent,
 };
 use orbitdock_connector_core::ConnectorEvent;
 use orbitdock_protocol::conversation_contracts::ConversationRow;
 use orbitdock_protocol::domain_events::{ToolKind, ToolStatus};
+use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::atomic::AtomicU64;
 use std::sync::Arc;
@@ -143,6 +147,195 @@ fn parse_service_tier_override_supports_set_and_clear() {
   );
   assert_eq!(parse_service_tier_override(Some("none")), Some(None));
   assert_eq!(parse_service_tier_override(Some("bogus")), None);
+}
+
+#[test]
+fn orbitdock_provider_defaults_add_openrouter_attribution_headers() {
+  let mut config = config_with_provider(
+    "openrouter",
+    ModelProviderInfo {
+      name: "OpenRouter".to_string(),
+      base_url: Some("https://openrouter.ai/api/v1".to_string()),
+      env_key: Some("OPENROUTER_API_KEY".to_string()),
+      env_key_instructions: None,
+      experimental_bearer_token: None,
+      wire_api: WireApi::Responses,
+      query_params: None,
+      http_headers: None,
+      env_http_headers: None,
+      request_max_retries: None,
+      stream_max_retries: None,
+      stream_idle_timeout_ms: None,
+      websocket_connect_timeout_ms: None,
+      requires_openai_auth: false,
+      supports_websockets: false,
+    },
+  );
+
+  apply_orbitdock_provider_defaults(&mut config);
+
+  let provider = config
+    .model_providers
+    .get("openrouter")
+    .expect("provider should exist");
+  let headers = provider
+    .http_headers
+    .as_ref()
+    .expect("headers should be set");
+  assert_eq!(
+    headers.get("HTTP-Referer").map(String::as_str),
+    Some("https://orbitdock.dev")
+  );
+  assert_eq!(
+    headers.get("X-OpenRouter-Title").map(String::as_str),
+    Some("OrbitDock")
+  );
+}
+
+#[test]
+fn orbitdock_provider_defaults_preserve_existing_openrouter_headers() {
+  let mut config = config_with_provider(
+    "openrouter",
+    ModelProviderInfo {
+      name: "OpenRouter".to_string(),
+      base_url: Some("https://openrouter.ai/api/v1".to_string()),
+      env_key: Some("OPENROUTER_API_KEY".to_string()),
+      env_key_instructions: None,
+      experimental_bearer_token: None,
+      wire_api: WireApi::Responses,
+      query_params: None,
+      http_headers: Some(HashMap::from([
+        (
+          "HTTP-Referer".to_string(),
+          "https://custom.example".to_string(),
+        ),
+        ("X-Title".to_string(), "Custom Title".to_string()),
+      ])),
+      env_http_headers: None,
+      request_max_retries: None,
+      stream_max_retries: None,
+      stream_idle_timeout_ms: None,
+      websocket_connect_timeout_ms: None,
+      requires_openai_auth: false,
+      supports_websockets: false,
+    },
+  );
+
+  apply_orbitdock_provider_defaults(&mut config);
+
+  let provider = config
+    .model_providers
+    .get("openrouter")
+    .expect("provider should exist");
+  let headers = provider
+    .http_headers
+    .as_ref()
+    .expect("headers should be set");
+  assert_eq!(
+    headers.get("HTTP-Referer").map(String::as_str),
+    Some("https://custom.example")
+  );
+  assert_eq!(
+    headers.get("X-Title").map(String::as_str),
+    Some("Custom Title")
+  );
+  assert!(!headers.contains_key("X-OpenRouter-Title"));
+}
+
+#[test]
+fn external_model_defaults_seed_synthetic_catalog_for_non_openai_models() {
+  let mut config = config_with_provider(
+    "openrouter",
+    ModelProviderInfo {
+      name: "OpenRouter".to_string(),
+      base_url: Some("https://openrouter.ai/api/v1".to_string()),
+      env_key: Some("OPENROUTER_API_KEY".to_string()),
+      env_key_instructions: None,
+      experimental_bearer_token: None,
+      wire_api: WireApi::Responses,
+      query_params: None,
+      http_headers: None,
+      env_http_headers: None,
+      request_max_retries: None,
+      stream_max_retries: None,
+      stream_idle_timeout_ms: None,
+      websocket_connect_timeout_ms: None,
+      requires_openai_auth: false,
+      supports_websockets: false,
+    },
+  );
+  config.model = Some("qwen/qwen3-coder-next".to_string());
+  config.model_catalog = None;
+
+  apply_orbitdock_external_model_defaults(&mut config);
+
+  let catalog = config.model_catalog.expect("catalog should be seeded");
+  let model = catalog
+    .models
+    .iter()
+    .find(|candidate| candidate.slug == "qwen/qwen3-coder-next")
+    .expect("synthetic model should exist");
+  assert_eq!(model.display_name, "qwen/qwen3-coder-next");
+  assert!(!model.used_fallback_model_metadata);
+  assert!(model.model_messages.is_some());
+  assert!(model
+    .base_instructions
+    .contains("Do not claim to be a specific branded assistant"));
+}
+
+#[test]
+fn external_model_defaults_leave_openai_models_untouched() {
+  let mut config = config_with_provider(
+    "openai",
+    ModelProviderInfo::create_openai_provider(Some("https://api.openai.com/v1".to_string())),
+  );
+  config.model = Some("gpt-5.4".to_string());
+  config.model_catalog = None;
+
+  apply_orbitdock_external_model_defaults(&mut config);
+
+  assert!(config.model_catalog.is_none());
+}
+
+fn config_with_provider(provider_id: &str, provider: ModelProviderInfo) -> CoreConfig {
+  let mut config =
+    CoreConfig::load_default_with_cli_overrides(Vec::new()).expect("default config should load");
+  config.model_provider_id = provider_id.to_string();
+  config.model_provider = provider.clone();
+  config
+    .model_providers
+    .insert(provider_id.to_string(), provider);
+  config
+}
+
+#[test]
+fn runtime_warning_suppresses_fallback_metadata_notice() {
+  let msg_counter = AtomicU64::new(0);
+  let events = super::event_mapping::runtime_signals::handle_warning(
+    "event-1",
+    WarningEvent {
+      message:
+        "Model metadata for `qwen/qwen3-coder-next` not found. Defaulting to fallback metadata; this can degrade performance and cause issues."
+          .to_string(),
+    },
+    &msg_counter,
+  );
+
+  assert!(events.is_empty());
+}
+
+#[test]
+fn runtime_warning_preserves_other_warnings() {
+  let msg_counter = AtomicU64::new(0);
+  let events = super::event_mapping::runtime_signals::handle_warning(
+    "event-1",
+    WarningEvent {
+      message: "Something else happened".to_string(),
+    },
+    &msg_counter,
+  );
+
+  assert_eq!(events.len(), 1);
 }
 
 #[test]

--- a/orbitdock-server/crates/server/src/connectors/codex_rollout/runtime.rs
+++ b/orbitdock-server/crates/server/src/connectors/codex_rollout/runtime.rs
@@ -15,6 +15,7 @@ use orbitdock_protocol::{
   CodexIntegrationMode, Provider, ServerMessage, SessionStatus, StateChanges,
   TokenUsageSnapshotKind, WorkStatus,
 };
+use rusqlite::{params, Connection, OptionalExtension};
 use tokio::sync::mpsc;
 use tokio::task::JoinHandle;
 use tracing::{debug, info};
@@ -100,6 +101,36 @@ struct WorkStateUpdate {
 }
 
 impl WatcherRuntime {
+  async fn should_preserve_user_closed_session(&self, session_id: &str) -> bool {
+    let db_path = self.app_state.db_path().clone();
+    let session_id = session_id.to_string();
+
+    tokio::task::spawn_blocking(move || -> Result<bool, rusqlite::Error> {
+      if !db_path.exists() {
+        return Ok(false);
+      }
+
+      let conn = Connection::open(db_path)?;
+      let row = conn
+        .query_row(
+          "SELECT status, end_reason FROM sessions WHERE id = ?1",
+          params![session_id],
+          |row| Ok((row.get::<_, String>(0)?, row.get::<_, Option<String>>(1)?)),
+        )
+        .optional()?;
+
+      Ok(matches!(
+        row,
+        Some((status, Some(end_reason)))
+          if status.eq_ignore_ascii_case("ended") && end_reason == "user_requested"
+      ))
+    })
+    .await
+    .ok()
+    .and_then(Result::ok)
+    .unwrap_or(false)
+  }
+
   pub(crate) async fn sweep_files(&mut self) -> anyhow::Result<()> {
     for path in self.tailer.active_candidates(STARTUP_SEED_RECENT_SECS) {
       self.process_file(path).await?;
@@ -565,6 +596,7 @@ impl WatcherRuntime {
       .file_name()
       .map(|s| s.to_string_lossy().to_string());
     let project_name = project_name.or(fallback_name);
+    let preserve_user_closed_state = self.should_preserve_user_closed_session(&session_id).await;
 
     let exists = self.app_state.get_session(&session_id).is_some();
 
@@ -576,6 +608,10 @@ impl WatcherRuntime {
       handle.set_model(model_provider.clone());
       handle.set_started_at(Some(started_at.clone()));
       handle.set_last_activity_at(Some(current_time_unix_z()));
+      if preserve_user_closed_state {
+        handle.set_status(SessionStatus::Ended);
+        handle.set_work_status(WorkStatus::Ended);
+      }
 
       let summary = handle.summary();
       self.app_state.add_session(handle);
@@ -603,17 +639,19 @@ impl WatcherRuntime {
           model: model_provider.clone(),
         })
         .await;
-      actor
-        .send(SessionCommand::SetStatus {
-          status: SessionStatus::Active,
-        })
-        .await;
-      if snap.work_status == WorkStatus::Ended {
+      if !preserve_user_closed_state {
         actor
-          .send(SessionCommand::SetWorkStatus {
-            status: WorkStatus::Waiting,
+          .send(SessionCommand::SetStatus {
+            status: SessionStatus::Active,
           })
           .await;
+        if snap.work_status == WorkStatus::Ended {
+          actor
+            .send(SessionCommand::SetWorkStatus {
+              status: WorkStatus::Waiting,
+            })
+            .await;
+        }
       }
       actor
         .send(SessionCommand::SetLastActivityAt {
@@ -1222,17 +1260,61 @@ impl WatcherRuntime {
       last_tool_at,
       status,
     } = update;
-    if let Some(actor) = self.app_state.get_session(session_id) {
-      actor
-        .send(SessionCommand::SetPendingAttention {
-          pending_tool_name: pending_tool_name.clone().flatten(),
-          pending_tool_input: pending_tool_input.clone().flatten(),
-          pending_question: pending_question.clone().flatten(),
-        })
-        .await;
+    let preserve_user_closed_state = self.should_preserve_user_closed_session(session_id).await;
+
+    if !preserve_user_closed_state {
+      if let Some(actor) = self.app_state.get_session(session_id) {
+        actor
+          .send(SessionCommand::SetPendingAttention {
+            pending_tool_name: pending_tool_name.clone().flatten(),
+            pending_tool_input: pending_tool_input.clone().flatten(),
+            pending_question: pending_question.clone().flatten(),
+          })
+          .await;
+      }
     }
 
-    let status = status.or(Some(SessionStatus::Active));
+    let status = if preserve_user_closed_state {
+      None
+    } else {
+      status.or(Some(SessionStatus::Active))
+    };
+    let work_status = if preserve_user_closed_state {
+      None
+    } else {
+      Some(work_status)
+    };
+    let pending_tool_name = if preserve_user_closed_state {
+      None
+    } else {
+      pending_tool_name
+    };
+    let pending_tool_input = if preserve_user_closed_state {
+      None
+    } else {
+      pending_tool_input
+    };
+    let pending_question = if preserve_user_closed_state {
+      None
+    } else {
+      pending_question
+    };
+    let attention_reason = if preserve_user_closed_state {
+      None
+    } else {
+      attention_reason
+    };
+    let last_tool = if preserve_user_closed_state {
+      None
+    } else {
+      last_tool
+    };
+    let last_tool_at = if preserve_user_closed_state {
+      None
+    } else {
+      last_tool_at
+    };
+
     let attention_pending_tool_name = pending_tool_name.clone().flatten();
     let attention_pending_tool_input = pending_tool_input.clone().flatten();
     let attention_pending_question = pending_question.clone().flatten();
@@ -1245,7 +1327,7 @@ impl WatcherRuntime {
         project_path: None,
         model: None,
         status,
-        work_status: Some(work_status),
+        work_status,
         attention_reason: attention_reason.map(Some),
         pending_tool_name,
         pending_tool_input,
@@ -1257,27 +1339,37 @@ impl WatcherRuntime {
       })
       .await;
 
-    if let Some(actor) = self.app_state.get_session(session_id) {
-      actor
-        .send(SessionCommand::SetPendingAttention {
-          pending_tool_name: attention_pending_tool_name,
-          pending_tool_input: attention_pending_tool_input,
-          pending_question: attention_pending_question,
-        })
+    if preserve_user_closed_state {
+      if let Some(actor) = self.app_state.get_session(session_id) {
+        actor
+          .send(SessionCommand::SetLastActivityAt {
+            ts: Some(current_time_unix_z()),
+          })
+          .await;
+      }
+    } else {
+      if let Some(actor) = self.app_state.get_session(session_id) {
+        actor
+          .send(SessionCommand::SetPendingAttention {
+            pending_tool_name: attention_pending_tool_name,
+            pending_tool_input: attention_pending_tool_input,
+            pending_question: attention_pending_question,
+          })
+          .await;
+      }
+
+      self
+        .broadcast_session_delta(
+          session_id,
+          StateChanges {
+            status: Some(SessionStatus::Active),
+            work_status,
+            last_activity_at: Some(current_time_unix_z()),
+            ..Default::default()
+          },
+        )
         .await;
     }
-
-    self
-      .broadcast_session_delta(
-        session_id,
-        StateChanges {
-          status: Some(SessionStatus::Active),
-          work_status: Some(work_status),
-          last_activity_at: Some(current_time_unix_z()),
-          ..Default::default()
-        },
-      )
-      .await;
 
     let _ = has_attention_payload;
 
@@ -2328,6 +2420,45 @@ mod rollout_watcher_tests {
             .expect("append rollout line");
   }
 
+  fn find_migrations_dir() -> PathBuf {
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    for ancestor in manifest_dir.ancestors() {
+      let candidate = ancestor.join("migrations");
+      if candidate.is_dir() {
+        return candidate;
+      }
+    }
+    panic!(
+      "Could not locate migrations directory from {:?}",
+      manifest_dir
+    );
+  }
+
+  fn run_all_migrations(db_path: &Path) {
+    let conn = Connection::open(db_path).expect("open db");
+    conn
+      .execute_batch(
+        "PRAGMA journal_mode = WAL;
+         PRAGMA busy_timeout = 5000;",
+      )
+      .expect("set pragmas");
+
+    let migrations_dir = find_migrations_dir();
+    let mut files: Vec<PathBuf> = std::fs::read_dir(&migrations_dir)
+      .expect("read migrations")
+      .filter_map(|entry| entry.ok().map(|e| e.path()))
+      .filter(|path| path.extension().and_then(|ext| ext.to_str()) == Some("sql"))
+      .collect();
+    files.sort();
+
+    for file in files {
+      let sql = std::fs::read_to_string(&file).expect("read migration");
+      conn.execute_batch(&sql).unwrap_or_else(|err| {
+        panic!("migration failed for {}: {}", file.display(), err);
+      });
+    }
+  }
+
   #[tokio::test]
   async fn sweep_files_only_revisits_active_paths() {
     ensure_server_test_data_dir();
@@ -2513,6 +2644,242 @@ mod rollout_watcher_tests {
         .len()
     );
     assert_eq!(persisted_session_id.as_deref(), Some(session_id.as_str()));
+
+    let _ = std::fs::remove_dir_all(&tmp_dir);
+  }
+
+  #[tokio::test]
+  async fn rollout_activity_preserves_user_closed_passive_session_in_memory_and_db() {
+    ensure_server_test_data_dir();
+    let session_id = format!("passive-reactivate-db-{}", std::process::id());
+    let tmp_dir = std::env::temp_dir().join(format!("orbitdock-rollout-db-{}", session_id));
+    std::fs::create_dir_all(tmp_dir.join(".orbitdock")).expect("create .orbitdock dir");
+    let db_path = tmp_dir.join(".orbitdock/orbitdock.db");
+    run_all_migrations(&db_path);
+
+    let rollout_path = tmp_dir.join("rollout.jsonl");
+    std::fs::write(
+      &rollout_path,
+      format!(
+        "{{\"type\":\"session_meta\",\"payload\":{{\"id\":\"{}\",\"cwd\":\"/tmp/repo\"}}}}\n",
+        session_id
+      ),
+    )
+    .expect("write initial rollout");
+    let initial_size = std::fs::metadata(&rollout_path)
+      .expect("stat rollout")
+      .len();
+
+    crate::infrastructure::persistence::flush_batch_for_test(
+      &db_path,
+      vec![
+        PersistCommand::RolloutSessionUpsert {
+          id: session_id.clone(),
+          thread_id: session_id.clone(),
+          project_path: "/tmp/repo".to_string(),
+          project_name: Some("repo".to_string()),
+          branch: Some("main".to_string()),
+          model: Some("gpt-5".to_string()),
+          context_label: Some("codex_cli_rs".to_string()),
+          transcript_path: rollout_path.to_string_lossy().to_string(),
+          started_at: "2026-02-10T00:00:00Z".to_string(),
+        },
+        PersistCommand::SessionEnd {
+          id: session_id.clone(),
+          reason: "user_requested".to_string(),
+        },
+      ],
+    )
+    .expect("seed ended passive session");
+
+    let (persist_tx, mut persist_rx) = mpsc::channel(128);
+    let app_state = Arc::new(SessionRegistry::new_with_primary_and_db_path(
+      persist_tx.clone(),
+      db_path.clone(),
+      true,
+      orbitdock_protocol::WorkspaceProviderKind::default(),
+    ));
+    let mut handle =
+      SessionHandle::new(session_id.clone(), Provider::Codex, "/tmp/repo".to_string());
+    handle.set_codex_integration_mode(Some(CodexIntegrationMode::Passive));
+    handle.set_transcript_path(Some(rollout_path.to_string_lossy().to_string()));
+    handle.set_status(SessionStatus::Ended);
+    handle.set_work_status(WorkStatus::Ended);
+    app_state.add_session(handle);
+
+    let (watcher_tx, _watcher_rx) = mpsc::unbounded_channel();
+    let mut runtime = make_test_runtime(app_state.clone(), persist_tx, watcher_tx);
+    runtime.tailer = JsonlTailer::new(HashMap::from([(
+      rollout_path.to_string_lossy().to_string(),
+      PersistedFileState {
+        offset: initial_size,
+        session_id: Some(session_id.clone()),
+        project_path: Some("/tmp/repo".to_string()),
+        model_provider: Some("codex".to_string()),
+        ignore_existing: Some(false),
+      },
+    )]));
+    runtime.processor = RolloutFileProcessor::new(HashMap::from([(
+      rollout_path.to_string_lossy().to_string(),
+      PersistedFileState {
+        offset: initial_size,
+        session_id: Some(session_id.clone()),
+        project_path: Some("/tmp/repo".to_string()),
+        model_provider: Some("codex".to_string()),
+        ignore_existing: Some(false),
+      },
+    )]));
+    runtime.processor.parse_states.insert(
+      rollout_path.to_string_lossy().to_string(),
+      default_parse_state(Some(session_id.clone())),
+    );
+
+    append_user_message(&rollout_path);
+    runtime
+      .process_file(rollout_path.clone())
+      .await
+      .expect("process rollout");
+
+    let mut persist_batch = Vec::new();
+    while let Ok(cmd) = persist_rx.try_recv() {
+      persist_batch.push(cmd);
+    }
+    crate::infrastructure::persistence::flush_batch_for_test(&db_path, persist_batch)
+      .expect("flush watcher updates");
+
+    let snapshot = app_state
+      .get_session(&session_id)
+      .expect("session exists")
+      .snapshot();
+    assert_eq!(snapshot.status, SessionStatus::Ended);
+    assert_eq!(snapshot.work_status, WorkStatus::Ended);
+
+    let conn = Connection::open(&db_path).expect("open db");
+    let (status, work_status, ended_at, end_reason): (
+      String,
+      String,
+      Option<String>,
+      Option<String>,
+    ) = conn
+      .query_row(
+        "SELECT status, work_status, ended_at, end_reason FROM sessions WHERE id = ?1",
+        params![session_id],
+        |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
+      )
+      .expect("query session");
+    assert_eq!(status, "ended");
+    assert_eq!(work_status, "ended");
+    assert!(ended_at.is_some(), "ended_at should stay populated");
+    assert_eq!(end_reason.as_deref(), Some("user_requested"));
+
+    let _ = std::fs::remove_dir_all(&tmp_dir);
+  }
+
+  #[tokio::test]
+  async fn startup_seed_preserves_user_closed_passive_session_when_runtime_is_empty() {
+    ensure_server_test_data_dir();
+    let session_id = format!("passive-startup-preserve-{}", std::process::id());
+    let tmp_dir = std::env::temp_dir().join(format!("orbitdock-rollout-startup-{}", session_id));
+    std::fs::create_dir_all(tmp_dir.join(".orbitdock")).expect("create .orbitdock dir");
+    let db_path = tmp_dir.join(".orbitdock/orbitdock.db");
+    run_all_migrations(&db_path);
+
+    let rollout_path = tmp_dir.join("rollout.jsonl");
+    std::fs::write(
+      &rollout_path,
+      format!(
+        "{{\"type\":\"session_meta\",\"payload\":{{\"id\":\"{}\",\"cwd\":\"/tmp/repo\"}}}}\n",
+        session_id
+      ),
+    )
+    .expect("write initial rollout");
+    let initial_size = std::fs::metadata(&rollout_path)
+      .expect("stat rollout")
+      .len();
+
+    crate::infrastructure::persistence::flush_batch_for_test(
+      &db_path,
+      vec![
+        PersistCommand::RolloutSessionUpsert {
+          id: session_id.clone(),
+          thread_id: session_id.clone(),
+          project_path: "/tmp/repo".to_string(),
+          project_name: Some("repo".to_string()),
+          branch: Some("main".to_string()),
+          model: Some("gpt-5".to_string()),
+          context_label: Some("codex_cli_rs".to_string()),
+          transcript_path: rollout_path.to_string_lossy().to_string(),
+          started_at: "2026-02-10T00:00:00Z".to_string(),
+        },
+        PersistCommand::SessionEnd {
+          id: session_id.clone(),
+          reason: "user_requested".to_string(),
+        },
+      ],
+    )
+    .expect("seed ended passive session");
+
+    let (persist_tx, mut persist_rx) = mpsc::channel(128);
+    let app_state = Arc::new(SessionRegistry::new_with_primary_and_db_path(
+      persist_tx.clone(),
+      db_path.clone(),
+      true,
+      orbitdock_protocol::WorkspaceProviderKind::default(),
+    ));
+    let (watcher_tx, _watcher_rx) = mpsc::unbounded_channel();
+    let mut runtime = make_test_runtime(app_state.clone(), persist_tx, watcher_tx);
+    runtime.tailer = JsonlTailer::new(HashMap::from([(
+      rollout_path.to_string_lossy().to_string(),
+      PersistedFileState {
+        offset: initial_size,
+        session_id: Some(session_id.clone()),
+        project_path: Some("/tmp/repo".to_string()),
+        model_provider: Some("codex".to_string()),
+        ignore_existing: Some(false),
+      },
+    )]));
+    runtime.processor = RolloutFileProcessor::new(HashMap::from([(
+      rollout_path.to_string_lossy().to_string(),
+      PersistedFileState {
+        offset: initial_size,
+        session_id: Some(session_id.clone()),
+        project_path: Some("/tmp/repo".to_string()),
+        model_provider: Some("codex".to_string()),
+        ignore_existing: Some(false),
+      },
+    )]));
+    runtime
+      .tailer
+      .mark_active(rollout_path.to_string_lossy().as_ref());
+    runtime
+      .tailer
+      .ensure_file(rollout_path.to_string_lossy().as_ref(), initial_size, None);
+
+    runtime.sweep_files().await.expect("run startup sweep");
+
+    let mut persist_batch = Vec::new();
+    while let Ok(cmd) = persist_rx.try_recv() {
+      persist_batch.push(cmd);
+    }
+    crate::infrastructure::persistence::flush_batch_for_test(&db_path, persist_batch)
+      .expect("flush watcher updates");
+
+    assert!(
+      app_state.get_session(&session_id).is_none(),
+      "startup sweep should not rematerialize a user-closed passive session"
+    );
+
+    let conn = Connection::open(&db_path).expect("open db");
+    let (status, work_status, end_reason): (String, String, Option<String>) = conn
+      .query_row(
+        "SELECT status, work_status, end_reason FROM sessions WHERE id = ?1",
+        params![session_id],
+        |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+      )
+      .expect("query session");
+    assert_eq!(status, "ended");
+    assert_eq!(work_status, "ended");
+    assert_eq!(end_reason.as_deref(), Some("user_requested"));
 
     let _ = std::fs::remove_dir_all(&tmp_dir);
   }

--- a/orbitdock-server/crates/server/src/infrastructure/persistence/mod.rs
+++ b/orbitdock-server/crates/server/src/infrastructure/persistence/mod.rs
@@ -85,6 +85,79 @@ pub(crate) use worktrees::{
 pub(crate) use writer::flush_batch_for_test;
 pub(crate) use writer::{create_persistence_channel, PersistenceWriter};
 
+fn session_was_user_closed(conn: &Connection, session_id: &str) -> Result<bool, rusqlite::Error> {
+  let row = conn
+    .query_row(
+      "SELECT status, end_reason FROM sessions WHERE id = ?1",
+      params![session_id],
+      |row| Ok((row.get::<_, String>(0)?, row.get::<_, Option<String>>(1)?)),
+    )
+    .optional()?;
+
+  Ok(matches!(
+    row,
+    Some((status, Some(end_reason)))
+      if status.eq_ignore_ascii_case("ended") && end_reason == "user_requested"
+  ))
+}
+
+fn claude_shadow_is_owned_by_direct_session(
+  conn: &Connection,
+  session_id: &str,
+) -> Result<bool, rusqlite::Error> {
+  let exists: i64 = conn.query_row(
+    "SELECT EXISTS(
+            SELECT 1
+            FROM sessions direct
+            WHERE direct.provider = 'claude'
+              AND direct.claude_sdk_session_id = ?1
+              AND COALESCE(direct.control_mode, CASE
+                    WHEN direct.provider = 'claude'
+                         AND direct.claude_integration_mode = 'direct'
+                        THEN 'direct'
+                    ELSE 'passive'
+                  END) = 'direct'
+        )",
+    params![session_id],
+    |row| row.get(0),
+  )?;
+
+  Ok(exists == 1)
+}
+
+fn preserve_direct_owned_claude_shadow(
+  conn: &Connection,
+  session_id: &str,
+  reason: &str,
+) -> Result<bool, rusqlite::Error> {
+  if !claude_shadow_is_owned_by_direct_session(conn, session_id)? {
+    return Ok(false);
+  }
+
+  let now = chrono_now();
+  conn.execute(
+    "UPDATE sessions
+             SET status = 'ended',
+                 work_status = 'ended',
+                 lifecycle_state = 'ended',
+                 ended_at = COALESCE(ended_at, ?1),
+                 end_reason = COALESCE(end_reason, ?2),
+                 attention_reason = 'none',
+                 pending_tool_name = NULL,
+                 pending_tool_input = NULL,
+                 pending_question = NULL,
+                 pending_approval_id = NULL,
+                 active_subagent_id = NULL,
+                 active_subagent_type = NULL
+             WHERE id = ?3
+               AND provider = 'claude'
+               AND (claude_integration_mode IS NULL OR claude_integration_mode != 'direct')",
+    params![now, reason, session_id],
+  )?;
+
+  Ok(true)
+}
+
 fn persist_subagent_upsert(
   conn: &Connection,
   session_id: &str,
@@ -261,18 +334,90 @@ pub(super) fn execute_command(
       });
 
       conn.execute(
-                "INSERT INTO sessions (id, project_path, project_name, branch, model, provider, status, work_status, lifecycle_state, control_mode, codex_integration_mode, claude_integration_mode, approval_policy, sandbox_mode, permission_mode, collaboration_mode, multi_agent, personality, service_tier, developer_instructions, codex_config_mode, codex_config_profile, codex_model_provider, codex_config_source, codex_config_overrides_json, started_at, last_activity_at, last_progress_at, forked_from_session_id, mission_id, issue_identifier, allow_bypass_permissions, worktree_id, is_worktree)
-                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, 'active', 'waiting', 'open', ?8, ?9, ?13, ?10, ?11, ?14, ?15, ?16, ?17, ?18, ?19, ?20, ?21, ?22, ?23, ?7, ?7, ?7, ?12, ?24, ?25, ?26, ?27, ?28, ?29)
+        "INSERT INTO sessions (
+                    id,
+                    project_path,
+                    project_name,
+                    branch,
+                    model,
+                    provider,
+                    status,
+                    work_status,
+                    lifecycle_state,
+                    control_mode,
+                    codex_integration_mode,
+                    claude_integration_mode,
+                    approval_policy,
+                    sandbox_mode,
+                    permission_mode,
+                    collaboration_mode,
+                    multi_agent,
+                    personality,
+                    service_tier,
+                    developer_instructions,
+                    codex_config_mode,
+                    codex_config_profile,
+                    codex_model_provider,
+                    codex_config_source,
+                    codex_config_overrides_json,
+                    started_at,
+                    last_activity_at,
+                    last_progress_at,
+                    forked_from_session_id,
+                    mission_id,
+                    issue_identifier,
+                    allow_bypass_permissions,
+                    worktree_id,
+                    is_worktree
+                 )
+                 VALUES (
+                    ?1, ?2, ?3, ?4, ?5, ?6, 'active', 'waiting', 'open',
+                    ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17,
+                    ?18, ?19, ?20, ?21, ?22, ?23, ?24, ?25, ?26, ?27,
+                    ?28, ?29, ?30, ?31
+                 )
                  ON CONFLICT(id) DO UPDATE SET
                    project_name = COALESCE(?3, project_name),
                    branch = COALESCE(?4, branch),
                    model = COALESCE(?5, model),
                    control_mode = COALESCE(sessions.control_mode, excluded.control_mode),
                    lifecycle_state = COALESCE(sessions.lifecycle_state, excluded.lifecycle_state),
-                   last_activity_at = ?7,
-                   last_progress_at = ?7",
-                params![id, project_path, project_name, branch, model, provider_str, now, control_mode, codex_integration_mode, approval_policy, sandbox_mode, forked_from_session_id, claude_integration_mode, permission_mode, collaboration_mode, multi_agent, personality, service_tier, developer_instructions, codex_config_mode, codex_config_profile, codex_model_provider, codex_config_source, codex_config_overrides_json, mission_id, issue_identifier, allow_bypass_permissions, worktree_id, worktree_id.is_some()],
-            )?;
+                   last_activity_at = ?24,
+                   last_progress_at = ?25",
+        params![
+          id,
+          project_path,
+          project_name,
+          branch,
+          model,
+          provider_str,
+          control_mode,
+          codex_integration_mode,
+          claude_integration_mode,
+          approval_policy,
+          sandbox_mode,
+          permission_mode,
+          collaboration_mode,
+          multi_agent,
+          personality,
+          service_tier,
+          developer_instructions,
+          codex_config_mode,
+          codex_config_profile,
+          codex_model_provider,
+          codex_config_source,
+          codex_config_overrides_json,
+          now.clone(),
+          now.clone(),
+          now,
+          forked_from_session_id,
+          mission_id,
+          issue_identifier,
+          allow_bypass_permissions,
+          worktree_id,
+          worktree_id.is_some(),
+        ],
+      )?;
     }
 
     PersistCommand::SessionUpdate {
@@ -901,6 +1046,10 @@ pub(super) fn execute_command(
       is_worktree,
       git_sha,
     } => {
+      if preserve_direct_owned_claude_shadow(conn, &id, "direct_owner_exists")? {
+        return Ok(());
+      }
+
       let now = chrono_now();
       conn.execute(
                 "INSERT INTO sessions (
@@ -975,6 +1124,10 @@ pub(super) fn execute_command(
       first_prompt,
       compact_count_increment,
     } => {
+      if preserve_direct_owned_claude_shadow(conn, &id, "direct_owner_exists")? {
+        return Ok(());
+      }
+
       let mut updates: Vec<String> = Vec::new();
       let mut params_vec: Vec<Box<dyn rusqlite::ToSql>> = Vec::new();
       let has_attention_reason = attention_reason.is_some();
@@ -1236,6 +1389,7 @@ pub(super) fn execute_command(
         return Ok(());
       }
 
+      let preserve_user_closed_state = session_was_user_closed(conn, &id)?;
       let now = chrono_now();
       conn.execute(
                 "INSERT INTO sessions (
@@ -1251,13 +1405,27 @@ pub(super) fn execute_command(
                     context_label = COALESCE(excluded.context_label, sessions.context_label),
                     transcript_path = excluded.transcript_path,
                     provider = 'codex',
-                    status = 'active',
+                    status = CASE
+                        WHEN ?11 THEN sessions.status
+                        ELSE 'active'
+                    END,
                     work_status = CASE
+                        WHEN ?11 THEN sessions.work_status
                         WHEN sessions.work_status IN ('permission', 'question', 'working') THEN sessions.work_status
                         ELSE 'waiting'
                     END,
-                    ended_at = NULL,
-                    end_reason = NULL,
+                    ended_at = CASE
+                        WHEN ?11 THEN sessions.ended_at
+                        ELSE NULL
+                    END,
+                    end_reason = CASE
+                        WHEN ?11 THEN sessions.end_reason
+                        ELSE NULL
+                    END,
+                    lifecycle_state = CASE
+                        WHEN ?11 THEN COALESCE(sessions.lifecycle_state, 'ended')
+                        ELSE 'open'
+                    END,
                     control_mode = CASE
                         WHEN sessions.control_mode = 'direct' THEN sessions.control_mode
                         ELSE 'passive'
@@ -1276,6 +1444,7 @@ pub(super) fn execute_command(
                     thread_id,
                     started_at,
                     now,
+                    preserve_user_closed_state,
                 ],
             )?;
     }
@@ -1299,6 +1468,7 @@ pub(super) fn execute_command(
         return Ok(());
       }
 
+      let preserve_user_closed_state = session_was_user_closed(conn, &id)?;
       let lifecycle_state_is_ended = matches!(status, Some(SessionStatus::Ended))
         || matches!(work_status, Some(WorkStatus::Ended));
       let status_str = status.map(|s| match s {
@@ -1332,48 +1502,52 @@ pub(super) fn execute_command(
         updates.push("model = ?".to_string());
         params_vec.push(Box::new(m));
       }
-      if let Some(s) = status_str {
-        updates.push("status = ?".to_string());
-        params_vec.push(Box::new(s.to_string()));
-        if s == "ended" {
-          updates.push("ended_at = COALESCE(ended_at, ?)".to_string());
-          params_vec.push(Box::new(chrono_now()));
-        } else {
-          updates.push("ended_at = NULL".to_string());
-          updates.push("end_reason = NULL".to_string());
+      if !preserve_user_closed_state {
+        if let Some(s) = status_str {
+          updates.push("status = ?".to_string());
+          params_vec.push(Box::new(s.to_string()));
+          if s == "ended" {
+            updates.push("ended_at = COALESCE(ended_at, ?)".to_string());
+            params_vec.push(Box::new(chrono_now()));
+          } else {
+            updates.push("ended_at = NULL".to_string());
+            updates.push("end_reason = NULL".to_string());
+          }
         }
-      }
-      if let Some(ws) = work_status_str {
-        updates.push("work_status = ?".to_string());
-        params_vec.push(Box::new(ws.to_string()));
-      }
-      if let Some(reason) = attention_reason {
-        updates.push("attention_reason = ?".to_string());
-        params_vec.push(Box::new(reason));
-      }
-      if let Some(tool_name) = pending_tool_name {
-        updates.push("pending_tool_name = ?".to_string());
-        params_vec.push(Box::new(tool_name));
-      }
-      if let Some(tool_input) = pending_tool_input {
-        updates.push("pending_tool_input = ?".to_string());
-        params_vec.push(Box::new(tool_input));
-      }
-      if let Some(question) = pending_question {
-        updates.push("pending_question = ?".to_string());
-        params_vec.push(Box::new(question));
+        if let Some(ws) = work_status_str {
+          updates.push("work_status = ?".to_string());
+          params_vec.push(Box::new(ws.to_string()));
+        }
+        if let Some(reason) = attention_reason {
+          updates.push("attention_reason = ?".to_string());
+          params_vec.push(Box::new(reason));
+        }
+        if let Some(tool_name) = pending_tool_name {
+          updates.push("pending_tool_name = ?".to_string());
+          params_vec.push(Box::new(tool_name));
+        }
+        if let Some(tool_input) = pending_tool_input {
+          updates.push("pending_tool_input = ?".to_string());
+          params_vec.push(Box::new(tool_input));
+        }
+        if let Some(question) = pending_question {
+          updates.push("pending_question = ?".to_string());
+          params_vec.push(Box::new(question));
+        }
       }
       if let Some(tokens) = total_tokens {
         updates.push("total_tokens = ?".to_string());
         params_vec.push(Box::new(tokens));
       }
-      if let Some(tool) = last_tool {
-        updates.push("last_tool = ?".to_string());
-        params_vec.push(Box::new(tool));
-      }
-      if let Some(tool_at) = last_tool_at {
-        updates.push("last_tool_at = ?".to_string());
-        params_vec.push(Box::new(tool_at));
+      if !preserve_user_closed_state {
+        if let Some(tool) = last_tool {
+          updates.push("last_tool = ?".to_string());
+          params_vec.push(Box::new(tool));
+        }
+        if let Some(tool_at) = last_tool_at {
+          updates.push("last_tool_at = ?".to_string());
+          params_vec.push(Box::new(tool_at));
+        }
       }
       if let Some(name) = custom_name {
         updates.push("custom_name = ?".to_string());
@@ -1384,7 +1558,9 @@ pub(super) fn execute_command(
         updates.push("last_activity_at = ?".to_string());
         params_vec.push(Box::new(chrono_now()));
 
-        if lifecycle_state_is_ended {
+        if preserve_user_closed_state {
+          updates.push("lifecycle_state = COALESCE(lifecycle_state, 'ended')".to_string());
+        } else if lifecycle_state_is_ended {
           updates.push("lifecycle_state = 'ended'".to_string());
         } else {
           updates.push("lifecycle_state = COALESCE(lifecycle_state, 'open')".to_string());

--- a/orbitdock-server/crates/server/src/infrastructure/persistence/session_reads.rs
+++ b/orbitdock-server/crates/server/src/infrastructure/persistence/session_reads.rs
@@ -24,6 +24,28 @@ type StoredCodexConfigRow = (
   Option<String>,
 );
 
+fn infer_codex_config_mode(
+  raw_mode: Option<&str>,
+  config_profile: Option<&str>,
+  model_provider: Option<&str>,
+) -> Option<CodexConfigMode> {
+  match raw_mode {
+    Some("inherit") => Some(CodexConfigMode::Inherit),
+    Some("profile") => Some(CodexConfigMode::Profile),
+    Some("custom") => Some(CodexConfigMode::Custom),
+    Some(_) => None,
+    None => {
+      if config_profile.is_some_and(|value| !value.trim().is_empty()) {
+        Some(CodexConfigMode::Profile)
+      } else if model_provider.is_some_and(|value| !value.trim().is_empty()) {
+        Some(CodexConfigMode::Custom)
+      } else {
+        None
+      }
+    }
+  }
+}
+
 /// Intermediate row from the active-sessions SQL query.
 struct ActiveSessionRow {
   id: String,
@@ -386,7 +408,24 @@ pub async fn load_sessions_for_startup() -> Result<Vec<RestoredSession>, anyhow:
                         COALESCE(uss.snapshot_kind, 'unknown')
                  FROM sessions s
                  LEFT JOIN usage_session_state uss ON uss.session_id = s.id
-                 WHERE s.status = 'active'
+                 WHERE (s.status = 'active'
+                    AND NOT (
+                      s.provider = 'claude'
+                      AND COALESCE(s.control_mode, CASE
+                            WHEN s.provider = 'claude' AND s.claude_integration_mode = 'direct' THEN 'direct'
+                            ELSE 'passive'
+                          END) != 'direct'
+                      AND EXISTS (
+                          SELECT 1
+                          FROM sessions direct
+                          WHERE direct.provider = 'claude'
+                            AND direct.claude_sdk_session_id = s.id
+                            AND COALESCE(direct.control_mode, CASE
+                                  WHEN direct.provider = 'claude' AND direct.claude_integration_mode = 'direct' THEN 'direct'
+                                  ELSE 'passive'
+                                END) = 'direct'
+                      )
+                    ))
                     OR (s.status = 'ended' AND s.end_reason = 'server_shutdown')
                  ORDER BY
                    COALESCE(
@@ -617,12 +656,11 @@ pub async fn load_sessions_for_startup() -> Result<Vec<RestoredSession>, anyhow:
                         |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?, row.get(4)?, row.get(5)?, row.get(6)?, row.get(7)?, row.get(8)?, row.get(9)?)),
                     )
                     .unwrap_or((None, None, None, None, None, None, None, None, None, None));
-                let codex_config_mode = match codex_config_mode_raw.as_deref() {
-                    Some("inherit") => Some(CodexConfigMode::Inherit),
-                    Some("profile") => Some(CodexConfigMode::Profile),
-                    Some("custom") => Some(CodexConfigMode::Custom),
-                    _ => None,
-                };
+                let codex_config_mode = infer_codex_config_mode(
+                    codex_config_mode_raw.as_deref(),
+                    codex_config_profile.as_deref(),
+                    codex_model_provider.as_deref(),
+                );
                 let codex_config_source = match codex_config_source_raw.as_deref() {
                     Some("orbitdock") => Some(CodexConfigSource::Orbitdock),
                     Some("user") => Some(CodexConfigSource::User),
@@ -1011,12 +1049,11 @@ pub async fn load_session_by_id(id: &str) -> Result<Option<RestoredSession>, any
                     |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?, row.get(4)?, row.get(5)?, row.get(6)?, row.get(7)?, row.get(8)?, row.get(9)?)),
                 )
                 .unwrap_or((None, None, None, None, None, None, None, None, None, None));
-            let codex_config_mode = match codex_config_mode_raw.as_deref() {
-                Some("inherit") => Some(CodexConfigMode::Inherit),
-                Some("profile") => Some(CodexConfigMode::Profile),
-                Some("custom") => Some(CodexConfigMode::Custom),
-                _ => None,
-            };
+            let codex_config_mode = infer_codex_config_mode(
+                codex_config_mode_raw.as_deref(),
+                codex_config_profile.as_deref(),
+                codex_model_provider.as_deref(),
+            );
             let codex_config_source = match codex_config_source_raw.as_deref() {
                 Some("orbitdock") => Some(CodexConfigSource::Orbitdock),
                 Some("user") => Some(CodexConfigSource::User),

--- a/orbitdock-server/crates/server/src/infrastructure/persistence/tests.rs
+++ b/orbitdock-server/crates/server/src/infrastructure/persistence/tests.rs
@@ -4,7 +4,7 @@ use std::sync::{Mutex, OnceLock};
 use orbitdock_protocol::conversation_contracts::{
   rows::MessageDeliveryStatus, ConversationRow, ConversationRowEntry, MessageRowContent,
 };
-use orbitdock_protocol::{Provider, SessionLifecycleState, SessionStatus};
+use orbitdock_protocol::{CodexConfigMode, Provider, SessionLifecycleState, SessionStatus};
 
 use super::commands::{PersistCommand, SessionCreateParams};
 use super::messages::load_messages_from_db;
@@ -836,6 +836,91 @@ fn load_session_by_id_and_startup_restore_use_persisted_control_mode() {
 }
 
 #[test]
+fn legacy_codex_rows_without_mode_infer_profile_and_custom_modes() {
+  let (conn, _db_path, _dir, _guard) = setup_test_db();
+
+  conn
+    .execute(
+      "INSERT INTO sessions (
+            id, provider, status, work_status, lifecycle_state, control_mode,
+            project_path, model, codex_config_mode, codex_config_profile, codex_model_provider
+         ) VALUES (
+            'legacy-codex-profile', 'codex', 'active', 'waiting', 'open', 'direct',
+            '/tmp/profile', 'qwen/qwen3-coder-next', NULL, 'qwen', 'openrouter'
+         )",
+      [],
+    )
+    .unwrap();
+  conn
+    .execute(
+      "INSERT INTO sessions (
+            id, provider, status, work_status, lifecycle_state, control_mode,
+            project_path, model, codex_config_mode, codex_config_profile, codex_model_provider
+         ) VALUES (
+            'legacy-codex-custom', 'codex', 'active', 'waiting', 'open', 'direct',
+            '/tmp/custom', 'qwen/qwen3-coder-next', NULL, NULL, 'openrouter'
+         )",
+      [],
+    )
+    .unwrap();
+  drop(conn);
+
+  let runtime = tokio::runtime::Builder::new_current_thread()
+    .enable_all()
+    .build()
+    .unwrap();
+
+  let profile_row = runtime
+    .block_on(super::session_reads::load_session_by_id(
+      "legacy-codex-profile",
+    ))
+    .unwrap()
+    .expect("legacy profile row should load");
+  assert_eq!(
+    profile_row.codex_config_mode,
+    Some(CodexConfigMode::Profile)
+  );
+  assert_eq!(profile_row.codex_config_profile.as_deref(), Some("qwen"));
+  assert_eq!(
+    profile_row.codex_model_provider.as_deref(),
+    Some("openrouter")
+  );
+
+  let custom_row = runtime
+    .block_on(super::session_reads::load_session_by_id(
+      "legacy-codex-custom",
+    ))
+    .unwrap()
+    .expect("legacy custom row should load");
+  assert_eq!(custom_row.codex_config_mode, Some(CodexConfigMode::Custom));
+  assert_eq!(
+    custom_row.codex_model_provider.as_deref(),
+    Some("openrouter")
+  );
+
+  let restored = runtime
+    .block_on(super::session_reads::load_sessions_for_startup())
+    .unwrap();
+  let startup_profile = restored
+    .iter()
+    .find(|session| session.id == "legacy-codex-profile")
+    .expect("legacy profile row should restore");
+  assert_eq!(
+    startup_profile.codex_config_mode,
+    Some(CodexConfigMode::Profile)
+  );
+
+  let startup_custom = restored
+    .iter()
+    .find(|session| session.id == "legacy-codex-custom")
+    .expect("legacy custom row should restore");
+  assert_eq!(
+    startup_custom.codex_config_mode,
+    Some(CodexConfigMode::Custom)
+  );
+}
+
+#[test]
 fn load_direct_claude_owner_by_sdk_session_id_returns_direct_owner() {
   let (_conn, db_path, _dir, _guard) = setup_test_db();
 
@@ -895,6 +980,77 @@ fn load_direct_claude_owner_by_sdk_session_id_returns_direct_owner() {
 }
 
 #[test]
+fn session_create_persists_codex_config_columns_without_placeholder_drift() {
+  let (_conn, db_path, _dir, _guard) = setup_test_db();
+  let batch = vec![PersistCommand::SessionCreate(Box::new(
+    SessionCreateParams {
+      id: "codex-profile-session".to_string(),
+      provider: Provider::Codex,
+      control_mode: orbitdock_protocol::SessionControlMode::Direct,
+      project_path: "/tmp/test".to_string(),
+      project_name: Some("Test Project".to_string()),
+      branch: Some("main".to_string()),
+      model: Some("qwen/qwen3-coder-next".to_string()),
+      approval_policy: Some("on-request".to_string()),
+      sandbox_mode: Some("workspace-write".to_string()),
+      permission_mode: None,
+      collaboration_mode: Some("default".to_string()),
+      multi_agent: Some(true),
+      personality: Some("mentor".to_string()),
+      service_tier: Some("priority".to_string()),
+      developer_instructions: Some("Stay focused".to_string()),
+      codex_config_mode: Some(orbitdock_protocol::CodexConfigMode::Profile),
+      codex_config_profile: Some("qwen".to_string()),
+      codex_model_provider: Some("openrouter".to_string()),
+      codex_config_source: Some(orbitdock_protocol::CodexConfigSource::User),
+      codex_config_overrides_json: Some("{\"effort\":\"high\"}".to_string()),
+      forked_from_session_id: None,
+      mission_id: None,
+      issue_identifier: None,
+      allow_bypass_permissions: false,
+      worktree_id: None,
+    },
+  ))];
+  super::writer::flush_batch_for_test(&db_path, batch).unwrap();
+
+  struct PersistedCodexSessionRow {
+    codex_config_mode: Option<String>,
+    codex_config_profile: Option<String>,
+    codex_model_provider: Option<String>,
+    codex_config_overrides_json: Option<String>,
+    started_at: Option<String>,
+  }
+
+  let conn = Connection::open(&db_path).unwrap();
+  let row = conn
+    .query_row(
+      "SELECT codex_config_mode, codex_config_profile, codex_model_provider, codex_config_overrides_json, started_at
+       FROM sessions
+       WHERE id = 'codex-profile-session'",
+      [],
+      |row| {
+        Ok(PersistedCodexSessionRow {
+          codex_config_mode: row.get(0)?,
+          codex_config_profile: row.get(1)?,
+          codex_model_provider: row.get(2)?,
+          codex_config_overrides_json: row.get(3)?,
+          started_at: row.get(4)?,
+        })
+      },
+    )
+    .unwrap();
+
+  assert_eq!(row.codex_config_mode.as_deref(), Some("profile"));
+  assert_eq!(row.codex_config_profile.as_deref(), Some("qwen"));
+  assert_eq!(row.codex_model_provider.as_deref(), Some("openrouter"));
+  assert_eq!(
+    row.codex_config_overrides_json.as_deref(),
+    Some("{\"effort\":\"high\"}")
+  );
+  assert!(row.started_at.is_some());
+}
+
+#[test]
 fn startup_restore_ends_passive_claude_shadow_owned_by_direct_session() {
   let (conn, db_path, _dir, _guard) = setup_test_db();
 
@@ -930,9 +1086,14 @@ fn startup_restore_ends_passive_claude_shadow_owned_by_direct_session() {
     .enable_all()
     .build()
     .unwrap();
-  let _ = runtime
+  let restored = runtime
     .block_on(super::session_reads::load_sessions_for_startup())
     .unwrap();
+
+  assert!(
+    restored.into_iter().all(|session| session.id != sdk_id),
+    "startup restore should not surface passive Claude shadows owned by a direct session"
+  );
 
   let conn = Connection::open(&db_path).unwrap();
   let shadow: (String, String, String) = conn
@@ -946,6 +1107,199 @@ fn startup_restore_ends_passive_claude_shadow_owned_by_direct_session() {
   assert_eq!(shadow.0, "ended");
   assert_eq!(shadow.1, "ended");
   assert_eq!(shadow.2, "startup_direct_shadow");
+}
+
+#[test]
+fn claude_session_upsert_skips_new_shadow_when_direct_owner_exists() {
+  let (conn, db_path, _dir, _guard) = setup_test_db();
+
+  let direct_id = "od-direct-shadow-owner";
+  let sdk_id = "claude-sdk-shadow";
+
+  conn.execute(
+        "INSERT INTO sessions (
+            id, provider, status, work_status, lifecycle_state, control_mode,
+            project_path, claude_integration_mode, claude_sdk_session_id, started_at, last_activity_at
+         ) VALUES (
+            ?1, 'claude', 'ended', 'ended', 'ended', 'direct',
+            '/tmp/test', 'direct', ?2, '2026-03-26T10:00:00Z', '2026-03-26T10:10:00Z'
+         )",
+        [direct_id, sdk_id],
+    )
+    .unwrap();
+  drop(conn);
+
+  super::writer::flush_batch_for_test(
+    &db_path,
+    vec![PersistCommand::ClaudeSessionUpsert {
+      id: sdk_id.to_string(),
+      project_path: "/tmp/test".to_string(),
+      project_name: Some("Test Project".to_string()),
+      branch: Some("main".to_string()),
+      model: Some("claude-opus-4-6".to_string()),
+      context_label: None,
+      transcript_path: Some("/tmp/test/transcript.jsonl".to_string()),
+      source: Some("hook".to_string()),
+      agent_type: None,
+      permission_mode: Some("acceptEdits".to_string()),
+      terminal_session_id: None,
+      terminal_app: None,
+      forked_from_session_id: None,
+      repository_root: Some("/tmp/test".to_string()),
+      is_worktree: false,
+      git_sha: Some("abc123".to_string()),
+    }],
+  )
+  .unwrap();
+
+  let conn = Connection::open(&db_path).unwrap();
+  let shadow_count: i64 = conn
+    .query_row(
+      "SELECT COUNT(*) FROM sessions WHERE id = ?1",
+      [sdk_id],
+      |row| row.get(0),
+    )
+    .unwrap();
+
+  assert_eq!(shadow_count, 0);
+}
+
+#[test]
+fn claude_session_upsert_ends_existing_shadow_when_direct_owner_exists() {
+  let (conn, db_path, _dir, _guard) = setup_test_db();
+
+  let direct_id = "od-direct-shadow-owner";
+  let sdk_id = "claude-sdk-shadow";
+
+  conn.execute(
+        "INSERT INTO sessions (
+            id, provider, status, work_status, lifecycle_state, control_mode,
+            project_path, claude_integration_mode, claude_sdk_session_id, started_at, last_activity_at
+         ) VALUES (
+            ?1, 'claude', 'ended', 'ended', 'ended', 'direct',
+            '/tmp/test', 'direct', ?2, '2026-03-26T10:00:00Z', '2026-03-26T10:10:00Z'
+         )",
+        [direct_id, sdk_id],
+    )
+    .unwrap();
+  conn
+    .execute(
+      "INSERT INTO sessions (
+            id, provider, status, work_status, lifecycle_state, control_mode,
+            project_path, claude_integration_mode, started_at, last_activity_at
+         ) VALUES (
+            ?1, 'claude', 'active', 'working', 'open', 'passive',
+            '/tmp/test', 'passive', '2026-03-26T10:05:00Z', '2026-03-26T10:05:00Z'
+         )",
+      [sdk_id],
+    )
+    .unwrap();
+  drop(conn);
+
+  super::writer::flush_batch_for_test(
+    &db_path,
+    vec![PersistCommand::ClaudeSessionUpsert {
+      id: sdk_id.to_string(),
+      project_path: "/tmp/test".to_string(),
+      project_name: Some("Test Project".to_string()),
+      branch: Some("main".to_string()),
+      model: Some("claude-opus-4-6".to_string()),
+      context_label: None,
+      transcript_path: Some("/tmp/test/transcript.jsonl".to_string()),
+      source: Some("hook".to_string()),
+      agent_type: None,
+      permission_mode: Some("acceptEdits".to_string()),
+      terminal_session_id: None,
+      terminal_app: None,
+      forked_from_session_id: None,
+      repository_root: Some("/tmp/test".to_string()),
+      is_worktree: false,
+      git_sha: Some("abc123".to_string()),
+    }],
+  )
+  .unwrap();
+
+  let conn = Connection::open(&db_path).unwrap();
+  let shadow: (String, String, String) = conn
+    .query_row(
+      "SELECT status, work_status, COALESCE(end_reason, '') FROM sessions WHERE id = ?1",
+      [sdk_id],
+      |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+    )
+    .unwrap();
+
+  assert_eq!(shadow.0, "ended");
+  assert_eq!(shadow.1, "ended");
+  assert_eq!(shadow.2, "direct_owner_exists");
+}
+
+#[test]
+fn claude_session_update_preserves_ended_shadow_when_direct_owner_exists() {
+  let (conn, db_path, _dir, _guard) = setup_test_db();
+
+  let direct_id = "od-direct-shadow-owner";
+  let sdk_id = "claude-sdk-shadow";
+
+  conn.execute(
+        "INSERT INTO sessions (
+            id, provider, status, work_status, lifecycle_state, control_mode,
+            project_path, claude_integration_mode, claude_sdk_session_id, started_at, last_activity_at
+         ) VALUES (
+            ?1, 'claude', 'ended', 'ended', 'ended', 'direct',
+            '/tmp/test', 'direct', ?2, '2026-03-26T10:00:00Z', '2026-03-26T10:10:00Z'
+         )",
+        [direct_id, sdk_id],
+    )
+    .unwrap();
+  conn
+    .execute(
+      "INSERT INTO sessions (
+            id, provider, status, work_status, lifecycle_state, control_mode,
+            project_path, claude_integration_mode, started_at, ended_at, end_reason, last_activity_at
+         ) VALUES (
+            ?1, 'claude', 'ended', 'ended', 'ended', 'passive',
+            '/tmp/test', 'passive', '2026-03-26T10:05:00Z', '2026-03-26T10:06:00Z', 'startup_direct_shadow', '2026-03-26T10:06:00Z'
+         )",
+      [sdk_id],
+    )
+    .unwrap();
+  drop(conn);
+
+  super::writer::flush_batch_for_test(
+    &db_path,
+    vec![PersistCommand::ClaudeSessionUpdate {
+      id: sdk_id.to_string(),
+      work_status: Some("working".to_string()),
+      attention_reason: Some(Some("awaitingReply".to_string())),
+      last_tool: Some(Some("Bash".to_string())),
+      last_tool_at: Some(Some("2026-03-26T10:07:00Z".to_string())),
+      pending_tool_name: Some(Some("Bash".to_string())),
+      pending_tool_input: Some(Some("{\"command\":\"pwd\"}".to_string())),
+      pending_question: Some(Some("continue?".to_string())),
+      source: None,
+      agent_type: None,
+      permission_mode: None,
+      active_subagent_id: Some(Some("subagent-1".to_string())),
+      active_subagent_type: Some(Some("worker".to_string())),
+      first_prompt: Some("hello".to_string()),
+      compact_count_increment: true,
+    }],
+  )
+  .unwrap();
+
+  let conn = Connection::open(&db_path).unwrap();
+  let shadow: (String, String, String, String) = conn
+    .query_row(
+      "SELECT status, work_status, lifecycle_state, COALESCE(end_reason, '') FROM sessions WHERE id = ?1",
+      [sdk_id],
+      |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
+    )
+    .unwrap();
+
+  assert_eq!(shadow.0, "ended");
+  assert_eq!(shadow.1, "ended");
+  assert_eq!(shadow.2, "ended");
+  assert_eq!(shadow.3, "startup_direct_shadow");
 }
 
 // ── Mission-scoped tracker credentials ─────────────────────────────

--- a/orbitdock-server/crates/server/src/runtime/codex_config.rs
+++ b/orbitdock-server/crates/server/src/runtime/codex_config.rs
@@ -93,10 +93,12 @@ impl CodexConfigSelection {
       CodexConfigMode::Inherit => {
         self.config_profile = None;
         self.model_provider = None;
+        self.overrides.model = None;
         self.overrides.model_provider = None;
       }
       CodexConfigMode::Profile => {
         self.model_provider = None;
+        self.overrides.model = None;
         self.overrides.model_provider = None;
       }
       CodexConfigMode::Custom => {
@@ -1266,6 +1268,7 @@ mod tests {
       config_profile: Some("qwen".to_string()),
       model_provider: Some("openrouter".to_string()),
       overrides: CodexSessionOverrides {
+        model: Some("gpt-5.4".to_string()),
         model_provider: Some("openrouter".to_string()),
         ..CodexSessionOverrides::default()
       },
@@ -1274,6 +1277,7 @@ mod tests {
 
     assert_eq!(normalized.config_profile, None);
     assert_eq!(normalized.model_provider, None);
+    assert_eq!(normalized.overrides.model, None);
     assert_eq!(normalized.overrides.model_provider, None);
   }
 
@@ -1290,5 +1294,26 @@ mod tests {
 
     assert_eq!(normalized.config_profile, None);
     assert_eq!(normalized.model_provider.as_deref(), Some("openrouter"));
+  }
+
+  #[test]
+  fn normalized_selection_clears_stale_model_for_profile_mode() {
+    let normalized = CodexConfigSelection {
+      config_source: CodexConfigSource::User,
+      config_mode: CodexConfigMode::Profile,
+      config_profile: Some("qwen".to_string()),
+      model_provider: Some("openrouter".to_string()),
+      overrides: CodexSessionOverrides {
+        model: Some("gpt-5.4".to_string()),
+        model_provider: Some("openrouter".to_string()),
+        ..CodexSessionOverrides::default()
+      },
+    }
+    .normalized();
+
+    assert_eq!(normalized.config_profile.as_deref(), Some("qwen"));
+    assert_eq!(normalized.model_provider, None);
+    assert_eq!(normalized.overrides.model, None);
+    assert_eq!(normalized.overrides.model_provider, None);
   }
 }

--- a/orbitdock-server/crates/server/src/runtime/message_dispatch.rs
+++ b/orbitdock-server/crates/server/src/runtime/message_dispatch.rs
@@ -108,7 +108,14 @@ pub(crate) async fn dispatch_send_message(
   }
 
   let requested_effort = normalize_non_empty(effort.clone());
-  let plan = plan_send_message(provider, &content, model, effort);
+  let requested_model = model.clone();
+  let plan = plan_send_message(
+    provider,
+    snapshot.codex_config_mode,
+    &content,
+    model,
+    effort,
+  );
 
   let ts_millis = SystemTime::now()
     .duration_since(UNIX_EPOCH)
@@ -123,6 +130,21 @@ pub(crate) async fn dispatch_send_message(
   let connector_effort = plan.connector_effort.clone();
   let first_prompt = plan.first_prompt.clone();
   let session_effort_update = plan.session_effort_update.clone();
+
+  if provider == Provider::Codex
+    && requested_model.as_deref() != action_model.as_deref()
+    && requested_model.is_some()
+  {
+    info!(
+      component = "session",
+      event = "session.message.codex_model_override_ignored",
+      session_id = %session_id,
+      requested_model = ?requested_model,
+      effective_model = ?snapshot.model,
+      codex_config_mode = ?snapshot.codex_config_mode,
+      "Ignored per-turn Codex model override for a non-custom session"
+    );
+  }
 
   if let Some(tx) = codex_tx {
     if tx
@@ -662,7 +684,8 @@ mod tests {
   use tokio::sync::mpsc;
 
   use orbitdock_protocol::{
-    CodexIntegrationMode, Provider, SessionLifecycleState, SessionStatus, StateChanges, WorkStatus,
+    CodexConfigMode, CodexIntegrationMode, Provider, SessionLifecycleState, SessionStatus,
+    StateChanges, WorkStatus,
   };
 
   use crate::domain::sessions::session::SessionHandle;
@@ -717,5 +740,33 @@ mod tests {
     assert_eq!(snapshot.message_count, 0);
     assert_eq!(snapshot.first_prompt.as_deref(), None);
     assert!(state.get_codex_action_tx(session_id).is_none());
+  }
+
+  #[test]
+  fn plan_send_message_ignores_codex_model_override_for_profile_sessions() {
+    let plan = crate::runtime::message_dispatch_policy::plan_send_message(
+      Provider::Codex,
+      Some(CodexConfigMode::Profile),
+      "hello world",
+      Some("gpt-5.4".to_string()),
+      Some("high".to_string()),
+    );
+
+    assert_eq!(plan.action_model, None);
+    assert_eq!(plan.connector_effort.as_deref(), Some("high"));
+    assert_eq!(plan.session_effort_update.as_deref(), Some("high"));
+  }
+
+  #[test]
+  fn plan_send_message_keeps_codex_model_override_for_custom_sessions() {
+    let plan = crate::runtime::message_dispatch_policy::plan_send_message(
+      Provider::Codex,
+      Some(CodexConfigMode::Custom),
+      "hello world",
+      Some("qwen/qwen3-coder-next".to_string()),
+      Some("high".to_string()),
+    );
+
+    assert_eq!(plan.action_model.as_deref(), Some("qwen/qwen3-coder-next"));
   }
 }

--- a/orbitdock-server/crates/server/src/runtime/message_dispatch_policy.rs
+++ b/orbitdock-server/crates/server/src/runtime/message_dispatch_policy.rs
@@ -2,7 +2,7 @@ use orbitdock_protocol::conversation_contracts::rows::MessageDeliveryStatus;
 use orbitdock_protocol::conversation_contracts::{
   ConversationRow, ConversationRowEntry, MessageRowContent,
 };
-use orbitdock_protocol::{ImageInput, Provider};
+use orbitdock_protocol::{CodexConfigMode, ImageInput, Provider};
 
 use crate::domain::sessions::session_naming::name_from_first_prompt;
 use crate::support::normalization::{normalize_model_override, normalize_non_empty};
@@ -24,12 +24,19 @@ pub(crate) enum PromptRowKind {
 
 pub(crate) fn plan_send_message(
   provider: Provider,
+  codex_config_mode: Option<CodexConfigMode>,
   content: &str,
   model: Option<String>,
   effort: Option<String>,
 ) -> SendMessagePlan {
   let first_prompt = name_from_first_prompt(content);
-  let action_model = normalize_model_override(model);
+  let normalized_model = normalize_model_override(model);
+  let action_model =
+    if provider == Provider::Codex && codex_config_mode != Some(CodexConfigMode::Custom) {
+      None
+    } else {
+      normalized_model
+    };
   let normalized_effort = normalize_non_empty(effort);
   let (session_effort_update, connector_effort) = if provider == Provider::Claude {
     (None, None)

--- a/orbitdock-server/crates/server/src/runtime/session_mutations.rs
+++ b/orbitdock-server/crates/server/src/runtime/session_mutations.rs
@@ -262,7 +262,7 @@ pub(crate) async fn update_session_config(
       Some(resolved.effective_settings.effort.clone()),
       Some(Some(config_mode)),
       Some(config_profile),
-      Some(model_provider),
+      Some(resolved.effective_settings.model_provider.clone()),
       Some(source),
       Some(overrides),
     )

--- a/orbitdock-server/crates/server/src/runtime/session_resume.rs
+++ b/orbitdock-server/crates/server/src/runtime/session_resume.rs
@@ -145,6 +145,52 @@ struct ClaudeResumeParams {
   allow_bypass_permissions: bool,
 }
 
+fn codex_resume_selection(request: &CodexResumeRequest) -> CodexConfigSelection {
+  let inferred_config_mode = request.codex_config_mode.unwrap_or({
+    if request
+      .codex_config_profile
+      .as_deref()
+      .is_some_and(|value| !value.trim().is_empty())
+    {
+      CodexConfigMode::Profile
+    } else if request
+      .codex_model_provider
+      .as_deref()
+      .is_some_and(|value| !value.trim().is_empty())
+    {
+      CodexConfigMode::Custom
+    } else {
+      CodexConfigMode::Inherit
+    }
+  });
+
+  CodexConfigSelection {
+    config_source: request
+      .codex_config_source
+      .unwrap_or(CodexConfigSource::User),
+    config_mode: inferred_config_mode,
+    config_profile: request.codex_config_profile.clone(),
+    model_provider: request.codex_model_provider.clone(),
+    overrides: request
+      .codex_config_overrides
+      .clone()
+      .unwrap_or(CodexSessionOverrides {
+        model: request.model.clone(),
+        model_provider: request.codex_model_provider.clone(),
+        approval_policy: request.approval_policy.clone(),
+        approval_policy_details: None,
+        sandbox_mode: request.sandbox_mode.clone(),
+        collaboration_mode: request.collaboration_mode.clone(),
+        multi_agent: request.multi_agent,
+        personality: request.personality.clone(),
+        service_tier: request.service_tier.clone(),
+        developer_instructions: request.developer_instructions.clone(),
+        effort: None,
+      }),
+  }
+  .normalized()
+}
+
 async fn spawn_claude_resume(state: &Arc<SessionRegistry>, params: ClaudeResumeParams) {
   let ClaudeResumeParams {
     session_id,
@@ -270,25 +316,14 @@ async fn spawn_claude_resume(state: &Arc<SessionRegistry>, params: ClaudeResumeP
 }
 
 async fn spawn_codex_resume(state: &Arc<SessionRegistry>, request: CodexResumeRequest) {
+  let normalized_selection = codex_resume_selection(&request);
   let CodexResumeRequest {
     session_id,
     project_path,
-    model,
     codex_thread_id,
-    approval_policy,
-    sandbox_mode,
-    collaboration_mode,
-    multi_agent,
-    personality,
-    service_tier,
-    developer_instructions,
-    codex_config_mode,
-    codex_config_profile,
-    codex_model_provider,
-    codex_config_source,
-    codex_config_overrides,
     mut handle,
     message_count,
+    ..
   } = request;
   let session_id = session_id.to_string();
   let persist_tx = state.persist().clone();
@@ -296,60 +331,58 @@ async fn spawn_codex_resume(state: &Arc<SessionRegistry>, request: CodexResumeRe
 
   tokio::spawn(async move {
     let connector_timeout = Duration::from_secs(15);
-    let task_session_id = session_id.clone();
-    let mut connector_task = tokio::spawn(async move {
-      let fallback_overrides = CodexSessionOverrides {
-        model: model.clone(),
-        model_provider: codex_model_provider.clone(),
-        approval_policy: approval_policy.clone(),
-        approval_policy_details: None,
-        sandbox_mode: sandbox_mode.clone(),
-        collaboration_mode: collaboration_mode.clone(),
-        multi_agent,
-        personality: personality.clone(),
-        service_tier: service_tier.clone(),
-        developer_instructions: developer_instructions.clone(),
-        effort: None,
-      };
-      let resolved = resolve_codex_settings(
-        &project_path,
-        CodexConfigSelection {
-          config_source: codex_config_source.unwrap_or(CodexConfigSource::User),
-          config_mode: codex_config_mode.unwrap_or(CodexConfigMode::Inherit),
-          config_profile: codex_config_profile.clone(),
-          model_provider: codex_model_provider.clone(),
-          overrides: codex_config_overrides.unwrap_or(fallback_overrides),
-        },
-      )
+    let resolved = resolve_codex_settings(&project_path, normalized_selection.clone())
       .await
       .ok();
-      let effective = resolved
-        .as_ref()
-        .map(|resolved| &resolved.effective_settings);
+    let effective = resolved
+      .as_ref()
+      .map(|resolved| &resolved.effective_settings);
+    let effective_model = effective
+      .and_then(|value| value.model.clone())
+      .or_else(|| normalized_selection.overrides.model.clone());
+    let effective_approval = effective
+      .and_then(|value| value.approval_policy.clone())
+      .or_else(|| normalized_selection.overrides.approval_policy.clone());
+    let effective_sandbox = effective
+      .and_then(|value| value.sandbox_mode.clone())
+      .or_else(|| normalized_selection.overrides.sandbox_mode.clone());
+    let effective_collaboration_mode = effective
+      .and_then(|value| value.collaboration_mode.clone())
+      .or_else(|| normalized_selection.overrides.collaboration_mode.clone());
+    let effective_multi_agent = effective
+      .and_then(|value| value.multi_agent)
+      .or(normalized_selection.overrides.multi_agent);
+    let effective_personality = effective
+      .and_then(|value| value.personality.clone())
+      .or_else(|| normalized_selection.overrides.personality.clone());
+    let effective_service_tier = effective
+      .and_then(|value| value.service_tier.clone())
+      .or_else(|| normalized_selection.overrides.service_tier.clone());
+    let effective_developer_instructions = effective
+      .and_then(|value| value.developer_instructions.clone())
+      .or_else(|| {
+        normalized_selection
+          .overrides
+          .developer_instructions
+          .clone()
+      });
+    let effective_model_provider = effective
+      .and_then(|value| value.model_provider.clone())
+      .or_else(|| normalized_selection.model_provider.clone())
+      .or_else(|| normalized_selection.overrides.model_provider.clone());
+    let effective_config_profile = effective
+      .and_then(|value| value.config_profile.clone())
+      .or_else(|| normalized_selection.config_profile.clone());
+    let resumed_session_model = effective_model.clone();
+    let task_session_id = session_id.clone();
+    let mut connector_task = tokio::spawn(async move {
       let control_plane = orbitdock_connector_codex::CodexControlPlane {
-        collaboration_mode: effective
-          .and_then(|value| value.collaboration_mode.clone())
-          .or(collaboration_mode),
-        multi_agent: effective
-          .and_then(|value| value.multi_agent)
-          .or(multi_agent),
-        personality: effective
-          .and_then(|value| value.personality.clone())
-          .or(personality),
-        service_tier: effective
-          .and_then(|value| value.service_tier.clone())
-          .or(service_tier),
-        developer_instructions: effective
-          .and_then(|value| value.developer_instructions.clone())
-          .or(developer_instructions),
+        collaboration_mode: effective_collaboration_mode.clone(),
+        multi_agent: effective_multi_agent,
+        personality: effective_personality.clone(),
+        service_tier: effective_service_tier.clone(),
+        developer_instructions: effective_developer_instructions.clone(),
       };
-      let effective_model = effective.and_then(|value| value.model.clone()).or(model);
-      let effective_approval = effective
-        .and_then(|value| value.approval_policy.clone())
-        .or(approval_policy);
-      let effective_sandbox = effective
-        .and_then(|value| value.sandbox_mode.clone())
-        .or(sandbox_mode);
       let build_session_config = |cp: orbitdock_connector_codex::CodexControlPlane| {
         orbitdock_connector_codex::session::CodexSessionConfig {
           cwd: &project_path,
@@ -357,8 +390,8 @@ async fn spawn_codex_resume(state: &Arc<SessionRegistry>, request: CodexResumeRe
           approval_policy: effective_approval.as_deref(),
           sandbox_mode: effective_sandbox.as_deref(),
           config_overrides: orbitdock_connector_codex::CodexConfigOverrides {
-            model_provider: effective.and_then(|value| value.model_provider.clone()),
-            config_profile: effective.and_then(|value| value.config_profile.clone()),
+            model_provider: effective_model_provider.clone(),
+            config_profile: effective_config_profile.clone(),
           },
           control_plane: cp,
           dynamic_tools_json: Vec::new(),
@@ -396,6 +429,7 @@ async fn spawn_codex_resume(state: &Arc<SessionRegistry>, request: CodexResumeRe
 
     match codex_start {
       Ok(codex_session) => {
+        handle.set_model(resumed_session_model);
         let thread_id = codex_session.thread_id().to_string();
         claim_codex_thread_for_direct_session(
           &state,
@@ -460,4 +494,115 @@ struct CodexResumeRequest {
   codex_config_overrides: Option<CodexSessionOverrides>,
   handle: crate::domain::sessions::session::SessionHandle,
   message_count: usize,
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  fn codex_resume_request(
+    model: Option<&str>,
+    codex_config_mode: Option<CodexConfigMode>,
+    codex_config_profile: Option<&str>,
+    codex_model_provider: Option<&str>,
+  ) -> CodexResumeRequest {
+    CodexResumeRequest {
+      session_id: "session-1".to_string(),
+      project_path: "/tmp/project".to_string(),
+      model: model.map(str::to_string),
+      codex_thread_id: None,
+      approval_policy: None,
+      sandbox_mode: None,
+      collaboration_mode: None,
+      multi_agent: None,
+      personality: None,
+      service_tier: None,
+      developer_instructions: None,
+      codex_config_mode,
+      codex_config_profile: codex_config_profile.map(str::to_string),
+      codex_model_provider: codex_model_provider.map(str::to_string),
+      codex_config_source: Some(CodexConfigSource::User),
+      codex_config_overrides: None,
+      handle: crate::domain::sessions::session::SessionHandle::new(
+        "session-1".to_string(),
+        Provider::Codex,
+        "/tmp/project".to_string(),
+      ),
+      message_count: 0,
+    }
+  }
+
+  #[test]
+  fn codex_resume_selection_clears_stale_model_for_profile_mode() {
+    let request = codex_resume_request(
+      Some("gpt-5.4"),
+      Some(CodexConfigMode::Profile),
+      Some("qwen"),
+      Some("openrouter"),
+    );
+    let selection = codex_resume_selection(&request);
+
+    assert_eq!(selection.config_mode, CodexConfigMode::Profile);
+    assert_eq!(selection.config_profile.as_deref(), Some("qwen"));
+    assert_eq!(selection.overrides.model, None);
+    assert_eq!(selection.overrides.model_provider, None);
+  }
+
+  #[test]
+  fn codex_resume_selection_preserves_explicit_model_for_custom_mode() {
+    let request = codex_resume_request(
+      Some("qwen/qwen3-coder-next"),
+      Some(CodexConfigMode::Custom),
+      None,
+      Some("openrouter"),
+    );
+    let selection = codex_resume_selection(&request);
+
+    assert_eq!(selection.config_mode, CodexConfigMode::Custom);
+    assert_eq!(
+      selection.overrides.model.as_deref(),
+      Some("qwen/qwen3-coder-next")
+    );
+    assert_eq!(
+      selection.overrides.model_provider.as_deref(),
+      Some("openrouter")
+    );
+  }
+
+  #[test]
+  fn codex_resume_selection_infers_profile_mode_for_legacy_rows() {
+    let request = codex_resume_request(
+      Some("qwen/qwen3-coder-next"),
+      None,
+      Some("qwen"),
+      Some("openrouter"),
+    );
+    let selection = codex_resume_selection(&request);
+
+    assert_eq!(selection.config_mode, CodexConfigMode::Profile);
+    assert_eq!(selection.config_profile.as_deref(), Some("qwen"));
+    assert_eq!(selection.overrides.model, None);
+    assert_eq!(selection.overrides.model_provider, None);
+  }
+
+  #[test]
+  fn codex_resume_selection_infers_custom_mode_for_legacy_provider_rows() {
+    let request = codex_resume_request(
+      Some("qwen/qwen3-coder-next"),
+      None,
+      None,
+      Some("openrouter"),
+    );
+    let selection = codex_resume_selection(&request);
+
+    assert_eq!(selection.config_mode, CodexConfigMode::Custom);
+    assert_eq!(
+      selection.overrides.model.as_deref(),
+      Some("qwen/qwen3-coder-next")
+    );
+    assert_eq!(
+      selection.overrides.model_provider.as_deref(),
+      Some("openrouter")
+    );
+  }
 }

--- a/orbitdock-server/crates/server/src/transport/http/session_lifecycle.rs
+++ b/orbitdock-server/crates/server/src/transport/http/session_lifecycle.rs
@@ -32,7 +32,7 @@ use orbitdock_protocol::{
   CodexApprovalPolicy, CodexConfigMode, CodexConfigSource, CodexSessionOverrides, Provider,
   ServerMessage,
 };
-use tracing::error;
+use tracing::{error, info};
 
 fn resolve_developer_instructions(
   developer_instructions: Option<String>,
@@ -247,6 +247,54 @@ pub struct CreateSessionResponse {
   pub session: SessionSummary,
 }
 
+fn create_codex_selection(
+  body: &CreateSessionRequest,
+  developer_instructions: Option<String>,
+  codex_config_source: Option<CodexConfigSource>,
+) -> Option<CodexConfigSelection> {
+  if body.provider != Provider::Codex {
+    return None;
+  }
+
+  Some(CodexSessionOverrides {
+    model: body.model.clone(),
+    model_provider: body.codex_model_provider.clone(),
+    approval_policy: body.approval_policy.clone().or_else(|| {
+      body
+        .approval_policy_details
+        .as_ref()
+        .map(|details| details.legacy_summary())
+    }),
+    approval_policy_details: body.approval_policy_details.clone(),
+    sandbox_mode: body.sandbox_mode.clone(),
+    collaboration_mode: body.collaboration_mode.clone(),
+    multi_agent: body.multi_agent,
+    personality: body.personality.clone(),
+    service_tier: body.service_tier.clone(),
+    developer_instructions,
+    effort: body.effort.clone(),
+  })
+  .zip(codex_config_source)
+  .map(|(overrides, source)| {
+    CodexConfigSelection {
+      config_source: source,
+      config_mode: body.codex_config_mode.unwrap_or({
+        if body.codex_config_profile.is_some() {
+          CodexConfigMode::Profile
+        } else if body.codex_model_provider.is_some() {
+          CodexConfigMode::Custom
+        } else {
+          CodexConfigMode::Inherit
+        }
+      }),
+      config_profile: body.codex_config_profile.clone(),
+      model_provider: body.codex_model_provider.clone(),
+      overrides,
+    }
+    .normalized()
+  })
+}
+
 pub async fn create_session(
   State(state): State<Arc<SessionRegistry>>,
   Json(body): Json<CreateSessionRequest>,
@@ -262,55 +310,30 @@ pub async fn create_session(
   } else {
     None
   };
-  let codex_overrides = if body.provider == Provider::Codex {
-    Some(CodexSessionOverrides {
-      model: body.model.clone(),
-      model_provider: body.codex_model_provider.clone(),
-      approval_policy: body.approval_policy.clone().or_else(|| {
-        body
-          .approval_policy_details
-          .as_ref()
-          .map(|details| details.legacy_summary())
-      }),
-      approval_policy_details: body.approval_policy_details.clone(),
-      sandbox_mode: body.sandbox_mode.clone(),
-      collaboration_mode: body.collaboration_mode.clone(),
-      multi_agent: body.multi_agent,
-      personality: body.personality.clone(),
-      service_tier: body.service_tier.clone(),
-      developer_instructions: developer_instructions.clone(),
-      effort: body.effort.clone(),
-    })
-  } else {
-    None
-  };
-  let resolved_codex = if let (Provider::Codex, Some(source), Some(overrides)) =
-    (body.provider, codex_config_source, codex_overrides.clone())
-  {
-    let selection = CodexConfigSelection {
-      config_source: source,
-      config_mode: body.codex_config_mode.unwrap_or({
-        if body.codex_config_profile.is_some() {
-          CodexConfigMode::Profile
-        } else if body.codex_model_provider.is_some() {
-          CodexConfigMode::Custom
-        } else {
-          CodexConfigMode::Inherit
-        }
-      }),
-      config_profile: body.codex_config_profile.clone(),
-      model_provider: body.codex_model_provider.clone(),
-      overrides,
-    }
-    .normalized();
+  let normalized_codex_selection =
+    create_codex_selection(&body, developer_instructions.clone(), codex_config_source);
+  let resolved_codex = if let Some(selection) = normalized_codex_selection.clone() {
     Some(
-      resolve_codex_settings(&body.cwd, selection.clone())
+      resolve_codex_settings(&body.cwd, selection)
         .await
         .map_err(|error| unprocessable("invalid_codex_config", error))?,
     )
   } else {
     None
   };
+  if let Some(ref resolved) = resolved_codex {
+    info!(
+      component = "session",
+      event = "session.create.codex_config_resolved",
+      session_id = %session_id,
+      requested_model = ?body.model,
+      resolved_model = ?resolved.effective_settings.model,
+      codex_config_mode = ?resolved.effective_settings.config_mode,
+      codex_config_profile = ?resolved.effective_settings.config_profile,
+      codex_model_provider = ?resolved.effective_settings.model_provider,
+      "Resolved Codex session config before create"
+    );
+  }
   let prepared = prepare_persist_direct_session(
     &state,
     session_id.clone(),
@@ -320,48 +343,78 @@ pub async fn create_session(
       model: resolved_codex
         .as_ref()
         .and_then(|resolved| resolved.effective_settings.model.clone())
-        .or(body.model.clone()),
+        .or_else(|| {
+          normalized_codex_selection
+            .as_ref()
+            .and_then(|selection| selection.overrides.model.clone())
+        }),
       approval_policy: resolved_codex
         .as_ref()
         .and_then(|resolved| resolved.effective_settings.approval_policy.clone())
-        .or_else(|| body.approval_policy.clone())
         .or_else(|| {
-          body
-            .approval_policy_details
+          normalized_codex_selection
             .as_ref()
-            .map(|details| details.legacy_summary())
+            .and_then(|selection| selection.overrides.approval_policy.clone())
         }),
       sandbox_mode: resolved_codex
         .as_ref()
         .and_then(|resolved| resolved.effective_settings.sandbox_mode.clone())
-        .or(body.sandbox_mode.clone()),
+        .or_else(|| {
+          normalized_codex_selection
+            .as_ref()
+            .and_then(|selection| selection.overrides.sandbox_mode.clone())
+        }),
       permission_mode: body.permission_mode.clone(),
       allowed_tools: body.allowed_tools.clone(),
       disallowed_tools: body.disallowed_tools.clone(),
       effort: resolved_codex
         .as_ref()
         .and_then(|resolved| resolved.effective_settings.effort.clone())
-        .or(body.effort.clone()),
+        .or_else(|| {
+          normalized_codex_selection
+            .as_ref()
+            .and_then(|selection| selection.overrides.effort.clone())
+        }),
       collaboration_mode: resolved_codex
         .as_ref()
         .and_then(|resolved| resolved.effective_settings.collaboration_mode.clone())
-        .or(body.collaboration_mode.clone()),
+        .or_else(|| {
+          normalized_codex_selection
+            .as_ref()
+            .and_then(|selection| selection.overrides.collaboration_mode.clone())
+        }),
       multi_agent: resolved_codex
         .as_ref()
         .and_then(|resolved| resolved.effective_settings.multi_agent)
-        .or(body.multi_agent),
+        .or_else(|| {
+          normalized_codex_selection
+            .as_ref()
+            .and_then(|selection| selection.overrides.multi_agent)
+        }),
       personality: resolved_codex
         .as_ref()
         .and_then(|resolved| resolved.effective_settings.personality.clone())
-        .or(body.personality.clone()),
+        .or_else(|| {
+          normalized_codex_selection
+            .as_ref()
+            .and_then(|selection| selection.overrides.personality.clone())
+        }),
       service_tier: resolved_codex
         .as_ref()
         .and_then(|resolved| resolved.effective_settings.service_tier.clone())
-        .or(body.service_tier.clone()),
+        .or_else(|| {
+          normalized_codex_selection
+            .as_ref()
+            .and_then(|selection| selection.overrides.service_tier.clone())
+        }),
       developer_instructions: resolved_codex
         .as_ref()
         .and_then(|resolved| resolved.effective_settings.developer_instructions.clone())
-        .or(developer_instructions),
+        .or_else(|| {
+          normalized_codex_selection
+            .as_ref()
+            .and_then(|selection| selection.overrides.developer_instructions.clone())
+        }),
       mission_id: None,
       issue_identifier: None,
       worktree_id: None,
@@ -377,14 +430,13 @@ pub async fn create_session(
           _ => None,
         }
       }),
-      codex_model_provider: resolved_codex.as_ref().and_then(|resolved| {
-        match resolved.effective_settings.config_mode {
-          CodexConfigMode::Custom => resolved.effective_settings.model_provider.clone(),
-          _ => None,
-        }
-      }),
+      codex_model_provider: resolved_codex
+        .as_ref()
+        .and_then(|resolved| resolved.effective_settings.model_provider.clone()),
       codex_config_source,
-      codex_config_overrides: codex_overrides,
+      codex_config_overrides: normalized_codex_selection
+        .as_ref()
+        .map(|selection| selection.overrides.clone()),
     },
   )
   .await;
@@ -932,4 +984,86 @@ pub async fn fork_session_to_existing_worktree(
     }),
   )
   .await
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  fn codex_request(
+    codex_config_mode: Option<CodexConfigMode>,
+    codex_config_profile: Option<&str>,
+    model_provider: Option<&str>,
+    model: Option<&str>,
+  ) -> CreateSessionRequest {
+    CreateSessionRequest {
+      provider: Provider::Codex,
+      cwd: "/tmp/project".to_string(),
+      model: model.map(str::to_string),
+      approval_policy: None,
+      approval_policy_details: None,
+      sandbox_mode: None,
+      permission_mode: None,
+      allowed_tools: Vec::new(),
+      disallowed_tools: Vec::new(),
+      effort: None,
+      collaboration_mode: None,
+      multi_agent: None,
+      personality: None,
+      service_tier: None,
+      developer_instructions: None,
+      system_prompt: None,
+      append_system_prompt: None,
+      allow_bypass_permissions: false,
+      codex_config_mode,
+      codex_config_profile: codex_config_profile.map(str::to_string),
+      codex_model_provider: model_provider.map(str::to_string),
+      codex_config_source: Some(CodexConfigSource::User),
+    }
+  }
+
+  #[test]
+  fn create_codex_selection_clears_stale_model_for_profile_mode() {
+    let selection = create_codex_selection(
+      &codex_request(
+        Some(CodexConfigMode::Profile),
+        Some("qwen"),
+        Some("openrouter"),
+        Some("gpt-5.4"),
+      ),
+      None,
+      Some(CodexConfigSource::User),
+    )
+    .expect("selection should exist");
+
+    assert_eq!(selection.config_mode, CodexConfigMode::Profile);
+    assert_eq!(selection.config_profile.as_deref(), Some("qwen"));
+    assert_eq!(selection.overrides.model, None);
+    assert_eq!(selection.overrides.model_provider, None);
+  }
+
+  #[test]
+  fn create_codex_selection_preserves_explicit_model_for_custom_mode() {
+    let selection = create_codex_selection(
+      &codex_request(
+        Some(CodexConfigMode::Custom),
+        None,
+        Some("openrouter"),
+        Some("qwen/qwen3-coder-next"),
+      ),
+      None,
+      Some(CodexConfigSource::User),
+    )
+    .expect("selection should exist");
+
+    assert_eq!(selection.config_mode, CodexConfigMode::Custom);
+    assert_eq!(
+      selection.overrides.model.as_deref(),
+      Some("qwen/qwen3-coder-next")
+    );
+    assert_eq!(
+      selection.overrides.model_provider.as_deref(),
+      Some("openrouter")
+    );
+  }
 }

--- a/scripts/archive-macos-app-release.sh
+++ b/scripts/archive-macos-app-release.sh
@@ -47,7 +47,7 @@ XCODEBUILD_ARGS=(
   -configuration Release
   -destination 'generic/platform=macOS'
   -archivePath "$ARCHIVE_PATH"
-  CODE_SIGN_STYLE=Automatic
+  CODE_SIGN_STYLE=Manual
   CODE_SIGN_IDENTITY="Developer ID Application"
   DEVELOPMENT_TEAM="$MACOS_DEVELOPMENT_TEAM"
   SPARKLE_FEED_URL="$SPARKLE_FEED_URL"


### PR DESCRIPTION
## Summary
- keep Codex provider and model truth server-authoritative across create, resume, and send for profile-scoped sessions
- stop the native composer and new-session flows from inventing hidden Codex model overrides or falling back to generic model lists for scoped providers
- seed neutral synthetic metadata for external Codex models so OpenRouter/Qwen sessions route correctly without fallback warning noise or misleading identity prompts

## Validation
- make rust-ci
- xcodebuild -project OrbitDockNative/OrbitDock.xcodeproj -scheme "OrbitDock Unit Tests" -destination "platform=macOS" -derivedDataPath /tmp/orbitdock-derived -only-testing:OrbitDockTests/DirectSessionComposerActionPlannerTests -only-testing:OrbitDockTests/DirectSessionComposerExecutionPlannerTests -only-testing:OrbitDockTests/DirectSessionComposerProviderPlannerTests -only-testing:OrbitDockTests/NewSessionRequestPlannerTests test
- validated a live OrbitDock CLI send against a fresh OpenRouter/Qwen session (`od-a4eac35a-2928-46ba-9a18-17739564f72c`)