### PR TITLE
♻️ Align Daytona provider with sandbox and toolbox APIs

### DIFF
--- a/orbitdock-server/crates/server/src/infrastructure/daytona.rs
+++ b/orbitdock-server/crates/server/src/infrastructure/daytona.rs
@@ -1,12 +1,12 @@
-use std::collections::HashMap;
-
 use anyhow::{Context, Result};
+use reqwest::StatusCode;
 use serde::{Deserialize, Serialize};
 
 use crate::admin::normalize_client_server_url;
 use crate::infrastructure::persistence::load_config_value;
 
-const DEFAULT_DAYTONA_IMAGE: &str = "ghcr.io/daytonaio/workspace:latest";
+const DEFAULT_DAYTONA_IMAGE: &str = "daytonaio/sandbox:latest";
+const DEFAULT_SANDBOX_START_TIMEOUT_SECS: u64 = 60;
 
 #[derive(Debug, Clone, Default)]
 struct DaytonaConfigSourceValues {
@@ -14,6 +14,7 @@ struct DaytonaConfigSourceValues {
   api_key: Option<String>,
   public_url: Option<String>,
   image: Option<String>,
+  target: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -22,6 +23,7 @@ pub(crate) struct DaytonaConfig {
   pub api_key: String,
   pub server_public_url: String,
   pub image: String,
+  pub target: Option<String>,
 }
 
 impl DaytonaConfig {
@@ -32,12 +34,14 @@ impl DaytonaConfig {
         api_key: std::env::var("ORBITDOCK_DAYTONA_API_KEY").ok(),
         public_url: std::env::var("ORBITDOCK_PUBLIC_SERVER_URL").ok(),
         image: std::env::var("ORBITDOCK_DAYTONA_IMAGE").ok(),
+        target: std::env::var("ORBITDOCK_DAYTONA_TARGET").ok(),
       },
       DaytonaConfigSourceValues {
         api_url: load_config_value("daytona_api_url"),
         api_key: load_config_value("daytona_api_key"),
         public_url: load_config_value("public_server_url"),
         image: load_config_value("daytona_image"),
+        target: load_config_value("daytona_target"),
       },
     )
   }
@@ -70,47 +74,92 @@ impl DaytonaConfig {
       .map(|value| value.trim().to_string())
       .filter(|value| !value.is_empty())
       .unwrap_or_else(|| DEFAULT_DAYTONA_IMAGE.to_string());
+    let target = env
+      .target
+      .or(persisted.target)
+      .map(|value| value.trim().to_string())
+      .filter(|value| !value.is_empty());
 
     Ok(Self {
       api_url,
       api_key,
       server_public_url,
       image,
+      target,
     })
   }
 }
 
 #[derive(Debug, Clone)]
-pub(crate) struct DaytonaWorkspaceCreateRequest {
+pub(crate) struct DaytonaSandboxCreateRequest {
   pub name: String,
-  pub repository_url: String,
-  pub branch: String,
   pub image: String,
+  pub target: Option<String>,
+  pub cpu: Option<u32>,
+  pub memory_gib: Option<u32>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum DaytonaSandboxState {
+  Creating,
+  Restoring,
+  Destroyed,
+  Destroying,
+  Started,
+  Stopped,
+  Starting,
+  Stopping,
+  Error,
+  BuildFailed,
+  PendingBuild,
+  BuildingSnapshot,
+  Unknown,
+  PullingSnapshot,
+  Archived,
+  Archiving,
+  Resizing,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) struct DaytonaWorkspaceSummary {
+pub(crate) struct DaytonaSandbox {
   pub id: String,
   pub name: String,
+  pub state: DaytonaSandboxState,
+  pub toolbox_proxy_url: String,
 }
 
 #[derive(Debug, Clone)]
-pub(crate) struct DaytonaExecRequest {
-  pub command: Vec<String>,
-  pub env: HashMap<String, String>,
+pub(crate) struct DaytonaToolboxExecRequest {
+  pub command: String,
+  pub cwd: Option<String>,
+  pub timeout_secs: Option<u32>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) struct DaytonaExecResult {
+pub(crate) struct DaytonaToolboxExecResult {
   pub exit_code: i32,
-  pub stdout: String,
-  pub stderr: String,
+  pub result: String,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct DaytonaGitCloneRequest {
+  pub url: String,
+  pub path: String,
+  pub branch: Option<String>,
 }
 
 #[derive(Clone)]
 pub(crate) struct DaytonaClient {
   http: reqwest::Client,
   config: DaytonaConfig,
+}
+
+#[derive(Clone)]
+pub(crate) struct DaytonaToolboxClient {
+  http: reqwest::Client,
+  base_url: String,
+  api_key: String,
 }
 
 impl DaytonaClient {
@@ -127,84 +176,185 @@ impl DaytonaClient {
     &self.config
   }
 
-  pub(crate) async fn create_workspace(
+  pub(crate) async fn create_sandbox(
     &self,
-    request: &DaytonaWorkspaceCreateRequest,
-  ) -> Result<DaytonaWorkspaceSummary> {
-    let body = DaytonaCreateWorkspaceBody {
-      name: request.name.clone(),
-      repository_url: request.repository_url.clone(),
-      branch: request.branch.clone(),
-      image: request.image.clone(),
-    };
+    request: &DaytonaSandboxCreateRequest,
+  ) -> Result<DaytonaSandbox> {
     let response = self
       .http
-      .post(format!("{}/workspaces", self.config.api_url))
+      .post(format!("{}/sandbox", self.config.api_url))
       .bearer_auth(&self.config.api_key)
-      .json(&body)
-      .send()
-      .await
-      .context("create Daytona workspace")?;
-    let response = error_for_status(response, "create Daytona workspace")?;
-    let body: DaytonaWorkspaceResponse = response
-      .json()
-      .await
-      .context("decode Daytona workspace response")?;
-
-    Ok(DaytonaWorkspaceSummary {
-      id: body.id,
-      name: body.name,
-    })
-  }
-
-  pub(crate) async fn exec_in_workspace(
-    &self,
-    workspace_id: &str,
-    request: &DaytonaExecRequest,
-  ) -> Result<DaytonaExecResult> {
-    let response = self
-      .http
-      .post(format!(
-        "{}/workspaces/{workspace_id}/exec",
-        self.config.api_url
-      ))
-      .bearer_auth(&self.config.api_key)
-      .json(&DaytonaExecBody {
-        command: request.command.clone(),
-        env: request.env.clone(),
+      .json(&DaytonaCreateSandboxBody {
+        name: request.name.clone(),
+        target: request.target.clone(),
+        cpu: request.cpu,
+        memory: request.memory_gib,
+        auto_stop_interval: Some(0),
+        auto_delete_interval: Some(-1),
+        build_info: DaytonaBuildInfoBody {
+          dockerfile_content: format!("FROM {}", request.image),
+        },
       })
       .send()
       .await
-      .with_context(|| format!("exec Daytona workspace {workspace_id}"))?;
-    let response = error_for_status(response, "exec Daytona workspace")?;
-    let body: DaytonaExecResponse = response
+      .context("create Daytona sandbox")?;
+    let response = error_for_status(response, "create Daytona sandbox")?;
+    let body: DaytonaSandboxResponse = response
       .json()
       .await
-      .context("decode Daytona exec response")?;
-    Ok(DaytonaExecResult {
-      exit_code: body.exit_code,
-      stdout: body.stdout.unwrap_or_default(),
-      stderr: body.stderr.unwrap_or_default(),
-    })
+      .context("decode Daytona sandbox response")?;
+    body.into_sandbox()
   }
 
-  pub(crate) async fn delete_workspace(&self, workspace_id: &str) -> Result<()> {
+  pub(crate) async fn get_sandbox(&self, sandbox_id: &str) -> Result<Option<DaytonaSandbox>> {
     let response = self
       .http
-      .delete(format!("{}/workspaces/{workspace_id}", self.config.api_url))
+      .get(format!("{}/sandbox/{sandbox_id}", self.config.api_url))
       .bearer_auth(&self.config.api_key)
       .send()
       .await
-      .with_context(|| format!("delete Daytona workspace {workspace_id}"))?;
+      .with_context(|| format!("get Daytona sandbox {sandbox_id}"))?;
 
-    if response.status().is_success() || response.status() == reqwest::StatusCode::NOT_FOUND {
+    if response.status() == StatusCode::NOT_FOUND {
+      return Ok(None);
+    }
+
+    let response = error_for_status(response, "get Daytona sandbox")?;
+    let body: DaytonaSandboxResponse = response
+      .json()
+      .await
+      .context("decode Daytona sandbox lookup response")?;
+    Ok(Some(body.into_sandbox()?))
+  }
+
+  pub(crate) async fn wait_for_sandbox_started(&self, sandbox_id: &str) -> Result<DaytonaSandbox> {
+    let deadline = tokio::time::Instant::now()
+      + std::time::Duration::from_secs(DEFAULT_SANDBOX_START_TIMEOUT_SECS);
+
+    loop {
+      let Some(sandbox) = self.get_sandbox(sandbox_id).await? else {
+        return Err(anyhow::anyhow!(
+          "Daytona sandbox {sandbox_id} disappeared before startup completed"
+        ));
+      };
+
+      match sandbox.state {
+        DaytonaSandboxState::Started => return Ok(sandbox),
+        DaytonaSandboxState::Error | DaytonaSandboxState::BuildFailed => {
+          return Err(anyhow::anyhow!(
+            "Daytona sandbox {sandbox_id} entered {:?}",
+            sandbox.state
+          ));
+        }
+        DaytonaSandboxState::Destroyed | DaytonaSandboxState::Destroying => {
+          return Err(anyhow::anyhow!(
+            "Daytona sandbox {sandbox_id} was destroyed during startup"
+          ));
+        }
+        _ => {}
+      }
+
+      if tokio::time::Instant::now() >= deadline {
+        return Err(anyhow::anyhow!(
+          "Timed out waiting for Daytona sandbox {sandbox_id} to start"
+        ));
+      }
+
+      tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+    }
+  }
+
+  pub(crate) async fn delete_sandbox(&self, sandbox_id: &str) -> Result<()> {
+    let response = self
+      .http
+      .delete(format!("{}/sandbox/{sandbox_id}", self.config.api_url))
+      .bearer_auth(&self.config.api_key)
+      .send()
+      .await
+      .with_context(|| format!("delete Daytona sandbox {sandbox_id}"))?;
+
+    if response.status().is_success() || response.status() == StatusCode::NOT_FOUND {
       return Ok(());
     }
 
     Err(anyhow::anyhow!(
-      "delete Daytona workspace failed with HTTP {}",
+      "delete Daytona sandbox failed with HTTP {}",
       response.status().as_u16()
     ))
+  }
+
+  pub(crate) fn toolbox_client(&self, sandbox: &DaytonaSandbox) -> DaytonaToolboxClient {
+    DaytonaToolboxClient {
+      http: self.http.clone(),
+      base_url: format!(
+        "{}/{}",
+        sandbox.toolbox_proxy_url.trim_end_matches('/'),
+        sandbox.id
+      ),
+      api_key: self.config.api_key.clone(),
+    }
+  }
+}
+
+impl DaytonaToolboxClient {
+  pub(crate) async fn git_clone(&self, request: &DaytonaGitCloneRequest) -> Result<()> {
+    let response = self
+      .http
+      .post(format!("{}/git/clone", self.base_url))
+      .bearer_auth(&self.api_key)
+      .json(&DaytonaToolboxGitCloneBody {
+        url: request.url.clone(),
+        path: request.path.clone(),
+        branch: request.branch.clone(),
+      })
+      .send()
+      .await
+      .context("clone repository through Daytona toolbox")?;
+    let _ = error_for_status(response, "clone repository through Daytona toolbox")?;
+    Ok(())
+  }
+
+  pub(crate) async fn execute_command(
+    &self,
+    request: &DaytonaToolboxExecRequest,
+  ) -> Result<DaytonaToolboxExecResult> {
+    let response = self
+      .http
+      .post(format!("{}/process/execute", self.base_url))
+      .bearer_auth(&self.api_key)
+      .json(&DaytonaToolboxExecuteBody {
+        command: request.command.clone(),
+        cwd: request.cwd.clone(),
+        timeout: request.timeout_secs,
+      })
+      .send()
+      .await
+      .context("execute Daytona toolbox command")?;
+    let response = error_for_status(response, "execute Daytona toolbox command")?;
+    let body: DaytonaToolboxExecuteResponse = response
+      .json()
+      .await
+      .context("decode Daytona toolbox execute response")?;
+    Ok(DaytonaToolboxExecResult {
+      exit_code: body.exit_code,
+      result: body.result,
+    })
+  }
+
+  pub(crate) async fn get_work_dir(&self) -> Result<String> {
+    let response = self
+      .http
+      .get(format!("{}/work-dir", self.base_url))
+      .bearer_auth(&self.api_key)
+      .send()
+      .await
+      .context("load Daytona toolbox work dir")?;
+    let response = error_for_status(response, "load Daytona toolbox work dir")?;
+    let body: DaytonaToolboxDirResponse = response
+      .json()
+      .await
+      .context("decode Daytona toolbox work dir response")?;
+    Ok(body.dir)
   }
 }
 
@@ -221,38 +371,88 @@ fn error_for_status(response: reqwest::Response, context: &str) -> Result<reqwes
 }
 
 #[derive(Debug, Serialize)]
-struct DaytonaCreateWorkspaceBody {
+#[serde(rename_all = "camelCase")]
+struct DaytonaCreateSandboxBody {
   name: String,
-  repository_url: String,
-  branch: String,
-  image: String,
-}
-
-#[derive(Debug, Deserialize)]
-struct DaytonaWorkspaceResponse {
-  id: String,
-  name: String,
+  #[serde(skip_serializing_if = "Option::is_none")]
+  target: Option<String>,
+  #[serde(skip_serializing_if = "Option::is_none")]
+  cpu: Option<u32>,
+  #[serde(skip_serializing_if = "Option::is_none")]
+  memory: Option<u32>,
+  #[serde(skip_serializing_if = "Option::is_none")]
+  auto_stop_interval: Option<i32>,
+  #[serde(skip_serializing_if = "Option::is_none")]
+  auto_delete_interval: Option<i32>,
+  build_info: DaytonaBuildInfoBody,
 }
 
 #[derive(Debug, Serialize)]
-struct DaytonaExecBody {
-  command: Vec<String>,
-  env: HashMap<String, String>,
+#[serde(rename_all = "camelCase")]
+struct DaytonaBuildInfoBody {
+  dockerfile_content: String,
 }
 
 #[derive(Debug, Deserialize)]
-struct DaytonaExecResponse {
-  #[serde(default)]
+#[serde(rename_all = "camelCase")]
+struct DaytonaSandboxResponse {
+  id: String,
+  name: String,
+  state: DaytonaSandboxState,
+  toolbox_proxy_url: String,
+}
+
+impl DaytonaSandboxResponse {
+  fn into_sandbox(self) -> Result<DaytonaSandbox> {
+    if self.toolbox_proxy_url.trim().is_empty() {
+      return Err(anyhow::anyhow!(
+        "Daytona sandbox response did not include toolboxProxyUrl"
+      ));
+    }
+
+    Ok(DaytonaSandbox {
+      id: self.id,
+      name: self.name,
+      state: self.state,
+      toolbox_proxy_url: self.toolbox_proxy_url,
+    })
+  }
+}
+
+#[derive(Debug, Serialize)]
+struct DaytonaToolboxGitCloneBody {
+  url: String,
+  path: String,
+  #[serde(skip_serializing_if = "Option::is_none")]
+  branch: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct DaytonaToolboxExecuteBody {
+  command: String,
+  #[serde(skip_serializing_if = "Option::is_none")]
+  cwd: Option<String>,
+  #[serde(skip_serializing_if = "Option::is_none")]
+  timeout: Option<u32>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct DaytonaToolboxExecuteResponse {
   exit_code: i32,
-  #[serde(default)]
-  stdout: Option<String>,
-  #[serde(default)]
-  stderr: Option<String>,
+  result: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct DaytonaToolboxDirResponse {
+  dir: String,
 }
 
 #[cfg(test)]
 mod tests {
-  use super::{DaytonaConfig, DaytonaConfigSourceValues};
+  use super::{
+    DaytonaConfig, DaytonaConfigSourceValues, DaytonaSandboxResponse, DaytonaSandboxState,
+  };
 
   #[test]
   fn daytona_config_prefers_env_over_persisted_values() {
@@ -262,12 +462,14 @@ mod tests {
         api_key: Some("env-key".into()),
         public_url: Some("https://dock.example.com".into()),
         image: Some("custom-image".into()),
+        target: Some("us".into()),
       },
       DaytonaConfigSourceValues {
         api_url: Some("https://persisted.daytona.example".into()),
         api_key: Some("persisted-key".into()),
         public_url: Some("https://persisted-dock.example.com".into()),
         image: Some("persisted-image".into()),
+        target: Some("eu".into()),
       },
     )
     .expect("resolve config");
@@ -276,6 +478,7 @@ mod tests {
     assert_eq!(config.api_key, "env-key");
     assert_eq!(config.server_public_url, "https://dock.example.com");
     assert_eq!(config.image, "custom-image");
+    assert_eq!(config.target.as_deref(), Some("us"));
   }
 
   #[test]
@@ -287,5 +490,19 @@ mod tests {
     .expect_err("missing config should fail");
 
     assert!(error.to_string().contains("daytona_api_url"));
+  }
+
+  #[test]
+  fn sandbox_response_requires_toolbox_proxy_url() {
+    let error = DaytonaSandboxResponse {
+      id: "sandbox-1".into(),
+      name: "orbitdock".into(),
+      state: DaytonaSandboxState::Started,
+      toolbox_proxy_url: String::new(),
+    }
+    .into_sandbox()
+    .expect_err("missing toolbox url should fail");
+
+    assert!(error.to_string().contains("toolboxProxyUrl"));
   }
 }

--- a/orbitdock-server/crates/server/src/runtime/workspace_dispatch/daytona.rs
+++ b/orbitdock-server/crates/server/src/runtime/workspace_dispatch/daytona.rs
@@ -1,4 +1,3 @@
-use std::collections::HashMap;
 use std::sync::Arc;
 
 use anyhow::{Context, Result};
@@ -9,7 +8,8 @@ use serde_json::json;
 use crate::domain::git::repo::resolve_origin_url;
 use crate::infrastructure::auth_tokens;
 use crate::infrastructure::daytona::{
-  DaytonaClient, DaytonaConfig, DaytonaExecRequest, DaytonaWorkspaceCreateRequest,
+  DaytonaClient, DaytonaConfig, DaytonaGitCloneRequest, DaytonaSandboxCreateRequest,
+  DaytonaSandboxState, DaytonaToolboxClient, DaytonaToolboxExecRequest,
 };
 use crate::infrastructure::persistence::{
   insert_workspace_record, load_workspace_record, update_workspace_record, WorkspaceRecord,
@@ -35,24 +35,18 @@ impl DaytonaWorkspaceProvider {
 
   async fn exec_required_success(
     &self,
-    workspace_external_id: &str,
-    request: DaytonaExecRequest,
+    toolbox: &DaytonaToolboxClient,
+    request: DaytonaToolboxExecRequest,
     context: &str,
   ) -> Result<()> {
-    let result = self
-      .client
-      .exec_in_workspace(workspace_external_id, &request)
-      .await?;
+    let result = toolbox.execute_command(&request).await?;
     if result.exit_code == 0 {
       return Ok(());
     }
 
-    let stderr = result.stderr.trim();
-    let stdout = result.stdout.trim();
-    let detail = if !stderr.is_empty() {
-      stderr
-    } else if !stdout.is_empty() {
-      stdout
+    let output = result.result.trim();
+    let detail = if !output.is_empty() {
+      output
     } else {
       "no output"
     };
@@ -104,15 +98,16 @@ impl WorkspaceProvider for DaytonaWorkspaceProvider {
 
     let workspace = match self
       .client
-      .create_workspace(&DaytonaWorkspaceCreateRequest {
+      .create_sandbox(&DaytonaSandboxCreateRequest {
         name: format!("orbitdock-{}", req.issue.identifier.to_lowercase()),
-        repository_url: repo_url.clone(),
-        branch: branch_name.clone(),
         image: req
           .workspace_config
           .image
           .clone()
           .unwrap_or_else(|| self.client.config().image.clone()),
+        target: self.client.config().target.clone(),
+        cpu: req.workspace_config.resources.cpu,
+        memory_gib: parse_memory_gib(req.workspace_config.resources.memory.as_deref()),
       })
       .await
     {
@@ -120,10 +115,74 @@ impl WorkspaceProvider for DaytonaWorkspaceProvider {
       Err(error) => {
         let _ = mark_workspace_failed(req.registry.clone(), workspace_id.clone()).await;
         return Err(WorkspaceError::Failed(format!(
-          "Create Daytona workspace failed: {error}"
+          "Create Daytona sandbox failed: {error}"
         )));
       }
     };
+
+    let workspace = if workspace.state == DaytonaSandboxState::Started {
+      workspace
+    } else {
+      match self.client.wait_for_sandbox_started(&workspace.id).await {
+        Ok(workspace) => workspace,
+        Err(error) => {
+          let _ = self.client.delete_sandbox(&workspace.id).await;
+          let _ = mark_workspace_failed(req.registry.clone(), workspace_id.clone()).await;
+          return Err(WorkspaceError::Failed(format!(
+            "Wait for Daytona sandbox start failed: {error}"
+          )));
+        }
+      }
+    };
+
+    let toolbox = self.client.toolbox_client(&workspace);
+    let work_dir = match toolbox.get_work_dir().await {
+      Ok(path) => path,
+      Err(error) => {
+        let _ = self.client.delete_sandbox(&workspace.id).await;
+        let _ = mark_workspace_failed(req.registry.clone(), workspace_id.clone()).await;
+        return Err(WorkspaceError::Failed(format!(
+          "Resolve Daytona work dir failed: {error}"
+        )));
+      }
+    };
+    let repo_path = repo_checkout_path(&work_dir);
+
+    if let Err(error) = toolbox
+      .git_clone(&DaytonaGitCloneRequest {
+        url: repo_url.clone(),
+        path: repo_path.clone(),
+        branch: Some(branch_name.clone()),
+      })
+      .await
+    {
+      let _ = self.client.delete_sandbox(&workspace.id).await;
+      let _ = mark_workspace_failed(req.registry.clone(), workspace_id.clone()).await;
+      return Err(WorkspaceError::Failed(format!(
+        "Clone repository into Daytona sandbox failed: {error}"
+      )));
+    }
+
+    for setup_command in &req.workspace_config.setup_commands {
+      if let Err(error) = self
+        .exec_required_success(
+          &toolbox,
+          DaytonaToolboxExecRequest {
+            command: setup_command.clone(),
+            cwd: Some(repo_path.clone()),
+            timeout_secs: Some(600),
+          },
+          "run Daytona workspace setup command",
+        )
+        .await
+      {
+        let _ = self.client.delete_sandbox(&workspace.id).await;
+        let _ = mark_workspace_failed(req.registry.clone(), workspace_id.clone()).await;
+        return Err(WorkspaceError::Failed(format!(
+          "Workspace setup command failed: {error}"
+        )));
+      }
+    }
 
     let launch_plan = DaytonaLaunchPlan::build(
       self.client.config(),
@@ -131,6 +190,7 @@ impl WorkspaceProvider for DaytonaWorkspaceProvider {
       &workspace_id,
       &session_id,
       &sync_token.token,
+      &repo_path,
     )
     .map_err(|error| {
       WorkspaceError::Failed(format!("Build Daytona launch plan failed: {error}"))
@@ -138,13 +198,13 @@ impl WorkspaceProvider for DaytonaWorkspaceProvider {
 
     if let Err(error) = self
       .exec_required_success(
-        &workspace.id,
+        &toolbox,
         launch_plan.start_server_request(),
         "start remote OrbitDock",
       )
       .await
     {
-      let _ = self.client.delete_workspace(&workspace.id).await;
+      let _ = self.client.delete_sandbox(&workspace.id).await;
       let _ = mark_workspace_failed(req.registry.clone(), workspace_id.clone()).await;
       return Err(WorkspaceError::Failed(format!(
         "Start remote OrbitDock failed: {error}"
@@ -153,13 +213,13 @@ impl WorkspaceProvider for DaytonaWorkspaceProvider {
 
     if let Err(error) = self
       .exec_required_success(
-        &workspace.id,
+        &toolbox,
         launch_plan.wait_for_server_request(),
         "wait for managed OrbitDock health",
       )
       .await
     {
-      let _ = self.client.delete_workspace(&workspace.id).await;
+      let _ = self.client.delete_sandbox(&workspace.id).await;
       let _ = mark_workspace_failed(req.registry.clone(), workspace_id.clone()).await;
       return Err(WorkspaceError::Failed(format!(
         "Managed OrbitDock did not become healthy: {error}"
@@ -168,13 +228,13 @@ impl WorkspaceProvider for DaytonaWorkspaceProvider {
 
     if let Err(error) = self
       .exec_required_success(
-        &workspace.id,
+        &toolbox,
         launch_plan.start_session_request(),
         "start managed session",
       )
       .await
     {
-      let _ = self.client.delete_workspace(&workspace.id).await;
+      let _ = self.client.delete_sandbox(&workspace.id).await;
       let _ = mark_workspace_failed(req.registry.clone(), workspace_id.clone()).await;
       return Err(WorkspaceError::Failed(format!(
         "Managed session start failed: {error}"
@@ -187,7 +247,11 @@ impl WorkspaceProvider for DaytonaWorkspaceProvider {
         id: &workspace_id,
         external_id: Some(&workspace.id),
         status: "running",
-        connection_info: Some(&json!({ "daytona_workspace_name": workspace.name })),
+        connection_info: Some(&json!({
+          "daytona_sandbox_name": workspace.name,
+          "daytona_toolbox_proxy_url": workspace.toolbox_proxy_url,
+          "repo_path": repo_path,
+        })),
         ready: true,
         destroyed: false,
       },
@@ -205,6 +269,7 @@ struct DaytonaLaunchPlan {
   sync_url: String,
   sync_token: String,
   workspace_id: String,
+  repo_path: String,
 }
 
 impl DaytonaLaunchPlan {
@@ -214,6 +279,7 @@ impl DaytonaLaunchPlan {
     workspace_id: &str,
     session_id: &str,
     sync_token: &str,
+    repo_path: &str,
   ) -> Result<Self> {
     let resolved = req.agent_config.resolve_for_provider(&req.provider_str);
     let cli_ref = crate::domain::instructions::orbitdock_system_instructions();
@@ -227,7 +293,7 @@ impl DaytonaLaunchPlan {
     let request = json!({
       "session_id": session_id,
       "provider": req.provider_str,
-      "cwd": ".",
+      "cwd": repo_path,
       "model": resolved.model,
       "approval_policy": resolved.approval_policy,
       "sandbox_mode": resolved.sandbox_mode,
@@ -258,62 +324,73 @@ impl DaytonaLaunchPlan {
       sync_url: config.server_public_url.clone(),
       sync_token: sync_token.to_string(),
       workspace_id: workspace_id.to_string(),
+      repo_path: repo_path.to_string(),
     })
   }
 
-  fn start_server_request(&self) -> DaytonaExecRequest {
-    let mut env = HashMap::new();
-    env.insert("ORBITDOCK_SYNC_URL".into(), self.sync_url.clone());
-    env.insert("ORBITDOCK_SYNC_TOKEN".into(), self.sync_token.clone());
-    env.insert("ORBITDOCK_WORKSPACE_ID".into(), self.workspace_id.clone());
-
-    DaytonaExecRequest {
-      command: vec![
-        "sh".into(),
-        "-lc".into(),
-        "nohup orbitdock start --bind 127.0.0.1:4000 --allow-insecure-no-auth --managed --workspace-id \"$ORBITDOCK_WORKSPACE_ID\" --sync-url \"$ORBITDOCK_SYNC_URL\" --sync-token \"$ORBITDOCK_SYNC_TOKEN\" >/tmp/orbitdock-managed.log 2>&1 & echo $! >/tmp/orbitdock-managed.pid".into(),
-      ],
-      env,
+  fn start_server_request(&self) -> DaytonaToolboxExecRequest {
+    DaytonaToolboxExecRequest {
+      command: format!(
+        "nohup orbitdock start --bind 127.0.0.1:4000 --allow-insecure-no-auth --managed --workspace-id {} --sync-url {} --sync-token {} >/tmp/orbitdock-managed.log 2>&1 & echo $! >/tmp/orbitdock-managed.pid",
+        shell_quote(&self.workspace_id),
+        shell_quote(&self.sync_url),
+        shell_quote(&self.sync_token),
+      ),
+      cwd: Some(self.repo_path.clone()),
+      timeout_secs: Some(10),
     }
   }
 
-  fn wait_for_server_request(&self) -> DaytonaExecRequest {
-    DaytonaExecRequest {
-      command: vec![
-        "sh".into(),
-        "-lc".into(),
-        "for _ in $(seq 1 60); do curl -fsS http://127.0.0.1:4000/health >/dev/null && exit 0; sleep 1; done; exit 1".into(),
-      ],
-      env: HashMap::new(),
+  fn wait_for_server_request(&self) -> DaytonaToolboxExecRequest {
+    DaytonaToolboxExecRequest {
+      command: "for _ in $(seq 1 60); do curl -fsS http://127.0.0.1:4000/health >/dev/null && exit 0; sleep 1; done; exit 1".into(),
+      cwd: Some(self.repo_path.clone()),
+      timeout_secs: Some(70),
     }
   }
 
-  fn start_session_request(&self) -> DaytonaExecRequest {
-    let mut env = HashMap::new();
-    env.insert(
-      "ORBITDOCK_MANAGED_SESSION_REQUEST_B64".into(),
-      self.managed_request_base64.clone(),
-    );
-    DaytonaExecRequest {
-      command: vec![
-        "sh".into(),
-        "-lc".into(),
-        "orbitdock managed-session-start --server-url http://127.0.0.1:4000 --request-base64 \"$ORBITDOCK_MANAGED_SESSION_REQUEST_B64\"".into(),
-      ],
-      env,
+  fn start_session_request(&self) -> DaytonaToolboxExecRequest {
+    DaytonaToolboxExecRequest {
+      command: format!(
+        "orbitdock managed-session-start --server-url http://127.0.0.1:4000 --request-base64 {}",
+        shell_quote(&self.managed_request_base64),
+      ),
+      cwd: Some(self.repo_path.clone()),
+      timeout_secs: Some(30),
     }
   }
 
-  fn graceful_shutdown_request() -> DaytonaExecRequest {
-    DaytonaExecRequest {
-      command: vec![
-        "sh".into(),
-        "-lc".into(),
-        "if [ ! -f /tmp/orbitdock-managed.pid ]; then exit 0; fi; pid=$(cat /tmp/orbitdock-managed.pid); kill -INT \"$pid\" 2>/dev/null || true; for _ in $(seq 1 35); do kill -0 \"$pid\" 2>/dev/null || exit 0; sleep 1; done; exit 1".into(),
-      ],
-      env: HashMap::new(),
+  fn graceful_shutdown_request() -> DaytonaToolboxExecRequest {
+    DaytonaToolboxExecRequest {
+      command: "if [ ! -f /tmp/orbitdock-managed.pid ]; then exit 0; fi; pid=$(cat /tmp/orbitdock-managed.pid); kill -INT \"$pid\" 2>/dev/null || true; for _ in $(seq 1 35); do kill -0 \"$pid\" 2>/dev/null || exit 0; sleep 1; done; exit 1".into(),
+      cwd: None,
+      timeout_secs: Some(40),
     }
   }
+}
+
+fn repo_checkout_path(work_dir: &str) -> String {
+  format!("{}/orbitdock-repo", work_dir.trim_end_matches('/'))
+}
+
+fn parse_memory_gib(raw: Option<&str>) -> Option<u32> {
+  let raw = raw?.trim();
+  if raw.is_empty() {
+    return None;
+  }
+
+  let normalized = raw
+    .strip_suffix("Gi")
+    .or_else(|| raw.strip_suffix("GB"))
+    .or_else(|| raw.strip_suffix('G'))
+    .unwrap_or(raw)
+    .trim();
+
+  normalized.parse::<u32>().ok()
+}
+
+fn shell_quote(value: &str) -> String {
+  format!("'{}'", value.replace('\'', "'\"'\"'"))
 }
 
 async fn resolve_mission_issue_row_id(
@@ -458,21 +535,31 @@ pub(crate) async fn destroy_daytona_workspace(
 
   if let Some(external_id) = workspace.external_id.as_deref() {
     let client = DaytonaClient::new(DaytonaConfig::load()?)?;
-    let shutdown = client
-      .exec_in_workspace(external_id, &DaytonaLaunchPlan::graceful_shutdown_request())
-      .await?;
-    if shutdown.exit_code != 0 {
-      tracing::warn!(
-        component = "workspace_provider",
-        event = "daytona.shutdown.nonzero_exit",
-        workspace_id = %workspace.id,
-        external_id = %external_id,
-        exit_code = shutdown.exit_code,
-        stderr = %shutdown.stderr,
-        "Managed workspace shutdown did not exit cleanly before delete"
-      );
+    if let Some(sandbox) = client.get_sandbox(external_id).await? {
+      if matches!(
+        sandbox.state,
+        DaytonaSandboxState::Started
+          | DaytonaSandboxState::Starting
+          | DaytonaSandboxState::Stopping
+      ) {
+        let shutdown = client
+          .toolbox_client(&sandbox)
+          .execute_command(&DaytonaLaunchPlan::graceful_shutdown_request())
+          .await?;
+        if shutdown.exit_code != 0 {
+          tracing::warn!(
+            component = "workspace_provider",
+            event = "daytona.shutdown.nonzero_exit",
+            workspace_id = %workspace.id,
+            external_id = %external_id,
+            exit_code = shutdown.exit_code,
+            output = %shutdown.result,
+            "Managed workspace shutdown did not exit cleanly before delete"
+          );
+        }
+      }
     }
-    client.delete_workspace(external_id).await?;
+    client.delete_sandbox(external_id).await?;
   }
 
   update_workspace(
@@ -502,6 +589,7 @@ mod tests {
       api_key: "secret".into(),
       server_public_url: "https://dock.example.com".into(),
       image: "image:latest".into(),
+      target: None,
     };
     let request = DispatchRequest {
       repo_root: "/repo".into(),
@@ -526,13 +614,42 @@ mod tests {
       prompt: "Fix it".into(),
       registry: crate::support::test_support::new_test_session_registry(true),
     };
-    let plan = DaytonaLaunchPlan::build(&config, &request, "workspace-1", "session-1", "token-1")
-      .expect("build launch plan");
+    let plan = DaytonaLaunchPlan::build(
+      &config,
+      &request,
+      "workspace-1",
+      "session-1",
+      "token-1",
+      "/sandbox/orbitdock-repo",
+    )
+    .expect("build launch plan");
 
     assert!(plan.sync_url.contains("dock.example.com"));
     assert!(plan.managed_request_base64.len() > 10);
-    assert!(plan.start_server_request().command[2].contains("orbitdock start"));
-    assert!(plan.start_server_request().command[2].contains("orbitdock-managed.pid"));
-    assert!(plan.start_session_request().command[2].contains("managed-session-start"));
+    assert_eq!(
+      plan.start_server_request().cwd.as_deref(),
+      Some("/sandbox/orbitdock-repo")
+    );
+    assert!(plan
+      .start_server_request()
+      .command
+      .contains("orbitdock start"));
+    assert!(plan
+      .start_server_request()
+      .command
+      .contains("orbitdock-managed.pid"));
+    assert!(plan
+      .start_session_request()
+      .command
+      .contains("managed-session-start"));
+  }
+
+  #[test]
+  fn parse_memory_gib_accepts_common_gib_forms() {
+    assert_eq!(super::parse_memory_gib(Some("8Gi")), Some(8));
+    assert_eq!(super::parse_memory_gib(Some("16GB")), Some(16));
+    assert_eq!(super::parse_memory_gib(Some("4G")), Some(4));
+    assert_eq!(super::parse_memory_gib(Some("2")), Some(2));
+    assert_eq!(super::parse_memory_gib(Some("bad")), None);
   }
 }


### PR DESCRIPTION
## Summary
- replace the guessed Daytona workspace client with typed sandbox and toolbox clients
- provision a Daytona sandbox, wait for start, clone the repo through toolbox, and launch managed OrbitDock from the checked-out repo path
- preserve OrbitDock's generic remote workspace provider boundary while keeping Daytona-specific sandbox details inside the infrastructure adapter

## Verification
- make rust-check
- make rust-test
- make rust-ci

## Notes
This is code-ready and validated against Daytona's current upstream API and SDK source, but it still needs one real Daytona smoke test for full production confidence around auth, toolbox routing, and remote runtime assumptions.