### PR TITLE
♻️ Align macOS with the existing TestFlight app ID

### DIFF
--- a/OrbitDockNative/OrbitDock.xcodeproj/project.pbxproj
+++ b/OrbitDockNative/OrbitDock.xcodeproj/project.pbxproj
@@ -358,7 +358,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 4;
+				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = J658W2V76T;
 				ENABLE_PREVIEWS = YES;
 				ENABLE_USER_SCRIPT_SANDBOXING = YES;
@@ -380,7 +380,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.4.0;
+				MARKETING_VERSION = 0.7.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.stubbornmule-software.OrbitDock-iOS.dev";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -400,7 +400,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 4;
+				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = J658W2V76T;
 				ENABLE_PREVIEWS = YES;
 				ENABLE_USER_SCRIPT_SANDBOXING = YES;
@@ -422,7 +422,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.4.0;
+				MARKETING_VERSION = 0.7.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.stubbornmule-software.OrbitDock-iOS";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -621,7 +621,7 @@
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 4;
+				CURRENT_PROJECT_VERSION = 1;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = J658W2V76T;
 				ENABLE_APP_SANDBOX = YES;
@@ -632,12 +632,13 @@
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = OrbitDock/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = OrbitDock;
+				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.developer-tools";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 15.0;
-				MARKETING_VERSION = 0.4.0;
+				MARKETING_VERSION = 0.7.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.stubbornmule-software.OrbitDock-iOS.dev";
 				PRODUCT_NAME = OrbitDock;
 				REGISTER_APP_GROUPS = YES;
@@ -659,7 +660,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 4;
+				CURRENT_PROJECT_VERSION = 1;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = J658W2V76T;
 				ENABLE_APP_SANDBOX = YES;
@@ -670,12 +671,13 @@
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = OrbitDock/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = OrbitDock;
+				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.developer-tools";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 15.0;
-				MARKETING_VERSION = 0.4.0;
+				MARKETING_VERSION = 0.7.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.stubbornmule-software.OrbitDock-iOS";
 				PRODUCT_NAME = OrbitDock;
 				PROVISIONING_PROFILE_SPECIFIER = "";


### PR DESCRIPTION
## Why

We want the macOS app to join the same TestFlight/App Store Connect path as the existing iOS app, but we also do not want to strand the current beta users who are already on the `com.stubbornmule-software.OrbitDock-iOS` track.

So this is the pragmatic bridge.

Instead of doing the clean bundle ID migration right now and forcing a TestFlight reset, this change aligns the macOS target to the existing iOS app identity so both platforms can move through the current beta track together.

## Approach

This keeps the current TestFlight alive and avoids unnecessary churn for the people already using it.

It is intentionally not the final naming state. We are treating the current `...OrbitDock-iOS` identity as a temporary distribution constraint, not the long-term product shape.

The launch-day cleanup is captured separately in #177 so we can switch to the proper shared OrbitDock app identity at the right moment.

## Why This Matters

This lets us validate the unified distribution path now without mixing that work with a bigger App Store identity migration.

It keeps momentum high, preserves the existing testers, and gets us closer to shipping the sandboxed macOS client through the same channel people are already using.

## Validation

- `xcodebuild -project OrbitDockNative/OrbitDock.xcodeproj -scheme OrbitDock -destination 'platform=macOS' -derivedDataPath /tmp/orbitdock-derived build`
- `xcodebuild -project OrbitDockNative/OrbitDock.xcodeproj -scheme 'OrbitDock iOS' -destination 'generic/platform=iOS' -derivedDataPath /tmp/orbitdock-ios-derived build`
