### PR TITLE
⚠️ Clean up Swift 6 actor-isolation warnings in native client

### DIFF
--- a/OrbitDockNative/OrbitDock/Views/Conversation/Markdown/MarkdownSystemParser.swift
+++ b/OrbitDockNative/OrbitDock/Views/Conversation/Markdown/MarkdownSystemParser.swift
@@ -13,17 +13,17 @@ import os
 enum MarkdownSystemParser {
   // MARK: - Cache
 
-  private struct CacheKey: Hashable, Sendable {
+  private nonisolated struct CacheKey: Hashable, Sendable {
     let markdown: String
     let style: ContentStyle
   }
 
-  private struct CacheEntry: Sendable {
+  private nonisolated struct CacheEntry: Sendable {
     let blocks: [MarkdownBlock]
     var accessTick: UInt64
   }
 
-  private struct CacheState: Sendable {
+  private nonisolated struct CacheState: Sendable {
     var entries: [CacheKey: CacheEntry] = [:]
     var tick: UInt64 = 0
   }
@@ -31,11 +31,11 @@ enum MarkdownSystemParser {
   private static let cache = OSAllocatedUnfairLock(initialState: CacheState())
 
   #if os(iOS)
-    private static let maxCacheSize = 160
+    nonisolated private static let maxCacheSize = 160
   #else
-    private static let maxCacheSize = 500
+    nonisolated private static let maxCacheSize = 500
   #endif
-  private static let evictionBatchSize = 64
+  nonisolated private static let evictionBatchSize = 64
 
   /// Two-space gap between list marker and content (inlined from deleted MarkdownTypography).
   private static let listMarkerGap = "  "
@@ -517,7 +517,7 @@ enum MarkdownSystemParser {
 
   // MARK: - Cache Machinery
 
-  private static func evictIfNeeded(state: inout CacheState) {
+  nonisolated private static func evictIfNeeded(state: inout CacheState) {
     guard state.entries.count >= maxCacheSize else { return }
     let toEvict = min(evictionBatchSize, state.entries.count)
     guard toEvict > 0 else { return }

--- a/OrbitDockNative/OrbitDock/Views/Conversation/Markdown/MarkdownTypes.swift
+++ b/OrbitDockNative/OrbitDock/Views/Conversation/Markdown/MarkdownTypes.swift
@@ -40,7 +40,7 @@ enum ListMarker: Equatable {
   }
 }
 
-enum ContentStyle: Hashable {
+nonisolated enum ContentStyle: Hashable {
   case standard
   case thinking
 }

--- a/OrbitDockNative/OrbitDock/Views/Dashboard/Shared/ConversationProjectGroup.swift
+++ b/OrbitDockNative/OrbitDock/Views/Dashboard/Shared/ConversationProjectGroup.swift
@@ -95,7 +95,7 @@ enum ConversationProjectGroupBuilder {
     return ordered + unordered
   }
 
-  private static func alphabeticalSort(
+  nonisolated private static func alphabeticalSort(
     lhs: ConversationProjectGroup,
     rhs: ConversationProjectGroup
   ) -> Bool {


### PR DESCRIPTION
## Summary

Fixes the 13 Swift 6 actor-isolation warnings present in the native client build across `MarkdownSystemParser.swift` and `ConversationProjectGroup.swift`.

- **`MarkdownSystemParser.swift`** — Cache types (`CacheKey`, `CacheEntry`, `CacheState`), eviction constants (`maxCacheSize`, `evictionBatchSize`), and `evictIfNeeded` are now explicitly `nonisolated`. These all run inside `OSAllocatedUnfairLock.withLock` closures which are `@Sendable`/nonisolated — the implicit `@MainActor` isolation from the build setting was never intended for them.
- **`MarkdownTypes.swift`** — `ContentStyle` is now `nonisolated`. It's a pure data enum stored in `CacheKey` — its `Hashable` conformance must be nonisolated for dictionary operations inside the lock.
- **`ConversationProjectGroup.swift`** — `alphabeticalSort` is now `nonisolated`. It's a pure comparison function passed to `Array.sorted(by:)` which expects a `@Sendable` closure.

No `@unchecked Sendable`, `nonisolated(unsafe)`, or blanket `@MainActor` suppression.

## Test plan

- [x] macOS build: zero actor-isolation warnings (was 13)
- [x] iOS build: zero actor-isolation warnings
- [x] All existing tests pass

Closes #123