### PR TITLE
🧹 Add local OrbitDock install make targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,8 @@ RUST_WORKSPACE_DIR ?= orbitdock-server
 RUST_TARGET_DIR ?= $(abspath .cache/rust/target)
 RUST_LEGACY_TARGET_DIR ?= $(abspath $(RUST_WORKSPACE_DIR)/target)
 RUST_BIN_PACKAGE ?= orbitdock
+ORBITDOCK_INSTALL_ROOT ?= $(HOME)/.orbitdock
+ORBITDOCK_INSTALLED_BIN ?= $(ORBITDOCK_INSTALL_ROOT)/bin/orbitdock
 RUST_PATH_PREFIX ?= $(HOME)/.cargo/bin:/opt/homebrew/bin:/usr/local/bin
 RUST_PATH ?= $(RUST_PATH_PREFIX):$(PATH)
 RUST_HOST_TARGET ?= $(shell PATH="$(RUST_PATH_PREFIX):$$PATH" rustc -vV 2>/dev/null | sed -n 's/^host: //p')
@@ -186,6 +188,9 @@ help:
 	@echo "make rust-build Build Rust orbitdock binary"
 	@echo "make rust-build-release Build Rust orbitdock binary in release mode for the host platform"
 	@echo "make rust-build-darwin Build fresh macOS arm64 orbitdock binary"
+	@echo "make rust-install-local Build debug orbitdock and atomically install to ~/.orbitdock/bin"
+	@echo "make rust-install-local-release Build release orbitdock and atomically install to ~/.orbitdock/bin"
+	@echo "make rust-promote-local Build, install, and run orbitdock doctor against the installed binary"
 	@echo "make rust-check Run fast cargo check for the shipped Rust package graph"
 	@echo "make rust-check-workspace Run cargo check for the full Rust workspace"
 	@echo "make rust-test  Run Rust workspace tests"

--- a/make/rust.mk
+++ b/make/rust.mk
@@ -2,6 +2,7 @@
 	rust-env rust-lock-status rust-unlock rust-size \
 	rust-sccache-stats rust-sccache-zero \
 	rust-ci rust-build rust-build-release rust-build-darwin \
+	rust-install-local rust-install-local-release rust-promote-local \
 	rust-check rust-check-workspace rust-test rust-fmt rust-fmt-check rust-lint \
 	rust-run rust-run-lan rust-run-debug rust-generate-token cli \
 	rust-release-darwin rust-release-linux rust-release-linux-all rust-release-linux-x86_64 rust-release-linux-aarch64 \
@@ -117,6 +118,27 @@ rust-build-darwin: web-build
 	fi
 	@chmod +x "$(RUST_TARGET_DIR)/darwin-arm64/orbitdock"
 	@./scripts/server-source-fingerprint.sh > "$(RUST_TARGET_DIR)/darwin-arm64/orbitdock.gitsha"
+
+rust-install-local: rust-build
+	@set -euo pipefail; \
+	mkdir -p "$(ORBITDOCK_INSTALL_ROOT)/bin"; \
+	staged_bin="$$(mktemp "$(ORBITDOCK_INSTALL_ROOT)/bin/.orbitdock.XXXXXX")"; \
+	cp "$(RUST_TARGET_DIR)/debug/orbitdock" "$$staged_bin"; \
+	chmod 755 "$$staged_bin"; \
+	mv -f "$$staged_bin" "$(ORBITDOCK_INSTALLED_BIN)"; \
+	echo "Installed debug binary to $(ORBITDOCK_INSTALLED_BIN)"
+
+rust-install-local-release: rust-build-release
+	@set -euo pipefail; \
+	mkdir -p "$(ORBITDOCK_INSTALL_ROOT)/bin"; \
+	staged_bin="$$(mktemp "$(ORBITDOCK_INSTALL_ROOT)/bin/.orbitdock.XXXXXX")"; \
+	cp "$(RUST_TARGET_DIR)/release/orbitdock" "$$staged_bin"; \
+	chmod 755 "$$staged_bin"; \
+	mv -f "$$staged_bin" "$(ORBITDOCK_INSTALLED_BIN)"; \
+	echo "Installed release binary to $(ORBITDOCK_INSTALLED_BIN)"
+
+rust-promote-local: rust-install-local
+	@"$(ORBITDOCK_INSTALLED_BIN)" doctor
 
 rust-check:
 	$(RUST_CARGO) check -p $(RUST_BIN_PACKAGE)


### PR DESCRIPTION
## Summary
- add Make variables for the local OrbitDock install path
- add make targets to install debug and release binaries into ~/.orbitdock/bin
- add a promote target that runs doctor against the installed binary

## Verification
- make help
