### PR TITLE
✨ Redesign the control deck and Codex session controls

### DIFF
--- a/OrbitDockNative/OrbitDock/ContentView.swift
+++ b/OrbitDockNative/OrbitDock/ContentView.swift
@@ -122,7 +122,14 @@ struct ContentView: View {
     DashboardView(
       isInitialLoading: runtimeRegistry.runtimes
         .filter(\.endpoint.isEnabled)
-        .contains { !$0.connection.hasReceivedInitialDashboardSnapshot },
+        .contains { runtime in
+          switch runtime.connection.connectionStatus {
+            case .connecting, .connected:
+              !runtime.connection.hasReceivedInitialDashboardSnapshot
+            case .disconnected, .failed:
+              false
+          }
+        },
       isRefreshingCachedSessions: isAnyRefreshingCachedSessions
     )
   }

--- a/OrbitDockNative/OrbitDock/OrbitDockApp.swift
+++ b/OrbitDockNative/OrbitDock/OrbitDockApp.swift
@@ -53,6 +53,7 @@ struct OrbitDockApp: App {
 
       Settings {
         SettingsView()
+          .environment(appRuntime)
           .environment(appRuntime.runtimeRegistry.activeSessionStore)
           .environment(\.modelPricingService, modelPricingService)
           .environment(appRuntime.runtimeRegistry)

--- a/OrbitDockNative/OrbitDock/OrbitDockWindowRoot.swift
+++ b/OrbitDockNative/OrbitDock/OrbitDockWindowRoot.swift
@@ -24,7 +24,16 @@ struct OrbitDockWindowRoot: View {
       } else {
         NavigationStack(path: Binding(get: { router.navigationStack }, set: { router.navigationStack = $0 })) {
           DashboardView(
-            isInitialLoading: false,
+            isInitialLoading: appRuntime.runtimeRegistry.runtimes
+              .filter(\.endpoint.isEnabled)
+              .contains { runtime in
+                switch runtime.connection.connectionStatus {
+                  case .connecting, .connected:
+                    !runtime.connection.hasReceivedInitialDashboardSnapshot
+                  case .disconnected, .failed:
+                    false
+                }
+              },
             isRefreshingCachedSessions: false
           )
           .navigationDestination(for: AppNavDestination.self) { destination in

--- a/OrbitDockNative/OrbitDock/Platform/PlatformViewModifiers.swift
+++ b/OrbitDockNative/OrbitDock/Platform/PlatformViewModifiers.swift
@@ -74,6 +74,19 @@ extension View {
 // MARK: - Generic Platform Conditionals
 
 extension View {
+  /// Apply a modifier chain conditionally; identity when the condition is false.
+  @ViewBuilder
+  func `if`<Transformed: View>(
+    _ condition: Bool,
+    transform: (Self) -> Transformed
+  ) -> some View {
+    if condition {
+      transform(self)
+    } else {
+      self
+    }
+  }
+
   /// Apply a modifier chain only on macOS; identity on iOS.
   /// The closure must use APIs available on both platforms (most SwiftUI modifiers are).
   @ViewBuilder

--- a/OrbitDockNative/OrbitDock/PreviewRuntime.swift
+++ b/OrbitDockNative/OrbitDock/PreviewRuntime.swift
@@ -20,6 +20,7 @@ struct PreviewRuntime {
   let notificationCoordinator: NotificationCoordinator
   let appStore: AppStore
   let externalNavigationCenter: AppExternalNavigationCenter
+  let appRuntime: OrbitDockAppRuntime
 
   init(scenario: Scenario = .dashboard) {
     let endpoint = Self.previewEndpoint()
@@ -99,10 +100,12 @@ struct PreviewRuntime {
     self.externalNavigationCenter = AppExternalNavigationCenter()
     self.appStore = AppStore(runtimeRegistry: runtimeRegistry)
     self.appStore.router = router
+    self.appRuntime = OrbitDockAppRuntime()
   }
 
   func inject(_ content: some View) -> some View {
     content
+      .environment(appRuntime)
       .environment(sessionStore)
       .environment(runtimeRegistry)
       .environment(usageServiceRegistry)

--- a/OrbitDockNative/OrbitDock/Services/Server/API/ControlDeckClient.swift
+++ b/OrbitDockNative/OrbitDock/Services/Server/API/ControlDeckClient.swift
@@ -1,0 +1,89 @@
+import Foundation
+
+struct ControlDeckClient: Sendable {
+  struct SubmitTurnResponse: Decodable {
+    let accepted: Bool
+    let row: ServerConversationRowEntry
+  }
+
+  private let http: ServerHTTPClient
+  private let requestBuilder: HTTPRequestBuilder
+
+  init(http: ServerHTTPClient, requestBuilder: HTTPRequestBuilder) {
+    self.http = http
+    self.requestBuilder = requestBuilder
+  }
+
+  func fetchSnapshot(_ sessionId: String) async throws -> ServerControlDeckSnapshotPayload {
+    try await http.get(
+      "/api/sessions/\(requestBuilder.encodePathComponent(sessionId))/control-deck"
+    )
+  }
+
+  func updateConfig(
+    _ sessionId: String,
+    request: ServerControlDeckConfigUpdateRequest
+  ) async throws -> ServerControlDeckSnapshotPayload {
+    try await http.request(
+      path: "/api/sessions/\(requestBuilder.encodePathComponent(sessionId))/control-deck",
+      method: "PATCH",
+      body: request
+    )
+  }
+
+  func fetchPreferences() async throws -> ServerControlDeckPreferences {
+    try await http.get("/api/control-deck/preferences")
+  }
+
+  func updatePreferences(_ request: ServerControlDeckPreferences) async throws -> ServerControlDeckPreferences {
+    try await http.request(
+      path: "/api/control-deck/preferences",
+      method: "PUT",
+      body: request
+    )
+  }
+
+  struct ImageAttachmentUploadResponse: Decodable {
+    let attachment: ServerControlDeckImageAttachmentRef
+
+    enum CodingKeys: String, CodingKey {
+      case attachment
+    }
+  }
+
+  func uploadImageAttachment(
+    sessionId: String,
+    data: Data,
+    mimeType: String,
+    displayName: String,
+    pixelWidth: Int?,
+    pixelHeight: Int?
+  ) async throws -> ServerControlDeckImageAttachmentRef {
+    var query = [URLQueryItem(name: "display_name", value: displayName)]
+    if let pixelWidth {
+      query.append(URLQueryItem(name: "pixel_width", value: "\(pixelWidth)"))
+    }
+    if let pixelHeight {
+      query.append(URLQueryItem(name: "pixel_height", value: "\(pixelHeight)"))
+    }
+
+    let response: ImageAttachmentUploadResponse = try await http.requestRaw(
+      path: "/api/sessions/\(requestBuilder.encodePathComponent(sessionId))/control-deck/attachments/images",
+      method: "POST",
+      bodyData: data,
+      contentType: mimeType,
+      query: query
+    )
+    return response.attachment
+  }
+
+  func submitTurn(
+    _ sessionId: String,
+    request: ServerControlDeckSubmitTurnRequest
+  ) async throws -> SubmitTurnResponse {
+    try await http.post(
+      "/api/sessions/\(requestBuilder.encodePathComponent(sessionId))/control-deck/submit",
+      body: request
+    )
+  }
+}

--- a/OrbitDockNative/OrbitDock/Services/Server/API/SessionsClient.swift
+++ b/OrbitDockNative/OrbitDock/Services/Server/API/SessionsClient.swift
@@ -449,6 +449,8 @@ struct SessionsClient: Sendable {
     var personality: String?
     var serviceTier: String?
     var developerInstructions: String?
+    var model: String?
+    var effort: String?
   }
 
   struct UpdateCodexSessionOverridesRequest: Encodable {
@@ -550,10 +552,10 @@ struct SessionsClient: Sendable {
     try await http.post("/api/codex/config/inspect", body: request)
   }
 
-  func fetchCodexConfigCatalog(cwd: String) async throws -> CodexConfigCatalogResponse {
+  func fetchCodexConfigCatalog(cwd: String?) async throws -> CodexConfigCatalogResponse {
     try await http.get(
       "/api/codex/config/catalog",
-      query: [URLQueryItem(name: "cwd", value: cwd)]
+      query: cwd.map { [URLQueryItem(name: "cwd", value: $0)] } ?? []
     )
   }
 

--- a/OrbitDockNative/OrbitDock/Services/Server/Protocol/ControlDeckContracts.swift
+++ b/OrbitDockNative/OrbitDock/Services/Server/Protocol/ControlDeckContracts.swift
@@ -1,0 +1,299 @@
+import Foundation
+
+enum ServerControlDeckDensity: String, Codable, Sendable {
+  case comfortable
+  case compact
+}
+
+enum ServerControlDeckEmptyVisibility: String, Codable, Sendable {
+  case auto
+  case always
+  case hidden
+}
+
+enum ServerControlDeckModule: String, Codable, Sendable {
+  case connection
+  case autonomy
+  case approvalMode = "approval_mode"
+  case collaborationMode = "collaboration_mode"
+  case autoReview = "auto_review"
+  case tokens
+  case model
+  case effort
+  case branch
+  case cwd
+  case attachments
+}
+
+struct ServerControlDeckModulePreference: Codable, Sendable {
+  let module: ServerControlDeckModule
+  let visible: Bool
+}
+
+struct ServerControlDeckPreferences: Codable, Sendable {
+  let density: ServerControlDeckDensity
+  let showWhenEmpty: ServerControlDeckEmptyVisibility
+  let modules: [ServerControlDeckModulePreference]
+
+  enum CodingKeys: String, CodingKey {
+    case density
+    case showWhenEmpty = "show_when_empty"
+    case modules
+  }
+}
+
+struct ServerControlDeckConfigState: Codable, Sendable {
+  let model: String?
+  let effort: String?
+  let approvalPolicy: String?
+  let approvalPolicyDetails: ServerCodexApprovalPolicy?
+  let sandboxMode: String?
+  let approvalsReviewer: ServerCodexApprovalsReviewer?
+  let permissionMode: String?
+  let collaborationMode: String?
+  let developerInstructions: String?
+  let codexConfigMode: ServerCodexConfigMode?
+  let codexConfigProfile: String?
+  let codexModelProvider: String?
+
+  enum CodingKeys: String, CodingKey {
+    case model
+    case effort
+    case approvalPolicy = "approval_policy"
+    case approvalPolicyDetails = "approval_policy_details"
+    case sandboxMode = "sandbox_mode"
+    case approvalsReviewer = "approvals_reviewer"
+    case permissionMode = "permission_mode"
+    case collaborationMode = "collaboration_mode"
+    case developerInstructions = "developer_instructions"
+    case codexConfigMode = "codex_config_mode"
+    case codexConfigProfile = "codex_config_profile"
+    case codexModelProvider = "codex_model_provider"
+  }
+}
+
+struct ServerControlDeckState: Codable, Sendable {
+  let provider: ServerProvider
+  let controlMode: ServerSessionControlMode
+  let lifecycleState: ServerSessionLifecycleState
+  let acceptsUserInput: Bool
+  let steerable: Bool
+  let projectPath: String
+  let currentCwd: String?
+  let gitBranch: String?
+  let config: ServerControlDeckConfigState
+
+  enum CodingKeys: String, CodingKey {
+    case provider
+    case controlMode = "control_mode"
+    case lifecycleState = "lifecycle_state"
+    case acceptsUserInput = "accepts_user_input"
+    case steerable
+    case projectPath = "project_path"
+    case currentCwd = "current_cwd"
+    case gitBranch = "git_branch"
+    case config
+  }
+}
+
+struct ServerControlDeckCapabilities: Codable, Sendable {
+  let supportsSkills: Bool
+  let supportsMentions: Bool
+  let supportsImages: Bool
+  let supportsSteer: Bool
+  let allowPerTurnModelOverride: Bool
+  let allowPerTurnEffortOverride: Bool
+  let approvalModeOptions: [ServerControlDeckPickerOption]
+  let permissionModeOptions: [ServerControlDeckPickerOption]
+  let collaborationModeOptions: [ServerControlDeckPickerOption]
+  let autoReviewOptions: [ServerControlDeckAutoReviewOption]
+  let availableStatusModules: [ServerControlDeckModule]
+
+  enum CodingKeys: String, CodingKey {
+    case supportsSkills = "supports_skills"
+    case supportsMentions = "supports_mentions"
+    case supportsImages = "supports_images"
+    case supportsSteer = "supports_steer"
+    case allowPerTurnModelOverride = "allow_per_turn_model_override"
+    case allowPerTurnEffortOverride = "allow_per_turn_effort_override"
+    case approvalModeOptions = "approval_mode_options"
+    case permissionModeOptions = "permission_mode_options"
+    case collaborationModeOptions = "collaboration_mode_options"
+    case autoReviewOptions = "auto_review_options"
+    case availableStatusModules = "available_status_modules"
+  }
+}
+
+struct ServerControlDeckPickerOption: Codable, Sendable {
+  let value: String
+  let label: String
+}
+
+struct ServerControlDeckAutoReviewOption: Codable, Sendable {
+  let value: String
+  let label: String
+  let approvalPolicy: String?
+  let sandboxMode: String?
+
+  enum CodingKeys: String, CodingKey {
+    case value
+    case label
+    case approvalPolicy = "approval_policy"
+    case sandboxMode = "sandbox_mode"
+  }
+}
+
+enum ServerControlDeckTokenStatusTone: String, Codable, Sendable {
+  case muted
+  case normal
+  case caution
+  case critical
+}
+
+struct ServerControlDeckTokenStatus: Codable, Sendable {
+  let label: String
+  let tone: ServerControlDeckTokenStatusTone
+}
+
+struct ServerControlDeckSnapshotPayload: Codable, Sendable {
+  let revision: UInt64
+  let sessionId: String
+  let state: ServerControlDeckState
+  let capabilities: ServerControlDeckCapabilities
+  let preferences: ServerControlDeckPreferences
+  let tokenUsage: ServerTokenUsage
+  let tokenUsageSnapshotKind: ServerTokenUsageSnapshotKind
+  let tokenStatus: ServerControlDeckTokenStatus
+
+  enum CodingKeys: String, CodingKey {
+    case revision
+    case sessionId = "session_id"
+    case state
+    case capabilities
+    case preferences
+    case tokenUsage = "token_usage"
+    case tokenUsageSnapshotKind = "token_usage_snapshot_kind"
+    case tokenStatus = "token_status"
+  }
+}
+
+struct ServerControlDeckConfigUpdateRequest: Codable, Sendable {
+  var model: String?
+  var effort: String?
+  var approvalPolicy: String?
+  var approvalPolicyDetails: ServerCodexApprovalPolicy?
+  var sandboxMode: String?
+  var approvalsReviewer: ServerCodexApprovalsReviewer?
+  var permissionMode: String?
+  var collaborationMode: String?
+
+  enum CodingKeys: String, CodingKey {
+    case model
+    case effort
+    case approvalPolicy = "approval_policy"
+    case approvalPolicyDetails = "approval_policy_details"
+    case sandboxMode = "sandbox_mode"
+    case approvalsReviewer = "approvals_reviewer"
+    case permissionMode = "permission_mode"
+    case collaborationMode = "collaboration_mode"
+  }
+}
+
+enum ServerControlDeckMentionKind: String, Codable, Sendable {
+  case file
+  case mcpResource = "mcp_resource"
+  case url
+  case symbol
+  case generic
+}
+
+struct ServerControlDeckMentionRef: Codable, Sendable {
+  let mentionId: String?
+  let kind: ServerControlDeckMentionKind
+  let name: String
+  let path: String
+  let relativePath: String?
+
+  enum CodingKeys: String, CodingKey {
+    case mentionId = "mention_id"
+    case kind
+    case name
+    case path
+    case relativePath = "relative_path"
+  }
+}
+
+struct ServerControlDeckImageAttachmentRef: Codable, Sendable {
+  let attachmentId: String
+  let displayName: String?
+
+  enum CodingKeys: String, CodingKey {
+    case attachmentId = "attachment_id"
+    case displayName = "display_name"
+  }
+}
+
+enum ServerControlDeckAttachmentRef: Codable, Sendable {
+  case mention(ServerControlDeckMentionRef)
+  case image(ServerControlDeckImageAttachmentRef)
+
+  private enum CodingKeys: String, CodingKey {
+    case type
+    case mentionId = "mention_id"
+    case kind
+    case name
+    case path
+    case relativePath = "relative_path"
+    case attachmentId = "attachment_id"
+    case displayName = "display_name"
+  }
+
+  private enum AttachmentType: String, Codable {
+    case mention
+    case image
+  }
+
+  init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    switch try container.decode(AttachmentType.self, forKey: .type) {
+      case .mention:
+        self = try .mention(ServerControlDeckMentionRef(from: decoder))
+      case .image:
+        self = try .image(ServerControlDeckImageAttachmentRef(from: decoder))
+    }
+  }
+
+  func encode(to encoder: Encoder) throws {
+    var container = encoder.container(keyedBy: CodingKeys.self)
+    switch self {
+      case let .mention(value):
+        try container.encode(AttachmentType.mention, forKey: .type)
+        try container.encodeIfPresent(value.mentionId, forKey: .mentionId)
+        try container.encode(value.kind, forKey: .kind)
+        try container.encode(value.name, forKey: .name)
+        try container.encode(value.path, forKey: .path)
+        try container.encodeIfPresent(value.relativePath, forKey: .relativePath)
+      case let .image(value):
+        try container.encode(AttachmentType.image, forKey: .type)
+        try container.encode(value.attachmentId, forKey: .attachmentId)
+        try container.encodeIfPresent(value.displayName, forKey: .displayName)
+    }
+  }
+}
+
+struct ServerControlDeckSkillRef: Codable, Sendable {
+  let name: String
+  let path: String
+}
+
+struct ServerControlDeckTurnOverrides: Codable, Sendable {
+  let model: String?
+  let effort: String?
+}
+
+struct ServerControlDeckSubmitTurnRequest: Codable, Sendable {
+  let text: String
+  let attachments: [ServerControlDeckAttachmentRef]
+  let skills: [ServerControlDeckSkillRef]
+  let overrides: ServerControlDeckTurnOverrides?
+}

--- a/OrbitDockNative/OrbitDock/Services/Server/Protocol/ServerSessionContracts.swift
+++ b/OrbitDockNative/OrbitDock/Services/Server/Protocol/ServerSessionContracts.swift
@@ -52,6 +52,11 @@ enum ServerCodexApprovalMode: String, Codable, Equatable, Hashable, Sendable {
   case never
 }
 
+enum ServerCodexApprovalsReviewer: String, Codable, CaseIterable, Hashable, Sendable {
+  case user
+  case guardianSubagent = "guardian_subagent"
+}
+
 struct ServerCodexGranularApprovalPolicy: Codable, Equatable, Hashable, Sendable {
   let sandboxApproval: Bool?
   let rules: Bool?
@@ -141,6 +146,7 @@ struct ServerCodexSessionOverrides: Codable, Equatable, Hashable, Sendable {
   let approvalPolicy: String?
   let approvalPolicyDetails: ServerCodexApprovalPolicy?
   let sandboxMode: String?
+  let approvalsReviewer: ServerCodexApprovalsReviewer?
   let collaborationMode: String?
   let multiAgent: Bool?
   let personality: String?
@@ -154,6 +160,7 @@ struct ServerCodexSessionOverrides: Codable, Equatable, Hashable, Sendable {
     case approvalPolicy = "approval_policy"
     case approvalPolicyDetails = "approval_policy_details"
     case sandboxMode = "sandbox_mode"
+    case approvalsReviewer = "approvals_reviewer"
     case collaborationMode = "collaboration_mode"
     case multiAgent = "multi_agent"
     case personality
@@ -396,6 +403,7 @@ struct ServerSessionSummary: Codable, Identifiable {
   let approvalPolicy: String?
   let approvalPolicyDetails: ServerCodexApprovalPolicy?
   let sandboxMode: String?
+  let approvalsReviewer: ServerCodexApprovalsReviewer?
   let permissionMode: String?
   let allowBypassPermissions: Bool
   let collaborationMode: String?
@@ -455,6 +463,7 @@ struct ServerSessionSummary: Codable, Identifiable {
     case approvalPolicy = "approval_policy"
     case approvalPolicyDetails = "approval_policy_details"
     case sandboxMode = "sandbox_mode"
+    case approvalsReviewer = "approvals_reviewer"
     case permissionMode = "permission_mode"
     case allowBypassPermissions = "allow_bypass_permissions"
     case collaborationMode = "collaboration_mode"
@@ -888,6 +897,7 @@ struct ServerStateChanges: Codable {
   let approvalPolicy: String??
   let approvalPolicyDetails: ServerCodexApprovalPolicy??
   let sandboxMode: String??
+  let approvalsReviewer: ServerCodexApprovalsReviewer??
   let collaborationMode: String??
   let multiAgent: Bool??
   let personality: String??
@@ -935,6 +945,7 @@ struct ServerStateChanges: Codable {
     approvalPolicy: String?? = nil,
     approvalPolicyDetails: ServerCodexApprovalPolicy?? = nil,
     sandboxMode: String?? = nil,
+    approvalsReviewer: ServerCodexApprovalsReviewer?? = nil,
     collaborationMode: String?? = nil,
     multiAgent: Bool?? = nil,
     personality: String?? = nil,
@@ -981,6 +992,7 @@ struct ServerStateChanges: Codable {
     self.approvalPolicy = approvalPolicy
     self.approvalPolicyDetails = approvalPolicyDetails
     self.sandboxMode = sandboxMode
+    self.approvalsReviewer = approvalsReviewer
     self.collaborationMode = collaborationMode
     self.multiAgent = multiAgent
     self.personality = personality
@@ -1029,6 +1041,7 @@ struct ServerStateChanges: Codable {
     case approvalPolicy = "approval_policy"
     case approvalPolicyDetails = "approval_policy_details"
     case sandboxMode = "sandbox_mode"
+    case approvalsReviewer = "approvals_reviewer"
     case collaborationMode = "collaboration_mode"
     case multiAgent = "multi_agent"
     case personality
@@ -1090,6 +1103,10 @@ struct ServerStateChanges: Codable {
       forKey: .approvalPolicyDetails
     )
     sandboxMode = try container.decodePatchValue(String.self, forKey: .sandboxMode)
+    approvalsReviewer = try container.decodePatchValue(
+      ServerCodexApprovalsReviewer.self,
+      forKey: .approvalsReviewer
+    )
     collaborationMode = try container.decodePatchValue(String.self, forKey: .collaborationMode)
     multiAgent = try container.decodePatchValue(Bool.self, forKey: .multiAgent)
     personality = try container.decodePatchValue(String.self, forKey: .personality)

--- a/OrbitDockNative/OrbitDock/Services/Server/ServerRuntimeRegistry.swift
+++ b/OrbitDockNative/OrbitDock/Services/Server/ServerRuntimeRegistry.swift
@@ -904,6 +904,13 @@ final class ServerRuntimeRegistry {
       runtime.connection.subscribeDashboard(sinceRevision: snapshot.revision)
       return .success
     } catch {
+      if let message = ServerContractGuard.compatibilityMessage(
+        for: error,
+        surface: "dashboard bootstrap"
+      ) {
+        runtime.connection.failCompatibility(message: message)
+        return .stop
+      }
       netLog(
         .error,
         cat: .api,
@@ -928,6 +935,13 @@ final class ServerRuntimeRegistry {
       runtime.connection.subscribeMissions(sinceRevision: snapshot.revision)
       return .success
     } catch {
+      if let message = ServerContractGuard.compatibilityMessage(
+        for: error,
+        surface: "missions bootstrap"
+      ) {
+        runtime.connection.failCompatibility(message: message)
+        return .stop
+      }
       netLog(
         .error,
         cat: .api,

--- a/OrbitDockNative/OrbitDock/Services/Server/SessionObservable.swift
+++ b/OrbitDockNative/OrbitDock/Services/Server/SessionObservable.swift
@@ -553,6 +553,7 @@ final class SessionObservable {
       case .context: "context"
       case .notice: "notice"
       case .shellCommand: "shellCommand"
+      case .commandExecution: "commandExecution"
       case .task: "task"
       case .tool: "tool"
       case .activityGroup: "activityGroup"

--- a/OrbitDockNative/OrbitDock/Services/Server/SessionStore+Commands.swift
+++ b/OrbitDockNative/OrbitDock/Services/Server/SessionStore+Commands.swift
@@ -2,6 +2,51 @@ import Foundation
 
 @MainActor
 extension SessionStore {
+  func fetchControlDeckSnapshot(sessionId: String) async throws -> ServerControlDeckSnapshotPayload {
+    try await clients.controlDeck.fetchSnapshot(sessionId)
+  }
+
+  func fetchControlDeckPreferences() async throws -> ServerControlDeckPreferences {
+    try await clients.controlDeck.fetchPreferences()
+  }
+
+  func updateControlDeckPreferences(
+    _ request: ServerControlDeckPreferences
+  ) async throws -> ServerControlDeckPreferences {
+    try await clients.controlDeck.updatePreferences(request)
+  }
+
+  func submitControlDeckTurn(
+    sessionId: String,
+    request: ServerControlDeckSubmitTurnRequest
+  ) async throws {
+    netLog(
+      .info,
+      cat: .store,
+      "Submit Control Deck turn",
+      sid: sessionId,
+      data: [
+        "textLength": request.text.count,
+        "attachments": request.attachments.count,
+        "skills": request.skills.count,
+      ]
+    )
+    do {
+      let response = try await clients.controlDeck.submitTurn(sessionId, request: request)
+      session(sessionId).applyRowsChanged(upserted: [response.row], removedIds: [])
+      triggerLocalNamingIfNeeded(sessionId: sessionId, prompt: request.text)
+    } catch {
+      netLog(
+        .error,
+        cat: .store,
+        "Submit Control Deck turn failed",
+        sid: sessionId,
+        data: ["error": String(describing: error)]
+      )
+      throw error
+    }
+  }
+
   func sendMessage(
     sessionId: String,
     content: String,
@@ -369,6 +414,24 @@ extension SessionStore {
         )
       }
     }
+  }
+
+  func uploadControlDeckImageAttachment(
+    sessionId: String,
+    data: Data,
+    mimeType: String,
+    displayName: String,
+    pixelWidth: Int?,
+    pixelHeight: Int?
+  ) async throws -> ServerControlDeckImageAttachmentRef {
+    try await clients.controlDeck.uploadImageAttachment(
+      sessionId: sessionId,
+      data: data,
+      mimeType: mimeType,
+      displayName: displayName,
+      pixelWidth: pixelWidth,
+      pixelHeight: pixelHeight
+    )
   }
 
   func uploadImageAttachment(

--- a/OrbitDockNative/OrbitDock/Services/Server/SessionStore.swift
+++ b/OrbitDockNative/OrbitDock/Services/Server/SessionStore.swift
@@ -18,6 +18,7 @@ protocol SessionStoreConnection: AnyObject {
   func removeListener(_ token: ServerConnectionListenerToken)
   func subscribeSessionSurface(_ sessionId: String, surface: ServerSessionSurface, sinceRevision: UInt64?)
   func unsubscribeSessionSurface(_ sessionId: String, surface: ServerSessionSurface)
+  func failCompatibility(message: String)
 }
 
 extension ServerConnection: SessionStoreConnection {}
@@ -382,6 +383,12 @@ final class SessionStore {
       )
       return bootstrap
     } catch {
+      if let message = ServerContractGuard.compatibilityMessage(
+        for: error,
+        surface: "session bootstrap"
+      ) {
+        connection.failCompatibility(message: message)
+      }
       netLog(
         .error,
         cat: .conv,

--- a/OrbitDockNative/OrbitDock/Views/Dashboard/Scene/DashboardStatusBar.swift
+++ b/OrbitDockNative/OrbitDock/Views/Dashboard/Scene/DashboardStatusBar.swift
@@ -14,7 +14,9 @@ import SwiftUI
 struct DashboardStatusBar: View {
   @Environment(\.horizontalSizeClass) private var horizontalSizeClass
   @Environment(\.modelPricingService) private var modelPricingService
+  @Environment(OrbitDockAppRuntime.self) private var appRuntime
   @Environment(ServerRuntimeRegistry.self) private var runtimeRegistry
+  @Environment(UsageServiceRegistry.self) private var usageRegistry
   @Environment(AppRouter.self) private var router
 
   let sessions: [RootSessionNode]
@@ -37,6 +39,17 @@ struct DashboardStatusBar: View {
     let calculator = modelPricingService.calculatorSnapshot
     let calendar = Calendar.current
     let startOfToday = calendar.startOfDay(for: Date())
+    let startOfTodayUnix = UInt64(max(startOfToday.timeIntervalSince1970, 0))
+
+    if usageRegistry.summaryTodayStartUnix == startOfTodayUnix,
+       let summary = usageRegistry.summary
+    {
+      return (
+        today: StatusBarStats.from(summary.today),
+        all: StatusBarStats.from(summary.allTime)
+      )
+    }
+
     let todaySessions = dashboardStatsSessions.filter {
       guard let start = $0.startedAt else { return false }
       return start >= startOfToday
@@ -149,12 +162,27 @@ struct DashboardStatusBar: View {
     }
     .fixedSize(horizontal: false, vertical: true)
     .background(Color.backgroundSecondary)
+    .overlay(alignment: .bottom) {
+      Rectangle()
+        .fill(Color.panelBorder.opacity(layoutMode.isPhoneCompact ? 0.45 : 0.28))
+        .frame(height: 1)
+    }
     .sheet(isPresented: $showServerSettings) {
       ServerCommPanel()
     }
     .sheet(isPresented: $showAppSettings) {
       SettingsView(showsCloseButton: true)
+        .environment(appRuntime)
+        .environment(appRuntime.notificationCoordinator)
+        .environment(runtimeRegistry)
         .environment(runtimeRegistry.activeSessionStore)
+        #if os(iOS)
+          .presentationDetents([.large])
+          .presentationDragIndicator(.visible)
+        #endif
+    }
+    .task(id: Calendar.current.startOfDay(for: Date())) {
+      await usageRegistry.refreshAll(todayStart: Calendar.current.startOfDay(for: Date()))
     }
   }
 
@@ -181,63 +209,53 @@ struct DashboardStatusBar: View {
   // MARK: - Phone Header
 
   private func phoneHeader(stats: (today: StatusBarStats, all: StatusBarStats)) -> some View {
-    VStack(alignment: .leading, spacing: Spacing.sm_) {
-      HStack(spacing: Spacing.sm) {
-        DashboardTabSwitcher(compact: true)
+    VStack(alignment: .leading, spacing: Spacing.xs) {
+      DashboardTabSwitcher(compact: true)
+        .frame(maxWidth: .infinity)
+
+      HStack(alignment: .center, spacing: Spacing.sm) {
+        phoneStatsButton(todayStats: stats.today, allStats: stats.all)
           .layoutPriority(1)
 
-        Spacer(minLength: Spacing.sm_)
+        if let connectionSummaryText {
+          phoneTelemetryDivider
+          phoneConnectionBadge(text: connectionSummaryText)
+        }
+
+        Spacer(minLength: Spacing.sm)
 
         phoneActionButtons
       }
-
-      HStack(spacing: Spacing.sm_) {
-        phoneStatsButton(todayStats: stats.today, allStats: stats.all)
-
-        Spacer(minLength: Spacing.sm_)
-
-        if let connectionSummaryText {
-          connectionStateBadge(text: connectionSummaryText)
-        }
-
-        if let serverButtonLabelText {
-          phoneServerStatusBadge(text: serverButtonLabelText)
-        }
-      }
+      .padding(.horizontal, Spacing.xs)
     }
     .padding(.horizontal, Spacing.md)
-    .padding(.vertical, Spacing.sm)
+    .padding(.top, Spacing.sm)
+    .padding(.bottom, Spacing.sm)
   }
 
   private func phoneStatsButton(todayStats: StatusBarStats, allStats: StatusBarStats) -> some View {
     Button {
       showStatsPopover.toggle()
     } label: {
-      HStack(spacing: Spacing.sm_) {
+      HStack(spacing: Spacing.gap) {
         Image(systemName: "gauge.with.dots.needle.33percent")
-          .font(.system(size: TypeScale.caption, weight: .semibold))
+          .font(.system(size: TypeScale.mini, weight: .semibold))
           .foregroundStyle(Color.accent)
 
-        VStack(alignment: .leading, spacing: 1) {
-          Text("Usage")
-            .font(.system(size: TypeScale.mini, weight: .semibold))
-            .foregroundStyle(Color.textTertiary)
+        Text("Usage")
+          .font(.system(size: TypeScale.mini, weight: .semibold))
+          .foregroundStyle(Color.textTertiary)
 
-          Text("\(DashboardFormatters.costCompact(todayStats.cost)) today")
-            .font(.system(size: TypeScale.caption, weight: .bold, design: .monospaced))
-            .foregroundStyle(Color.textSecondary)
-        }
+        Text(DashboardFormatters.costCompact(todayStats.cost))
+          .font(.system(size: TypeScale.caption, weight: .bold, design: .monospaced))
+          .foregroundStyle(Color.textPrimary)
+
+        Text("today")
+          .font(.system(size: TypeScale.mini, weight: .medium))
+          .foregroundStyle(Color.textTertiary)
       }
-      .padding(.horizontal, Spacing.sm)
-      .padding(.vertical, Spacing.xs)
-      .background(
-        Capsule(style: .continuous)
-          .fill(Color.backgroundTertiary.opacity(0.58))
-          .overlay(
-            Capsule(style: .continuous)
-              .stroke(Color.surfaceBorder.opacity(OpacityTier.subtle), lineWidth: 1)
-          )
-      )
+      .padding(.vertical, Spacing.xxs)
+      .contentShape(Rectangle())
     }
     .buttonStyle(.plain)
     .accessibilityLabel("Show usage and stats")
@@ -330,6 +348,7 @@ struct DashboardStatusBar: View {
       settingsButton
       serverButton(showLabel: false)
     }
+    .padding(.vertical, Spacing.xxs)
   }
 
   private func newSessionButton(showLabel: Bool) -> some View {
@@ -347,7 +366,7 @@ struct DashboardStatusBar: View {
             .foregroundStyle(Color.textSecondary)
         }
       }
-      .frame(minWidth: showLabel ? 0 : 28, minHeight: 28, alignment: .center)
+      .frame(minWidth: showLabel ? 0 : 32, minHeight: 32, alignment: .center)
       .padding(.horizontal, showLabel ? Spacing.xs : 0)
       .contentShape(Rectangle())
     }
@@ -373,7 +392,7 @@ struct DashboardStatusBar: View {
       Image(systemName: "magnifyingglass")
         .font(.system(size: 10, weight: .medium))
         .foregroundStyle(Color.textTertiary)
-        .frame(width: 28, height: 28)
+        .frame(width: 32, height: 32)
     }
     .buttonStyle(.plain)
     .help("Search sessions (⌘K)")
@@ -384,7 +403,7 @@ struct DashboardStatusBar: View {
       Image(systemName: "gearshape")
         .font(.system(size: 10, weight: .medium))
         .foregroundStyle(Color.textTertiary)
-        .frame(width: 28, height: 28)
+        .frame(width: 32, height: 32)
     }
     .buttonStyle(.plain)
   }
@@ -444,6 +463,37 @@ struct DashboardStatusBar: View {
     )
   }
 
+  private var phoneTelemetryDivider: some View {
+    Capsule(style: .continuous)
+      .fill(Color.panelBorder.opacity(0.75))
+      .frame(width: 1, height: 14)
+      .padding(.vertical, Spacing.xxs)
+      .accessibilityHidden(true)
+  }
+
+  private func phoneConnectionBadge(text: String) -> some View {
+    HStack(spacing: Spacing.xs) {
+      if unavailableEndpointCount > 0 {
+        Image(systemName: "wifi.slash")
+          .font(.system(size: TypeScale.micro, weight: .bold))
+          .foregroundStyle(Color.statusPermission)
+      } else if connectingEndpointCount > 0 || isInitialLoading || isRefreshingCachedSessions {
+        ProgressView()
+          .controlSize(.mini)
+      } else {
+        Circle()
+          .fill(Color.feedbackPositive)
+          .frame(width: 6, height: 6)
+          .shadow(color: Color.feedbackPositive.opacity(0.45), radius: 3)
+      }
+
+      Text(text)
+        .font(.system(size: TypeScale.micro, weight: .semibold))
+        .foregroundStyle(unavailableEndpointCount > 0 ? Color.statusPermission : Color.textTertiary)
+        .lineLimit(1)
+    }
+  }
+
   private func headerMetric(
     value: String,
     label: String,
@@ -481,8 +531,15 @@ struct DashboardTabSwitcher: View {
       tabButton(label: "Missions", icon: "antenna.radiowaves.left.and.right", tab: .missions)
       tabButton(label: "Library", icon: "books.vertical", tab: .library)
     }
-    .padding(compact ? Spacing.xxs : Spacing.gap)
-    .background(Color.backgroundTertiary.opacity(0.6), in: Capsule())
+    .padding(compact ? Spacing.gap : Spacing.gap)
+    .background(
+      RoundedRectangle(cornerRadius: compact ? Radius.xl : Radius.xl, style: .continuous)
+        .fill(compact ? Color.backgroundTertiary.opacity(0.96) : Color.backgroundTertiary.opacity(0.6))
+        .overlay(
+          RoundedRectangle(cornerRadius: compact ? Radius.xl : Radius.xl, style: .continuous)
+            .stroke(Color.surfaceBorder.opacity(compact ? OpacityTier.medium : 0), lineWidth: 1)
+        )
+    )
   }
 
   private func tabButton(label: String, icon: String, tab: DashboardTab) -> some View {
@@ -501,15 +558,23 @@ struct DashboardTabSwitcher: View {
           .lineLimit(1)
       }
       .foregroundStyle(isActive ? Color.textPrimary : Color.textTertiary)
+      .frame(maxWidth: compact ? .infinity : nil, minHeight: compact ? 30 : nil)
       .padding(.horizontal, compact ? Spacing.sm : Spacing.md_)
       .padding(.vertical, compact ? Spacing.sm_ : Spacing.sm_)
       .background(
         isActive
-          ? Color.surfaceHover
+          ? Color.surfaceSelected
           : Color.clear,
-        in: Capsule()
+        in: RoundedRectangle(cornerRadius: compact ? Radius.lg : Radius.xl, style: .continuous)
       )
-      .fixedSize(horizontal: true, vertical: false)
+      .overlay(
+        RoundedRectangle(cornerRadius: compact ? Radius.lg : Radius.xl, style: .continuous)
+          .stroke(
+            isActive && compact ? Color.accent.opacity(OpacityTier.light) : Color.clear,
+            lineWidth: 1
+          )
+      )
+      .fixedSize(horizontal: !compact, vertical: false)
     }
     .buttonStyle(.plain)
   }
@@ -524,6 +589,7 @@ struct DashboardTabSwitcher: View {
     shouldBootstrapFromSettings: false
   )
   let router = AppRouter()
+  let appRuntime = OrbitDockAppRuntime()
   VStack(spacing: 0) {
     DashboardStatusBar(
       sessions: [],
@@ -537,6 +603,7 @@ struct DashboardTabSwitcher: View {
       .frame(height: 200)
   }
   .frame(width: 900)
+  .environment(appRuntime)
   .environment(runtimeRegistry)
   .environment(router)
 }

--- a/OrbitDockNative/OrbitDock/Views/Dashboard/Scene/MissionControlCommandDeck.swift
+++ b/OrbitDockNative/OrbitDock/Views/Dashboard/Scene/MissionControlCommandDeck.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct MissionControlCommandDeck: View {
   @Environment(\.horizontalSizeClass) private var horizontalSizeClass
+  @Environment(ServerRuntimeRegistry.self) private var runtimeRegistry
 
   let groups: [ConversationProjectGroup]
   let hasMultipleEndpoints: Bool
@@ -41,12 +42,14 @@ struct MissionControlCommandDeck: View {
   }
 
   private var emptyState: some View {
-    VStack(alignment: .leading, spacing: Spacing.sm) {
-      Text("All clear")
+    let emptyState = emptyStateCopy
+
+    return VStack(alignment: .leading, spacing: Spacing.sm) {
+      Text(emptyState.title)
         .font(.system(size: TypeScale.large, weight: .bold, design: .rounded))
         .foregroundStyle(Color.textPrimary)
 
-      Text("No active conversations in this view. Start a session or adjust your filters.")
+      Text(emptyState.message)
         .font(.system(size: TypeScale.body))
         .foregroundStyle(Color.textSecondary)
     }
@@ -62,6 +65,74 @@ struct MissionControlCommandDeck: View {
     )
   }
 
+  private var emptyStateCopy: (title: String, message: String) {
+    let statuses = runtimeRegistry.runtimes
+      .filter(\.endpoint.isEnabled)
+      .map { runtimeRegistry.displayConnectionStatus(for: $0.endpoint.id) }
+
+    if let message = statuses.compactMap(\.failureMessage).first(where: \.isCompatibilityGuidance) {
+      return (
+        "Server upgrade required",
+        "\(message) Open Server Settings to reconnect to a newer OrbitDock server."
+      )
+    }
+
+    if statuses.contains(where: \.isConnectingLike) {
+      return (
+        "Connecting to server",
+        "OrbitDock is waiting for a compatible dashboard snapshot before showing sessions."
+      )
+    }
+
+    if statuses.contains(where: \.isUnavailable) {
+      return (
+        "Server unavailable",
+        "OrbitDock couldn't load session data from the configured server. Check Server Settings, then try reconnecting."
+      )
+    }
+
+    return (
+      "All clear",
+      "No active conversations in this view. Start a session or adjust your filters."
+    )
+  }
+
+}
+
+private extension ConnectionStatus {
+  var failureMessage: String? {
+    guard case let .failed(message) = self else { return nil }
+    let trimmed = message.trimmingCharacters(in: .whitespacesAndNewlines)
+    return trimmed.isEmpty ? nil : trimmed
+  }
+
+  var isConnectingLike: Bool {
+    switch self {
+      case .connecting:
+        true
+      default:
+        false
+    }
+  }
+
+  var isUnavailable: Bool {
+    switch self {
+      case .disconnected, .failed:
+        true
+      case .connecting, .connected:
+        false
+    }
+  }
+}
+
+private extension String {
+  var isCompatibilityGuidance: Bool {
+    let normalized = lowercased()
+    return normalized.contains("compatible")
+      || normalized.contains("compatibility")
+      || normalized.contains("upgrade")
+      || normalized.contains("too old")
+  }
 }
 
 private struct ConversationProjectSection: View {

--- a/OrbitDockNative/OrbitDock/Views/NewSession/NewSessionConfigurationCard.swift
+++ b/OrbitDockNative/OrbitDock/Views/NewSession/NewSessionConfigurationCard.swift
@@ -22,6 +22,8 @@ struct NewSessionConfigurationCard: View {
   @Binding var codexPersonality: CodexPersonalityPreset
   @Binding var codexServiceTier: CodexServiceTierPreset
   @Binding var codexInstructions: String
+  let hasSelectedPath: Bool
+  let codexCatalogRequiresProjectPath: Bool
   let codexCatalog: SessionsClient.CodexConfigCatalogResponse?
   let codexCatalogLoading: Bool
   let codexCatalogError: String?
@@ -288,7 +290,7 @@ struct NewSessionConfigurationCard: View {
       case .claude:
         "Pick the model, permission posture, and reasoning effort before launch."
       case .codex:
-        "Resolve the folder config first, then layer per-session overrides only when you need them."
+        "Choose a folder when you want Codex to resolve project defaults, or jump straight to a saved profile or custom launch."
     }
   }
 
@@ -363,6 +365,24 @@ struct NewSessionConfigurationCard: View {
         title: codexConfigModeSummaryTitle,
         detail: codexConfigModeSummaryDetail
       )
+
+      if provider == .codex, !hasSelectedPath, codexConfigMode == .inherit {
+        codexLaunchHintCard(
+          title: "Folder mode needs a project",
+          detail: "Saved profiles and providers are available now, but OrbitDock needs a folder before it can resolve the effective Codex setup for that project.",
+          tint: .statusQuestion,
+          icon: "folder.badge.questionmark"
+        )
+      }
+
+      if provider == .codex, !hasSelectedPath, codexCatalogRequiresProjectPath {
+        codexLaunchHintCard(
+          title: "Older server still needs a folder",
+          detail: "This OrbitDock server is still using the older Codex catalog behavior, so saved profiles will appear after you choose a project. Restart the server to enable global profile browsing.",
+          tint: .feedbackCaution,
+          icon: "arrow.triangle.2.circlepath"
+        )
+      }
 
       if let codexCatalogError, !codexCatalogError.isEmpty {
         Text(codexCatalogError)
@@ -479,7 +499,7 @@ struct NewSessionConfigurationCard: View {
   private var codexConfigModeSummaryTitle: String {
     switch codexConfigMode {
       case .inherit:
-        "Use the folder's effective Codex config"
+        hasSelectedPath ? "Use the folder's effective Codex config" : "Choose a folder for project defaults"
       case .profile:
         selectedProfileSummary.map { "Use profile \($0.name)" } ?? "Choose a saved Codex profile"
       case .custom:
@@ -490,7 +510,9 @@ struct NewSessionConfigurationCard: View {
   private var codexConfigModeSummaryDetail: String {
     switch codexConfigMode {
       case .inherit:
-        "OrbitDock will inherit the effective profile, provider, and model Codex resolves for this folder."
+        hasSelectedPath
+          ? "OrbitDock will inherit the effective profile, provider, and model Codex resolves for this folder."
+          : "Pick a project folder to resolve its Codex defaults. Saved profiles and custom providers can still be selected before that."
       case .profile:
         selectedProfileSummary.map {
           [
@@ -648,9 +670,15 @@ struct NewSessionConfigurationCard: View {
 
   private var profileModePlaceholder: String {
     if profileOptions.isEmpty {
+      if codexCatalogLoading {
+        return "Loading your saved Codex profiles."
+      }
       return "No saved Codex profiles were returned yet."
     }
-    return "Pick one of your saved Codex profiles to use it for this session."
+    if hasSelectedPath {
+      return "Pick one of your saved Codex profiles to use it for this session."
+    }
+    return "Pick one of your saved Codex profiles now, then choose a folder when you're ready to launch."
   }
 
   private func codexModeSummary(title: String, detail: String) -> some View {
@@ -681,6 +709,32 @@ struct NewSessionConfigurationCard: View {
         RoundedRectangle(cornerRadius: Radius.md, style: .continuous)
           .stroke(Color.surfaceBorder.opacity(OpacityTier.light), lineWidth: 1)
       )
+  }
+
+  private func codexLaunchHintCard(title: String, detail: String, tint: Color, icon: String) -> some View {
+    HStack(alignment: .top, spacing: Spacing.sm) {
+      Image(systemName: icon)
+        .font(.system(size: TypeScale.caption, weight: .semibold))
+        .foregroundStyle(tint)
+        .frame(width: 18, height: 18)
+
+      VStack(alignment: .leading, spacing: Spacing.xxs) {
+        Text(title)
+          .font(.system(size: TypeScale.caption, weight: .semibold))
+          .foregroundStyle(Color.textPrimary)
+        Text(detail)
+          .font(.system(size: TypeScale.caption))
+          .foregroundStyle(Color.textTertiary)
+          .fixedSize(horizontal: false, vertical: true)
+      }
+      .frame(maxWidth: .infinity, alignment: .leading)
+    }
+    .padding(Spacing.md)
+    .background(tint.opacity(OpacityTier.tint), in: RoundedRectangle(cornerRadius: Radius.md, style: .continuous))
+    .overlay(
+      RoundedRectangle(cornerRadius: Radius.md, style: .continuous)
+        .stroke(tint.opacity(OpacityTier.light), lineWidth: 1)
+    )
   }
 
   private var codexResolvedValuesSection: some View {

--- a/OrbitDockNative/OrbitDock/Views/NewSession/NewSessionSheet.swift
+++ b/OrbitDockNative/OrbitDock/Views/NewSession/NewSessionSheet.swift
@@ -29,6 +29,7 @@ struct NewSessionSheet: View {
   @State private var codexConfigCatalogError: String?
   @State private var codexConfigCatalogLoading = false
   @State private var codexConfigCatalogRequestID = 0
+  @State private var codexCatalogRequiresProjectPath = false
   @State private var codexScopedModels: [ServerCodexModelOption]?
   @State private var codexScopedModelsLoading = false
   @State private var codexScopedModelsError: String?
@@ -480,6 +481,8 @@ struct NewSessionSheet: View {
       codexPersonality: $model.codexPersonality,
       codexServiceTier: $model.codexServiceTier,
       codexInstructions: $model.codexInstructions,
+      hasSelectedPath: !model.selectedPath.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+      codexCatalogRequiresProjectPath: codexCatalogRequiresProjectPath,
       codexCatalog: codexConfigCatalog,
       codexCatalogLoading: codexConfigCatalogLoading,
       codexCatalogError: codexConfigCatalogError,
@@ -557,25 +560,22 @@ struct NewSessionSheet: View {
       codexConfigCatalog = nil
       codexConfigCatalogError = nil
       codexConfigCatalogLoading = false
+      codexCatalogRequiresProjectPath = false
       return
     }
 
     let cwd = model.selectedPath.trimmingCharacters(in: .whitespacesAndNewlines)
-    guard !cwd.isEmpty else {
-      codexConfigCatalog = nil
-      codexConfigCatalogError = nil
-      codexConfigCatalogLoading = false
-      return
-    }
-
     codexConfigCatalogLoading = true
     codexConfigCatalogError = nil
+    codexCatalogRequiresProjectPath = false
     codexConfigCatalogRequestID += 1
     let requestID = codexConfigCatalogRequestID
 
     Task {
       do {
-        let response = try await endpointAppState.clients.sessions.fetchCodexConfigCatalog(cwd: cwd)
+        let response = try await endpointAppState.clients.sessions.fetchCodexConfigCatalog(
+          cwd: cwd.isEmpty ? nil : cwd
+        )
         await MainActor.run {
           guard requestID == codexConfigCatalogRequestID,
                 model.provider == .codex,
@@ -583,6 +583,7 @@ struct NewSessionSheet: View {
           else { return }
           codexConfigCatalog = response
           codexConfigCatalogLoading = false
+          codexCatalogRequiresProjectPath = false
           if model.codexConfigMode == .profile,
              model.codexConfigProfile.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
           {
@@ -601,11 +602,18 @@ struct NewSessionSheet: View {
                 model.selectedPath.trimmingCharacters(in: .whitespacesAndNewlines) == cwd
           else { return }
           codexConfigCatalog = nil
-          codexConfigCatalogError = error.localizedDescription
+          codexCatalogRequiresProjectPath = isLegacyCodexCatalogProjectRequirement(error: error, cwd: cwd)
+          codexConfigCatalogError = codexCatalogRequiresProjectPath ? nil : error.localizedDescription
           codexConfigCatalogLoading = false
         }
       }
     }
+  }
+
+  private func isLegacyCodexCatalogProjectRequirement(error: Error, cwd: String) -> Bool {
+    guard cwd.isEmpty else { return false }
+    guard let requestError = error as? ServerRequestError else { return false }
+    return requestError.statusCode == 400
   }
 
   private var scopedCodexModelProvider: String? {

--- a/OrbitDockNative/OrbitDock/Views/Providers/Claude/ClaudePermissionPicker.swift
+++ b/OrbitDockNative/OrbitDock/Views/Providers/Claude/ClaudePermissionPicker.swift
@@ -31,6 +31,16 @@ enum ClaudePermissionMode: String, CaseIterable, Identifiable {
     }
   }
 
+  var compactStatusName: String {
+    switch self {
+      case .plan: "Plan"
+      case .dontAsk: "No Ask"
+      case .default: "Default"
+      case .acceptEdits: "Edits"
+      case .bypassPermissions: "Bypass"
+    }
+  }
+
   var icon: String {
     switch self {
       case .plan: "map.fill"
@@ -87,42 +97,67 @@ struct ClaudePermissionPill: View {
     var iconFontSize: CGFloat {
       switch self {
         case .regular: TypeScale.body
-        case .statusBar: 9
+        case .statusBar:
+          #if os(iOS)
+            IconScale.xs
+          #else
+            IconScale.sm
+          #endif
       }
     }
 
     var textFontSize: CGFloat {
       switch self {
         case .regular: TypeScale.body
-        case .statusBar: 10
+        case .statusBar:
+          #if os(iOS)
+            TypeScale.mini
+          #else
+            TypeScale.micro
+          #endif
       }
     }
 
     var horizontalPadding: CGFloat {
       switch self {
         case .regular: CGFloat(Spacing.md)
-        case .statusBar: 6
+        case .statusBar:
+          #if os(iOS)
+            CGFloat(Spacing.sm_)
+          #else
+            CGFloat(Spacing.sm)
+          #endif
       }
     }
 
     var verticalPadding: CGFloat {
       switch self {
         case .regular: CGFloat(Spacing.sm)
-        case .statusBar: 3
+        case .statusBar:
+          #if os(iOS)
+            CGFloat(Spacing.gap)
+          #else
+            CGFloat(Spacing.xs)
+          #endif
       }
     }
 
     var spacing: CGFloat {
       switch self {
         case .regular: CGFloat(Spacing.xs)
-        case .statusBar: 3
+        case .statusBar: CGFloat(Spacing.xs)
       }
     }
 
     var height: CGFloat? {
       switch self {
         case .regular: nil
-        case .statusBar: 20
+        case .statusBar:
+          #if os(iOS)
+            24
+          #else
+            20
+          #endif
       }
     }
   }
@@ -135,6 +170,13 @@ struct ClaudePermissionPill: View {
   var onUpdate: ((ClaudePermissionMode) -> Void)?
   @State private var showPopover = false
 
+  private var title: String {
+    #if os(iOS)
+      if size == .statusBar { return currentMode.compactStatusName }
+    #endif
+    return currentMode.displayName
+  }
+
   var body: some View {
     Button {
       if let onTapOverride {
@@ -146,7 +188,7 @@ struct ClaudePermissionPill: View {
       HStack(spacing: size.spacing) {
         Image(systemName: currentMode.icon)
           .font(.system(size: size.iconFontSize, weight: .semibold))
-        Text(currentMode.displayName)
+        Text(title)
           .font(.system(size: size.textFontSize, weight: .semibold))
       }
       .foregroundStyle(isActive ? Color.backgroundSecondary : currentMode.color)
@@ -159,6 +201,11 @@ struct ClaudePermissionPill: View {
           : AnyShapeStyle(currentMode.color.opacity(OpacityTier.light)),
         in: Capsule()
       )
+      .overlay(
+        Capsule()
+          .strokeBorder(currentMode.color.opacity(OpacityTier.medium), lineWidth: 0.75)
+      )
+      .if(size == .regular) { $0.themeShadow(Shadow.sm) }
     }
     .buttonStyle(.plain)
     .fixedSize()

--- a/OrbitDockNative/OrbitDock/Views/Providers/Codex/AutonomyPicker.swift
+++ b/OrbitDockNative/OrbitDock/Views/Providers/Codex/AutonomyPicker.swift
@@ -99,6 +99,17 @@ enum AutonomyLevel: String, CaseIterable, Identifiable {
     }
   }
 
+  var controlDeckAutoReviewLabel: String {
+    switch self {
+      case .locked: "You Review It"
+      case .guarded: "Sandbox Retries First"
+      case .autonomous: "OrbitDock Can Decide"
+      case .open: "OrbitDock Decides Openly"
+      case .fullAuto: "Codex Keeps Going"
+      case .unrestricted: "Nothing Stops It"
+    }
+  }
+
   var autoReviewStatusIcon: String {
     switch self {
       case .locked: "lock.shield.fill"
@@ -134,6 +145,23 @@ enum AutonomyLevel: String, CaseIterable, Identifiable {
         "Approval UI becomes read-only context here. Codex runs directly inside the configured sandbox and will not pause for confirmation."
       case .unrestricted:
         "There is no sandbox and no approval pause. OrbitDock can only show policy context after the fact, so treat this as a deliberate high-trust mode."
+    }
+  }
+
+  var controlDeckAutoReviewSummary: String {
+    switch self {
+      case .locked:
+        "Blocked work always comes back to you. OrbitDock does not try to resolve it on your behalf."
+      case .guarded:
+        "OrbitDock lets the sandbox try first. You only see the prompt when the sandbox cannot satisfy the request."
+      case .autonomous:
+        "OrbitDock can approve or deny some blocked work for Codex when it has enough confidence, so you get interrupted less often."
+      case .open:
+        "OrbitDock can still make that decision for Codex, but it is doing it without sandbox restrictions."
+      case .fullAuto:
+        "Codex stays in motion without approval interruptions. You are choosing audit context over live approval."
+      case .unrestricted:
+        "There is no sandbox and no approval stop. Nothing blocks the agent before it acts."
     }
   }
 
@@ -232,7 +260,7 @@ struct AutonomyPill: View {
     var iconFontSize: CGFloat {
       switch self {
         case .regular: TypeScale.body
-        case .statusBar: TypeScale.mini
+        case .statusBar: IconScale.sm
       }
     }
 
@@ -246,28 +274,33 @@ struct AutonomyPill: View {
     var horizontalPadding: CGFloat {
       switch self {
         case .regular: CGFloat(Spacing.md)
-        case .statusBar: Spacing.sm_
+        case .statusBar: CGFloat(Spacing.sm)
       }
     }
 
     var verticalPadding: CGFloat {
       switch self {
         case .regular: CGFloat(Spacing.sm)
-        case .statusBar: Spacing.gap
+        case .statusBar: CGFloat(Spacing.xs)
       }
     }
 
     var spacing: CGFloat {
       switch self {
         case .regular: CGFloat(Spacing.xs)
-        case .statusBar: Spacing.gap
+        case .statusBar: CGFloat(Spacing.xs)
       }
     }
 
     var height: CGFloat? {
       switch self {
         case .regular: nil
-        case .statusBar: 20
+        case .statusBar:
+          #if os(iOS)
+            30
+          #else
+            20
+          #endif
       }
     }
   }
@@ -309,6 +342,11 @@ struct AutonomyPill: View {
           : AnyShapeStyle(currentLevel.color.opacity(OpacityTier.light)),
         in: Capsule()
       )
+      .overlay(
+        Capsule()
+          .strokeBorder(currentLevel.color.opacity(OpacityTier.medium), lineWidth: 0.75)
+      )
+      .themeShadow(Shadow.sm)
     }
     .buttonStyle(.plain)
     .fixedSize()

--- a/OrbitDockNative/OrbitDock/Views/Providers/Codex/CodexCollaborationModePicker.swift
+++ b/OrbitDockNative/OrbitDock/Views/Providers/Codex/CodexCollaborationModePicker.swift
@@ -15,6 +15,13 @@ enum CodexCollaborationMode: String, CaseIterable, Identifiable {
     }
   }
 
+  var compactStatusName: String {
+    switch self {
+      case .default: "Default"
+      case .plan: "Plan"
+    }
+  }
+
   var icon: String {
     switch self {
       case .default: "chevron.left.forwardslash.chevron.right"
@@ -32,9 +39,9 @@ enum CodexCollaborationMode: String, CaseIterable, Identifiable {
   var description: String {
     switch self {
       case .default:
-        "Standard Codex flow for direct coding, edits, and worker coordination."
+        "Best for normal coding sessions. Codex edits directly and coordinates the work as it goes."
       case .plan:
-        "Planner-first mode that favors structured thinking and explicit coordination."
+        "Best when you want more structure first. Codex leans planner-first before diving into execution."
     }
   }
 
@@ -203,27 +210,67 @@ struct CodexModePill: View {
     case statusBar
 
     var iconFontSize: CGFloat {
-      self == .statusBar ? 9 : TypeScale.body
+      if self == .statusBar {
+        #if os(iOS)
+          IconScale.xs
+        #else
+          IconScale.sm
+        #endif
+      } else {
+        TypeScale.body
+      }
     }
 
     var textFontSize: CGFloat {
-      self == .statusBar ? 10 : TypeScale.body
+      if self == .statusBar {
+        #if os(iOS)
+          TypeScale.mini
+        #else
+          TypeScale.micro
+        #endif
+      } else {
+        TypeScale.body
+      }
     }
 
     var horizontalPadding: CGFloat {
-      self == .statusBar ? 6 : CGFloat(Spacing.md)
+      if self == .statusBar {
+        #if os(iOS)
+          CGFloat(Spacing.sm_)
+        #else
+          CGFloat(Spacing.sm)
+        #endif
+      } else {
+        CGFloat(Spacing.md)
+      }
     }
 
     var verticalPadding: CGFloat {
-      self == .statusBar ? 3 : CGFloat(Spacing.sm)
+      if self == .statusBar {
+        #if os(iOS)
+          CGFloat(Spacing.gap)
+        #else
+          CGFloat(Spacing.xs)
+        #endif
+      } else {
+        CGFloat(Spacing.sm)
+      }
     }
 
     var spacing: CGFloat {
-      self == .statusBar ? 3 : CGFloat(Spacing.xs)
+      self == .statusBar ? CGFloat(Spacing.xs) : CGFloat(Spacing.xs)
     }
 
     var height: CGFloat? {
-      self == .statusBar ? 20 : nil
+      if self == .statusBar {
+        #if os(iOS)
+          24
+        #else
+          20
+        #endif
+      } else {
+        nil
+      }
     }
   }
 
@@ -233,6 +280,13 @@ struct CodexModePill: View {
   var onUpdate: ((CodexCollaborationMode) -> Void)?
   @State private var showPopover = false
 
+  private var title: String {
+    #if os(iOS)
+      if size == .statusBar { return currentMode.compactStatusName }
+    #endif
+    return currentMode.displayName
+  }
+
   var body: some View {
     Button {
       showPopover.toggle()
@@ -240,7 +294,7 @@ struct CodexModePill: View {
       HStack(spacing: size.spacing) {
         Image(systemName: currentMode.icon)
           .font(.system(size: size.iconFontSize, weight: .semibold))
-        Text(currentMode.displayName)
+        Text(title)
           .font(.system(size: size.textFontSize, weight: .semibold))
       }
       .foregroundStyle(currentMode.color)
@@ -248,14 +302,26 @@ struct CodexModePill: View {
       .padding(.vertical, size.verticalPadding)
       .frame(height: size.height)
       .background(currentMode.color.opacity(OpacityTier.light), in: Capsule())
+      .overlay(
+        Capsule()
+          .strokeBorder(currentMode.color.opacity(OpacityTier.medium), lineWidth: 0.75)
+      )
+      .if(size == .regular) { $0.themeShadow(Shadow.sm) }
     }
     .buttonStyle(.plain)
     .fixedSize()
     .platformPopover(isPresented: $showPopover) {
       VStack(alignment: .leading, spacing: Spacing.md) {
-        Text("Collaboration")
-          .font(.system(size: TypeScale.subhead, weight: .semibold))
-          .foregroundStyle(Color.textPrimary)
+        VStack(alignment: .leading, spacing: Spacing.xs) {
+          Text("Collaboration")
+            .font(.system(size: TypeScale.subhead, weight: .semibold))
+            .foregroundStyle(Color.textPrimary)
+
+          Text("Controls how Codex approaches the work, from direct execution to planner-first coordination.")
+            .font(.system(size: TypeScale.caption))
+            .foregroundStyle(Color.textSecondary)
+            .fixedSize(horizontal: false, vertical: true)
+        }
 
         ForEach(supportedModes) { mode in
           Button {
@@ -293,6 +359,11 @@ struct CodexModePill: View {
         }
       }
       .padding(Spacing.lg)
+      #if os(iOS)
+        .frame(maxWidth: .infinity)
+        .navigationTitle("Collaboration")
+        .navigationBarTitleDisplayMode(.inline)
+      #endif
       .ifMacOS { $0.frame(width: 280) }
       .background(Color.backgroundSecondary)
     }

--- a/OrbitDockNative/OrbitDock/Views/SessionDetail/SessionDetailContentSections.swift
+++ b/OrbitDockNative/OrbitDock/Views/SessionDetail/SessionDetailContentSections.swift
@@ -7,6 +7,7 @@ struct SessionDetailConversationSection: View {
   let isSessionActive: Bool
   let displayStatus: SessionDisplayStatus
   let currentTool: String?
+  let showsOrbitStatusIndicator: Bool
   let chatViewMode: ChatViewMode
   let openFileInReview: ((String) -> Void)?
   let focusWorkerInDeck: ((String) -> Void)?
@@ -22,6 +23,7 @@ struct SessionDetailConversationSection: View {
       isSessionActive: isSessionActive,
       displayStatus: displayStatus,
       currentTool: currentTool,
+      showsOrbitStatusIndicator: showsOrbitStatusIndicator,
       chatViewMode: chatViewMode,
       scrollCommand: $scrollCommand,
       onJumpToLatest: onJumpToLatest,

--- a/OrbitDockNative/OrbitDock/Views/SessionDetail/SessionDetailView+Sections.swift
+++ b/OrbitDockNative/OrbitDock/Views/SessionDetail/SessionDetailView+Sections.swift
@@ -107,6 +107,7 @@ extension SessionDetailView {
       isSessionActive: presentation.isSessionActive,
       displayStatus: presentation.displayStatus,
       currentTool: presentation.currentTool,
+      showsOrbitStatusIndicator: !screenPresentation.isDirect,
       chatViewMode: chatViewMode,
       openFileInReview: presentation.canOpenFileInReview ? { filePath in
         withAnimation(Motion.gentle) {

--- a/OrbitDockNative/OrbitDock/Views/SessionDetail/SessionDetailView.swift
+++ b/OrbitDockNative/OrbitDock/Views/SessionDetail/SessionDetailView.swift
@@ -38,29 +38,7 @@ struct SessionDetailView: View {
 
   var body: some View {
     VStack(spacing: 0) {
-      #if os(macOS)
-        // Custom header on macOS (no native nav bar)
-        HeaderView(
-          sessionId: sessionId,
-          endpointId: endpointId,
-          presentation: screenPresentation,
-          codexAccountStatus: scopedServerState.codexAccountStatus,
-          onEndSession: screenPresentation.isActive ? { viewModel.endSession() } : nil,
-          layoutConfig: screenPresentation.isDirect ? $viewModel.layoutConfig : nil,
-          chatViewMode: $chatViewMode,
-          workerPanelVisible: $showWorkerPanel,
-          hasWorkerPanelContent: workerRosterPresentation != nil
-        )
-
-        Divider()
-          .foregroundStyle(Color.panelBorder)
-      #else
-        // iOS: status strip only (native nav bar handles title + back)
-        iOSStatusStrip
-
-        Divider()
-          .foregroundStyle(Color.panelBorder)
-      #endif
+      topChrome
 
       // Diff-available banner
       if viewModel.showDiffBanner, viewModel.layoutConfig == .conversationOnly {
@@ -85,20 +63,10 @@ struct SessionDetailView: View {
         workerCompanionPanel
       }
 
-      // Terminal strip — lives between conversation and composer on both platforms
       terminalStripSection
 
       SessionDetailFooter(mode: footerMode) {
-        DirectSessionComposer(
-          sessionId: sessionId,
-          sessionStore: scopedServerState,
-          selectedSkills: $viewModel.selectedSkills,
-          pendingPanelOpenSignal: viewModel.pendingApprovalPanelOpenSignal,
-          followMode: viewModel.followMode,
-          unreadCount: viewModel.unreadCount,
-          onJumpToLatest: viewModel.jumpConversationToLatest,
-          onTogglePinned: viewModel.toggleConversationFollowMode
-        )
+        directSessionFooter
       } takeOverBar: {
         TakeOverInputBar(
           onTakeOver: {
@@ -180,6 +148,82 @@ struct SessionDetailView: View {
 
   var sessionDetailWorktreeCleanupState: SessionDetailWorktreeCleanupBannerState? {
     viewModel.sessionDetailWorktreeCleanupState
+  }
+
+  private var directSessionFooter: some View {
+    VStack(spacing: 0) {
+      if screenPresentation.isActive || screenPresentation.displayStatus != .ended {
+        directSessionDockHeader
+      }
+
+      #if os(macOS)
+        if let session = controlDeckTerminalSession, viewModel.showInlineTerminal {
+          dividerLine
+
+          terminalPanel(session: session)
+            .frame(maxWidth: .infinity, minHeight: 200, maxHeight: 320)
+            .transition(.move(edge: .bottom).combined(with: .opacity))
+        }
+      #endif
+
+      dividerLine
+
+      ControlDeckScreen(
+        sessionId: sessionId,
+        sessionStore: scopedServerState,
+        chromeStyle: .embedded,
+        terminalTitle: controlDeckTerminalSession?.title,
+        sessionDisplayStatus: screenPresentation.displayStatus,
+        currentTool: currentTool,
+        onToggleTerminal: {
+          if let session = controlDeckTerminalSession {
+            handleTerminalStripTap(session: session)
+          }
+        }
+      )
+    }
+    .background(Color.backgroundSecondary)
+    .clipShape(RoundedRectangle(cornerRadius: Radius.xl, style: .continuous))
+    .overlay(
+      RoundedRectangle(cornerRadius: Radius.xl, style: .continuous)
+        .strokeBorder(Color.panelBorder, lineWidth: 1)
+    )
+    .padding(.horizontal, Spacing.sm)
+    .padding(.bottom, Spacing.xs)
+    #if os(iOS)
+    .fullScreenCover(isPresented: $viewModel.showTerminalInteractiveSheet) {
+      if let session = controlDeckTerminalSession {
+        TerminalInteractiveSheet(session: session)
+      } else {
+        Color.clear
+      }
+    }
+    #endif
+  }
+
+  @ViewBuilder
+  private var topChrome: some View {
+    #if os(macOS)
+      HeaderView(
+        sessionId: sessionId,
+        endpointId: endpointId,
+        presentation: screenPresentation,
+        codexAccountStatus: scopedServerState.codexAccountStatus,
+        onEndSession: screenPresentation.isActive ? { viewModel.endSession() } : nil,
+        layoutConfig: screenPresentation.isDirect ? $viewModel.layoutConfig : nil,
+        chatViewMode: $chatViewMode,
+        workerPanelVisible: $showWorkerPanel,
+        hasWorkerPanelContent: workerRosterPresentation != nil
+      )
+
+      Divider()
+        .foregroundStyle(Color.panelBorder)
+    #else
+      iOSStatusStrip
+
+      Divider()
+        .foregroundStyle(Color.panelBorder)
+    #endif
   }
 
   // MARK: - iOS Native Nav Bar
@@ -318,26 +362,35 @@ struct SessionDetailView: View {
     .background(Color.blue.opacity(0.08))
   }
 
+  /// Active terminal session for control deck integration — nil when no terminal exists.
+  private var controlDeckTerminalSession: TerminalSessionController? {
+    guard viewModel.showTerminalPanel,
+          let terminalId = viewModel.activeTerminalId
+    else { return nil }
+    return terminalRegistry.session(for: terminalId)
+  }
+
   // MARK: - Terminal Strip
 
   @ViewBuilder
   var terminalStripSection: some View {
-    if viewModel.showTerminalPanel,
-       let terminalId = viewModel.activeTerminalId,
-       let session = terminalRegistry.session(for: terminalId) {
+    if screenPresentation.isDirect {
+      EmptyView()
+    } else if viewModel.showTerminalPanel,
+              let terminalId = viewModel.activeTerminalId,
+              let session = terminalRegistry.session(for: terminalId)
+    {
       VStack(spacing: 0) {
-        // Active terminal — show live strip (always visible when terminal exists)
-        TerminalLiveStrip(session: session) {
+        TerminalLiveStrip(session: session, onTap: {
           handleTerminalStripTap(session: session)
-        }
+        }, fallbackPath: screenPresentation.projectPath)
         .transition(.move(edge: .bottom).combined(with: .opacity))
 
-        // macOS: inline panel expands below the strip
         #if os(macOS)
-        if viewModel.showInlineTerminal {
-          terminalPanel(session: session)
-            .transition(.move(edge: .bottom).combined(with: .opacity))
-        }
+          if viewModel.showInlineTerminal {
+            terminalPanel(session: session)
+              .transition(.move(edge: .bottom).combined(with: .opacity))
+          }
         #endif
       }
       #if os(iOS)
@@ -345,42 +398,117 @@ struct SessionDetailView: View {
         TerminalInteractiveSheet(session: session)
       }
       #endif
-    } else if screenPresentation.isActive || screenPresentation.isDirect {
-      // No terminal — show launch button
+    } else if screenPresentation.isActive {
       terminalLaunchStrip
     }
+  }
+
+  @ViewBuilder
+  private var directSessionDockHeader: some View {
+    VStack(spacing: 0) {
+      OrbitStatusIndicator(
+        displayStatus: screenPresentation.displayStatus,
+        currentTool: currentTool,
+        chromeStyle: .embedded
+      )
+
+      if let session = controlDeckTerminalSession {
+        dividerLine
+
+        TerminalLiveStrip(session: session, onTap: {
+          handleTerminalStripTap(session: session)
+        }, fallbackPath: screenPresentation.projectPath, chromeStyle: .embedded)
+        .transition(.move(edge: .bottom).combined(with: .opacity))
+      } else if screenPresentation.isActive {
+        dividerLine
+
+        terminalLaunchStrip
+          .transition(.move(edge: .bottom).combined(with: .opacity))
+      }
+    }
+    .padding(.top, Spacing.xs)
+    .padding(.bottom, Spacing.xxs)
+  }
+
+  private var dividerLine: some View {
+    Color.surfaceBorder.opacity(0.28)
+      .frame(height: 1)
+      .padding(.horizontal, Spacing.md)
+  }
+
+  private var terminalLaunchTitle: String {
+    shortenedTerminalPath(screenPresentation.projectPath) ?? "Launch interactive shell"
   }
 
   private var terminalLaunchStrip: some View {
     Button {
       launchTerminal()
     } label: {
-      HStack(spacing: Spacing.sm_) {
-        Image(systemName: "terminal")
-          .font(.system(size: TypeScale.meta, weight: .medium))
-          .foregroundStyle(Color.textQuaternary)
+      HStack(alignment: .firstTextBaseline, spacing: Spacing.sm_) {
+        Image(systemName: "chevron.right")
+          .font(.system(size: TypeScale.mini, weight: .bold, design: .monospaced))
+          .foregroundStyle(Color.terminal)
+          .frame(width: 12, height: 16)
 
-        Text("Terminal")
-          .font(.system(size: TypeScale.meta, weight: .medium))
-          .foregroundStyle(Color.textQuaternary)
+        HStack(spacing: Spacing.xs) {
+          Text("Terminal")
+            .font(.system(size: TypeScale.meta, weight: .semibold, design: .monospaced))
+            .foregroundStyle(Color.textPrimary)
+
+          Text("·")
+            .font(.system(size: TypeScale.meta, weight: .medium))
+            .foregroundStyle(Color.textQuaternary)
+
+          Text(terminalLaunchTitle)
+            .font(.system(size: TypeScale.meta, weight: .medium, design: .monospaced))
+            .foregroundStyle(Color.textQuaternary)
+            .lineLimit(1)
+        }
 
         Spacer(minLength: 0)
+
+        Image(systemName: "plus.circle.fill")
+          .font(.system(size: IconScale.xs, weight: .bold))
+          .foregroundStyle(Color.accent)
       }
-      .padding(.horizontal, Spacing.lg)
-      .padding(.vertical, Spacing.sm_)
+      .padding(.horizontal, Spacing.md)
+      .padding(.vertical, Spacing.xs)
+      .background(Color.clear)
       .contentShape(Rectangle())
     }
     .buttonStyle(.plain)
     .help("Launch terminal")
   }
 
+  private func shortenedTerminalPath(_ raw: String?) -> String? {
+    guard let raw else { return nil }
+    let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !trimmed.isEmpty else { return nil }
+
+    let path = trimmed.replacingOccurrences(of: "^~", with: NSHomeDirectory(), options: .regularExpression)
+    let home = NSHomeDirectory()
+    if path.hasPrefix(home) {
+      let suffix = String(path.dropFirst(home.count)).trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+      if suffix.isEmpty { return "~" }
+      if let last = suffix.split(separator: "/").last {
+        return "~/\(last)"
+      }
+      return "~"
+    }
+
+    if let last = path.split(separator: "/").last, !last.isEmpty {
+      return String(last)
+    }
+    return trimmed
+  }
+
   private func handleTerminalStripTap(session: TerminalSessionController) {
     #if os(iOS)
-    viewModel.showTerminalInteractiveSheet = true
+      viewModel.showTerminalInteractiveSheet = true
     #else
-    withAnimation(Motion.gentle) {
-      viewModel.showInlineTerminal.toggle()
-    }
+      withAnimation(Motion.gentle) {
+        viewModel.showInlineTerminal.toggle()
+      }
     #endif
   }
 
@@ -405,9 +533,9 @@ struct SessionDetailView: View {
       viewModel.activeTerminalId = terminalId
       viewModel.showTerminalPanel = true
       #if os(iOS)
-      viewModel.showTerminalInteractiveSheet = true
+        viewModel.showTerminalInteractiveSheet = true
       #else
-      viewModel.showInlineTerminal = true
+        viewModel.showInlineTerminal = true
       #endif
     }
     Platform.services.playHaptic(.selection)
@@ -417,14 +545,14 @@ struct SessionDetailView: View {
     if let runtime = runtimeRegistry.runtimesByEndpointId[endpointId] {
       let token = runtime.connection.addListener { [weak controller] event in
         switch event {
-        case let .terminalOutput(tid, data) where tid == terminalId:
-          controller?.feedOutput(data)
-          controller?.setConnected(true)
-        case let .terminalExited(tid, _) where tid == terminalId:
-          controller?.setConnected(false)
-          controller?.removeListener?()
-        default:
-          break
+          case let .terminalOutput(tid, data) where tid == terminalId:
+            controller?.feedOutput(data)
+            controller?.setConnected(true)
+          case let .terminalExited(tid, _) where tid == terminalId:
+            controller?.setConnected(false)
+            controller?.removeListener?()
+          default:
+            break
         }
       }
       let connection = runtime.connection
@@ -445,11 +573,11 @@ struct SessionDetailView: View {
   // MARK: - Terminal Panel (macOS inline)
 
   #if os(macOS)
-  func terminalPanel(session: TerminalSessionController) -> some View {
-    TerminalView(session: session)
-      .frame(maxWidth: .infinity, minHeight: 200, maxHeight: 320)
-      .background(Color.backgroundCode)
-  }
+    func terminalPanel(session: TerminalSessionController) -> some View {
+      TerminalView(session: session)
+        .frame(maxWidth: .infinity, minHeight: 200, maxHeight: 320)
+        .background(Color.backgroundCode)
+    }
   #endif
 
   // MARK: - Helpers

--- a/OrbitDockNative/OrbitDock/Views/SessionDetail/SessionWorkerRoster.swift
+++ b/OrbitDockNative/OrbitDock/Views/SessionDetail/SessionWorkerRoster.swift
@@ -395,6 +395,10 @@ enum SessionWorkerRosterPlanner {
         title = "Shell"
         iconName = "terminal.fill"
         tint = .feedbackWarning
+      case let .commandExecution(commandExecution):
+        title = commandExecutionTitle(commandExecution)
+        iconName = "terminal.fill"
+        tint = commandExecutionTint(commandExecution)
       case .context:
         title = "Context"
         iconName = "info.circle.fill"
@@ -469,6 +473,10 @@ enum SessionWorkerRosterPlanner {
           ?? shellCommand.summary?.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty
           ?? shellCommand.command?.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty
           ?? shellCommand.title.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty
+      case let .commandExecution(commandExecution):
+        commandExecution.aggregatedOutput?.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty
+          ?? commandExecution.liveOutputPreview?.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty
+          ?? commandExecution.command.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty
       case let .task(task):
         task.resultText?.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty
           ?? task.summary?.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty
@@ -649,6 +657,8 @@ enum SessionWorkerRosterPlanner {
         "Reasoning"
       case .shellCommand:
         "Shell"
+      case let .commandExecution(commandExecution):
+        commandExecutionTitle(commandExecution)
       case .plan:
         "Plan"
       case .hook:
@@ -705,12 +715,21 @@ enum SessionWorkerRosterPlanner {
     return nil
   }
 
+  private static func linkedWorkerID(for child: ServerConversationActivityGroupChild) -> String? {
+    switch child {
+      case let .tool(tool):
+        linkedWorkerID(for: tool)
+      case .commandExecution:
+        nil
+    }
+  }
+
   private static func workerEventIcon(for entry: ServerConversationRowEntry) -> String {
     switch entry.row {
       case let .tool(tool):
         ToolCardStyle.icon(for: tool.title)
       case let .activityGroup(group):
-        group.children.first.map { ToolCardStyle.icon(for: $0.title) } ?? "square.stack.3d.up.fill"
+        group.children.first.map(workerEventIcon(for:)) ?? "square.stack.3d.up.fill"
       case let .worker(worker):
         visuals(for: worker.worker.agentType ?? "worker").iconName
       case .assistant:
@@ -719,6 +738,8 @@ enum SessionWorkerRosterPlanner {
         "brain"
       case .shellCommand:
         "terminal"
+      case let .commandExecution(commandExecution):
+        commandExecutionIcon(commandExecution)
       case .system, .context, .notice, .task, .approval, .question:
         "gearshape.2.fill"
       case .user:
@@ -773,8 +794,19 @@ enum SessionWorkerRosterPlanner {
         }
       case .thinking:
         ("Reasoning", .statusQuestion)
+      case let .commandExecution(commandExecution):
+        commandExecutionStatusPresentation(commandExecution)
       default:
         ("Captured", .textSecondary)
+    }
+  }
+
+  private static func workerEventIcon(for child: ServerConversationActivityGroupChild) -> String {
+    switch child {
+      case let .tool(tool):
+        ToolCardStyle.icon(for: tool.title)
+      case let .commandExecution(commandExecution):
+        commandExecutionIcon(commandExecution)
     }
   }
 
@@ -831,6 +863,8 @@ enum SessionWorkerRosterPlanner {
       case let .activityGroup(group):
         group.children.lazy.compactMap { assignmentPreview(for: $0) }.first
           ?? group.summary?.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty
+      case let .commandExecution(commandExecution):
+        commandExecution.command.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty
       default:
         nil
     }
@@ -845,6 +879,15 @@ enum SessionWorkerRosterPlanner {
       ?? tool.subtitle?.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty
   }
 
+  private static func assignmentPreview(for child: ServerConversationActivityGroupChild) -> String? {
+    switch child {
+      case let .tool(tool):
+        assignmentPreview(for: tool)
+      case let .commandExecution(commandExecution):
+        commandExecution.command.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty
+    }
+  }
+
   private static func reportPreview(for entry: ServerConversationRowEntry) -> String? {
     switch entry.row {
       case let .worker(worker):
@@ -857,6 +900,9 @@ enum SessionWorkerRosterPlanner {
           ?? tool.toolDisplay.liveOutputPreview?.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty
       case let .activityGroup(group):
         group.children.lazy.compactMap { reportPreview(for: $0) }.first
+      case let .commandExecution(commandExecution):
+        commandExecution.aggregatedOutput?.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty
+          ?? commandExecution.liveOutputPreview?.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty
       case let .task(task):
         task.resultText?.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty
           ?? task.summary?.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty
@@ -869,6 +915,16 @@ enum SessionWorkerRosterPlanner {
     tool.toolDisplay.outputDisplay?.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty
       ?? tool.toolDisplay.outputPreview?.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty
       ?? tool.toolDisplay.liveOutputPreview?.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty
+  }
+
+  private static func reportPreview(for child: ServerConversationActivityGroupChild) -> String? {
+    switch child {
+      case let .tool(tool):
+        reportPreview(for: tool)
+      case let .commandExecution(commandExecution):
+        commandExecution.aggregatedOutput?.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty
+          ?? commandExecution.liveOutputPreview?.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty
+      }
   }
 
   private static func parsedStringValue(from jsonString: String?, keys: [String]) -> String? {
@@ -904,10 +960,88 @@ enum SessionWorkerRosterPlanner {
         parseDate(worker.worker.lastActivityAt)
           ?? parseDate(worker.worker.startedAt)
           ?? parseDate(worker.worker.endedAt)
+      case .commandExecution:
+        nil
       case .shellCommand:
         nil
       case .activityGroup, .context, .notice, .task, .question, .approval, .plan, .hook, .handoff:
         nil
+    }
+  }
+
+  private static func commandExecutionTitle(
+    _ row: ServerConversationCommandExecutionRow
+  ) -> String {
+    guard let first = row.commandActions.first else { return "Command" }
+
+    switch first.type {
+      case .read:
+        if row.commandActions.allSatisfy({ $0.type == .read }) {
+          if row.commandActions.count == 1 {
+            return "Read"
+          }
+          return "Read \(row.commandActions.count) files"
+        }
+      case .search:
+        if row.commandActions.allSatisfy({ $0.type == .search }) {
+          return "Search"
+        }
+      case .listFiles:
+        if row.commandActions.allSatisfy({ $0.type == .listFiles }) {
+          return "List files"
+        }
+      case .unknown:
+        break
+    }
+
+    return "Command"
+  }
+
+  private static func commandExecutionIcon(
+    _ row: ServerConversationCommandExecutionRow
+  ) -> String {
+    if row.commandActions.allSatisfy({ $0.type == .read }) {
+      return "doc.text.magnifyingglass"
+    }
+    if row.commandActions.allSatisfy({ $0.type == .search || $0.type == .listFiles }) {
+      return "magnifyingglass"
+    }
+    return "terminal"
+  }
+
+  private static func commandExecutionTint(
+    _ row: ServerConversationCommandExecutionRow
+  ) -> Color {
+    switch row.status {
+      case .failed:
+        return .feedbackNegative
+      case .declined:
+        return .feedbackWarning
+      case .inProgress:
+        return .statusWorking
+      case .completed:
+        if row.commandActions.allSatisfy({ $0.type == .read }) {
+          return .toolRead
+        }
+        if row.commandActions.allSatisfy({ $0.type == .search || $0.type == .listFiles }) {
+          return .toolSearch
+        }
+        return .toolBash
+    }
+  }
+
+  private static func commandExecutionStatusPresentation(
+    _ row: ServerConversationCommandExecutionRow
+  ) -> (label: String, color: Color) {
+    switch row.status {
+      case .inProgress:
+        return ("Live", .statusWorking)
+      case .completed:
+        return ("Captured", .textSecondary)
+      case .failed:
+        return ("Error", .feedbackNegative)
+      case .declined:
+        return ("Declined", .feedbackWarning)
     }
   }
 }

--- a/OrbitDockNative/OrbitDock/Views/Sessions/Composer/ComposerTextArea.swift
+++ b/OrbitDockNative/OrbitDock/Views/Sessions/Composer/ComposerTextArea.swift
@@ -415,6 +415,10 @@ private func clampedSelection(_ selection: NSRange, maxLength: Int) -> NSRange {
         guard let coordinator, let textView else { return }
         coordinator.recalculateHeight(for: textView)
       }
+      textView.onFirstResponderChange = { [weak coordinator] isFocused in
+        guard let coordinator else { return }
+        coordinator.parent.onFocusEvent(isFocused ? .began : .ended(userInitiated: true))
+      }
 
       scrollView.documentView = textView
       coordinator.textView = textView
@@ -454,6 +458,7 @@ private func clampedSelection(_ selection: NSRange, maxLength: Int) -> NSRange {
         textView.canPasteImage = nil
         textView.onKeyCommand = nil
         textView.onBoundsWidthChange = nil
+        textView.onFirstResponderChange = nil
       }
       coordinator.textView = nil
     }
@@ -624,8 +629,21 @@ private func clampedSelection(_ selection: NSRange, maxLength: Int) -> NSRange {
     var canPasteImage: (() -> Bool)?
     var onKeyCommand: ((ComposerTextAreaKeyCommand) -> Bool)?
     var onBoundsWidthChange: (() -> Void)?
+    var onFirstResponderChange: ((Bool) -> Void)?
 
     private var previousBoundsWidth: CGFloat = 0
+
+    override func becomeFirstResponder() -> Bool {
+      let result = super.becomeFirstResponder()
+      if result { onFirstResponderChange?(true) }
+      return result
+    }
+
+    override func resignFirstResponder() -> Bool {
+      let result = super.resignFirstResponder()
+      if result { onFirstResponderChange?(false) }
+      return result
+    }
 
     override func layout() {
       super.layout()

--- a/OrbitDockNative/OrbitDock/Views/Sessions/Composer/DirectSessionComposerViewState.swift
+++ b/OrbitDockNative/OrbitDock/Views/Sessions/Composer/DirectSessionComposerViewState.swift
@@ -239,6 +239,7 @@ extension DirectSessionComposer {
       approvalPolicy: nil,
       approvalPolicyDetails: nil,
       sandboxMode: nil,
+      approvalsReviewer: nil,
       collaborationMode: nil,
       multiAgent: nil,
       personality: nil,

--- a/OrbitDockNative/OrbitDock/Views/Sessions/ControlDeck/ControlDeckApprovalZone.swift
+++ b/OrbitDockNative/OrbitDock/Views/Sessions/ControlDeck/ControlDeckApprovalZone.swift
@@ -1,0 +1,588 @@
+import SwiftUI
+
+struct ControlDeckApprovalZone: View {
+  let approval: ControlDeckApproval
+  let onApprove: () -> Void
+  let onApproveForSession: () -> Void
+  let onDeny: () -> Void
+  let onAnswer: (String, String?) -> Void
+  let onGrantPermission: () -> Void
+  let onGrantPermissionForSession: () -> Void
+  let onDenyPermission: () -> Void
+
+  @State private var answerDrafts: [String: String] = [:]
+  @State private var appeared = false
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: Spacing.md) {
+      header
+      if let detail = trimmedDetail {
+        summaryCard(detail)
+      }
+      content
+      actions
+    }
+    .padding(.horizontal, Spacing.md)
+    .padding(.vertical, Spacing.md)
+    .opacity(appeared ? 1 : 0)
+    .offset(y: appeared ? 0 : 8)
+    .onAppear {
+      withAnimation(Motion.gentle) {
+        appeared = true
+      }
+      #if os(iOS)
+        UIImpactFeedbackGenerator(style: .medium).impactOccurred()
+      #endif
+    }
+  }
+
+  // MARK: - Header
+
+  private var header: some View {
+    VStack(alignment: .leading, spacing: Spacing.sm_) {
+      HStack(spacing: Spacing.xs) {
+        statusBadge(
+          title: kindBadgeTitle,
+          icon: headerIcon,
+          tint: headerColor
+        )
+
+        promptCountBadge
+
+        Spacer(minLength: 0)
+      }
+
+      Text(approval.title)
+        .font(.system(size: TypeScale.title, weight: .semibold))
+        .foregroundStyle(Color.textPrimary)
+        .lineLimit(2)
+
+      Text(guidanceText)
+        .font(.system(size: TypeScale.caption, weight: .medium))
+        .foregroundStyle(Color.textSecondary)
+        .lineLimit(3)
+    }
+  }
+
+  private var headerIcon: String {
+    switch approval.kind {
+      case .tool: "terminal"
+      case .question: "questionmark.bubble"
+      case .permission: "lock.shield"
+    }
+  }
+
+  private var headerColor: Color {
+    switch approval.kind {
+      case .tool: .feedbackCaution
+      case .question: .accent
+      case .permission: .statusPermission
+    }
+  }
+
+  private var kindBadgeTitle: String {
+    switch approval.kind {
+      case .tool: "Review"
+      case .question: "Question"
+      case .permission: "Permission"
+    }
+  }
+
+  private var guidanceText: String {
+    switch approval.kind {
+      case .tool:
+        "Check the requested action before you approve it. Use the menu if you want to allow it for the whole session."
+      case .question:
+        "Answer the agent directly here so it can keep moving without leaving the deck."
+      case .permission:
+        "Review the requested access and decide whether to grant it once or for the rest of this session."
+    }
+  }
+
+  @ViewBuilder
+  private var promptCountBadge: some View {
+    if case let .question(prompts) = approval.kind, prompts.count > 1 {
+      Text("\(prompts.count) prompts")
+        .font(.system(size: TypeScale.mini, weight: .semibold, design: .monospaced))
+        .foregroundStyle(Color.textTertiary)
+        .padding(.horizontal, Spacing.xs)
+        .padding(.vertical, 2)
+        .background(Color.backgroundTertiary, in: Capsule())
+    }
+  }
+
+  // MARK: - Content
+
+  @ViewBuilder
+  private var content: some View {
+    switch approval.kind {
+      case let .tool(_, command, filePath, diff):
+        toolContent(command: command, filePath: filePath, diff: diff)
+      case let .question(prompts):
+        questionContent(prompts: prompts)
+      case let .permission(reason, descriptions):
+        permissionContent(reason: reason, descriptions: descriptions)
+    }
+  }
+
+  private func toolContent(command: String?, filePath: String?, diff: String?) -> some View {
+    VStack(alignment: .leading, spacing: Spacing.sm) {
+      approvalCard(title: "Requested Action", icon: "terminal", tint: .feedbackCaution) {
+        VStack(alignment: .leading, spacing: Spacing.sm_) {
+          if let command, !command.isEmpty {
+            metadataRow(title: "Command", value: command, multiLine: true)
+          }
+          if let filePath, !filePath.isEmpty {
+            metadataRow(title: "Path", value: filePath, multiLine: false)
+          }
+        }
+      }
+
+      if let diff, !diff.isEmpty {
+        ApprovalDiffPreview(diffString: diff)
+      }
+    }
+  }
+
+  private func questionContent(prompts: [ControlDeckApproval.Prompt]) -> some View {
+    VStack(alignment: .leading, spacing: Spacing.sm) {
+      ForEach(Array(prompts.enumerated()), id: \.element.id) { index, prompt in
+        approvalCard(
+          title: prompts.count > 1 ? "Prompt \(index + 1)" : "Prompt",
+          icon: "questionmark.bubble",
+          tint: .statusQuestion
+        ) {
+          VStack(alignment: .leading, spacing: Spacing.sm) {
+            Text(prompt.question)
+              .font(.system(size: TypeScale.caption, weight: .medium))
+              .foregroundStyle(Color.textPrimary)
+              .lineLimit(6)
+
+            if !prompt.options.isEmpty {
+              questionOptions(prompt)
+            } else {
+              answerField(prompt: prompt)
+            }
+          }
+        }
+      }
+    }
+  }
+
+  private func questionOptions(_ prompt: ControlDeckApproval.Prompt) -> some View {
+    VStack(spacing: Spacing.xxs) {
+      ForEach(prompt.options, id: \.self) { option in
+        Button {
+          onAnswer(option, prompt.id)
+        } label: {
+          HStack(spacing: Spacing.sm_) {
+            Image(systemName: "arrow.turn.down.right")
+              .font(.system(size: TypeScale.mini, weight: .semibold))
+              .foregroundStyle(Color.statusQuestion.opacity(0.9))
+
+            Text(option)
+              .font(.system(size: TypeScale.caption, weight: .medium))
+              .foregroundStyle(Color.textPrimary)
+              .frame(maxWidth: .infinity, alignment: .leading)
+              .lineLimit(2)
+          }
+          .padding(.horizontal, Spacing.sm)
+          .padding(.vertical, Spacing.sm_)
+          .background(Color.backgroundPrimary, in: RoundedRectangle(cornerRadius: Radius.md, style: .continuous))
+          .overlay(
+            RoundedRectangle(cornerRadius: Radius.md, style: .continuous)
+              .strokeBorder(Color.statusQuestion.opacity(OpacityTier.light), lineWidth: 1)
+          )
+        }
+        .buttonStyle(.plain)
+      }
+    }
+  }
+
+  private func answerField(prompt: ControlDeckApproval.Prompt) -> some View {
+    let text = Binding<String>(
+      get: { answerDrafts[prompt.id] ?? "" },
+      set: { answerDrafts[prompt.id] = $0 }
+    )
+
+    return HStack(spacing: Spacing.sm) {
+      Group {
+        if prompt.isSecret {
+          SecureField("Type your answer", text: text)
+        } else {
+          TextField("Type your answer", text: text)
+        }
+      }
+      .font(.system(size: TypeScale.caption))
+      .textFieldStyle(.plain)
+
+      Button {
+        let answer = text.wrappedValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !answer.isEmpty else { return }
+        onAnswer(answer, prompt.id)
+        answerDrafts[prompt.id] = ""
+      } label: {
+        Image(systemName: "arrow.up")
+          .font(.system(size: TypeScale.caption, weight: .bold))
+          .foregroundStyle(submissionText(prompt.id).isEmpty ? Color.textQuaternary : Color.backgroundPrimary)
+          .frame(width: 28, height: 28)
+          .background(
+            submissionText(prompt.id).isEmpty ? Color.backgroundPrimary : Color.statusQuestion,
+            in: Circle()
+          )
+      }
+      .buttonStyle(.plain)
+      .disabled(submissionText(prompt.id).isEmpty)
+    }
+    .padding(.horizontal, Spacing.sm)
+    .padding(.vertical, Spacing.sm_)
+    .background(Color.backgroundPrimary, in: RoundedRectangle(cornerRadius: Radius.md, style: .continuous))
+    .overlay(
+      RoundedRectangle(cornerRadius: Radius.md, style: .continuous)
+        .strokeBorder(Color.statusQuestion.opacity(OpacityTier.light), lineWidth: 1)
+    )
+  }
+
+  private func permissionContent(reason: String?, descriptions: [String]) -> some View {
+    VStack(alignment: .leading, spacing: Spacing.sm) {
+      if let reason, !reason.isEmpty {
+        approvalCard(title: "Why access is needed", icon: "lock.shield", tint: .statusPermission) {
+          Text(reason)
+            .font(.system(size: TypeScale.caption, weight: .medium))
+            .foregroundStyle(Color.textPrimary)
+            .lineLimit(4)
+        }
+      }
+
+      if !descriptions.isEmpty {
+        approvalCard(title: "Requested Access", icon: "key.horizontal", tint: .statusPermission) {
+          VStack(alignment: .leading, spacing: Spacing.xs) {
+            ForEach(descriptions, id: \.self) { description in
+              HStack(alignment: .top, spacing: Spacing.sm_) {
+                Circle()
+                  .fill(Color.statusPermission)
+                  .frame(width: 6, height: 6)
+                  .padding(.top, 4)
+
+                Text(description)
+                  .font(.system(size: TypeScale.caption, weight: .medium, design: .monospaced))
+                  .foregroundStyle(Color.textSecondary)
+                  .lineLimit(3)
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  // MARK: - Actions
+
+  @ViewBuilder
+  private var actions: some View {
+    switch approval.kind {
+      case .tool:
+        decisionFooter(
+          secondaryTitle: "Deny",
+          secondaryTint: .textSecondary,
+          secondaryAction: {
+            onDeny()
+            hapticDeny()
+          },
+          primaryTitle: "Approve Once",
+          primaryTint: .feedbackPositive,
+          primaryAction: {
+            onApprove()
+            hapticApprove()
+          },
+          menuActions: [
+            ("Approve for Session", {
+              onApproveForSession()
+              hapticApprove()
+            })
+          ],
+          footnote: "The primary action approves this request once. Use the menu if you want the approval to persist for the rest of the session."
+        )
+      case .question:
+        EmptyView()
+      case .permission:
+        decisionFooter(
+          secondaryTitle: "Deny",
+          secondaryTint: .textSecondary,
+          secondaryAction: {
+            onDenyPermission()
+            hapticDeny()
+          },
+          primaryTitle: "Grant Once",
+          primaryTint: .statusPermission,
+          primaryAction: {
+            onGrantPermission()
+            hapticApprove()
+          },
+          menuActions: [
+            ("Grant for Session", {
+              onGrantPermissionForSession()
+              hapticApprove()
+            })
+          ],
+          footnote: "Grant once when the access only makes sense for this step. Grant for session when you trust the rest of the work to need the same scope."
+        )
+    }
+  }
+
+  private func decisionFooter(
+    secondaryTitle: String,
+    secondaryTint: Color,
+    secondaryAction: @escaping () -> Void,
+    primaryTitle: String,
+    primaryTint: Color,
+    primaryAction: @escaping () -> Void,
+    menuActions: [(String, () -> Void)],
+    footnote: String
+  ) -> some View {
+    VStack(alignment: .leading, spacing: Spacing.sm_) {
+      let stackedLayout = approvalButtonLayout == .stacked
+
+      Group {
+        if stackedLayout {
+          VStack(spacing: Spacing.sm) {
+            splitPrimaryActionButton(
+              title: primaryTitle,
+              tint: primaryTint,
+              primaryAction: primaryAction,
+              menuActions: menuActions
+            )
+            secondaryButton(title: secondaryTitle, tint: secondaryTint, action: secondaryAction)
+          }
+        } else {
+          HStack(spacing: Spacing.sm) {
+            secondaryButton(title: secondaryTitle, tint: secondaryTint, action: secondaryAction)
+            splitPrimaryActionButton(
+              title: primaryTitle,
+              tint: primaryTint,
+              primaryAction: primaryAction,
+              menuActions: menuActions
+            )
+          }
+        }
+      }
+
+      Text(footnote)
+        .font(.system(size: TypeScale.micro, weight: .medium))
+        .foregroundStyle(Color.textTertiary)
+        .lineLimit(3)
+    }
+  }
+
+  private func splitPrimaryActionButton(
+    title: String,
+    tint: Color,
+    primaryAction: @escaping () -> Void,
+    menuActions: [(String, () -> Void)]
+  ) -> some View {
+    HStack(spacing: 0) {
+      Button(action: primaryAction) {
+        HStack(spacing: Spacing.sm_) {
+          Image(systemName: "checkmark.circle.fill")
+            .font(.system(size: TypeScale.caption, weight: .bold))
+
+          Text(title)
+            .font(.system(size: TypeScale.caption, weight: .semibold))
+            .lineLimit(1)
+        }
+        .foregroundStyle(Color.backgroundPrimary)
+        .frame(maxWidth: .infinity, minHeight: approvalButtonHeight)
+        .contentShape(Rectangle())
+      }
+      .buttonStyle(.plain)
+
+      if !menuActions.isEmpty {
+        Rectangle()
+          .fill(Color.backgroundPrimary.opacity(0.12))
+          .frame(width: 1)
+
+        Menu {
+          ForEach(Array(menuActions.enumerated()), id: \.offset) { _, action in
+            Button(action.0) { action.1() }
+          }
+        } label: {
+          HStack(spacing: Spacing.xs) {
+            Image(systemName: "ellipsis.circle")
+              .font(.system(size: TypeScale.caption, weight: .bold))
+            #if os(iOS)
+              if approvalButtonLayout == .stacked {
+                Text("More")
+                  .font(.system(size: TypeScale.caption, weight: .semibold))
+              }
+            #endif
+          }
+          .foregroundStyle(Color.backgroundPrimary)
+          .frame(minWidth: approvalMenuWidth, minHeight: approvalButtonHeight)
+          .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+      }
+    }
+    .background(tint, in: RoundedRectangle(cornerRadius: Radius.lg, style: .continuous))
+    .overlay(
+      RoundedRectangle(cornerRadius: Radius.lg, style: .continuous)
+        .strokeBorder(tint.opacity(0.95), lineWidth: 1)
+    )
+    .themeShadow(Shadow.glow(color: tint, intensity: 0.16))
+  }
+
+  private func secondaryButton(
+    title: String,
+    tint: Color,
+    action: @escaping () -> Void
+  ) -> some View {
+    Button(action: action) {
+      HStack(spacing: Spacing.sm_) {
+        Image(systemName: "xmark.circle.fill")
+          .font(.system(size: TypeScale.caption, weight: .bold))
+
+        Text(title)
+          .font(.system(size: TypeScale.caption, weight: .semibold))
+          .lineLimit(1)
+
+        Spacer(minLength: 0)
+      }
+      .foregroundStyle(tint)
+      .padding(.horizontal, Spacing.md)
+      .frame(maxWidth: .infinity, minHeight: approvalButtonHeight, alignment: .leading)
+      .contentShape(Rectangle())
+      .background(Color.backgroundPrimary, in: RoundedRectangle(cornerRadius: Radius.lg, style: .continuous))
+      .overlay(
+        RoundedRectangle(cornerRadius: Radius.lg, style: .continuous)
+          .strokeBorder(Color.panelBorder.opacity(OpacityTier.medium), lineWidth: 1)
+      )
+    }
+    .buttonStyle(.plain)
+  }
+
+  private var approvalButtonHeight: CGFloat {
+    #if os(iOS)
+      46
+    #else
+      40
+    #endif
+  }
+
+  private var approvalMenuWidth: CGFloat {
+    #if os(iOS)
+      approvalButtonLayout == .stacked ? 92 : 60
+    #else
+      44
+    #endif
+  }
+
+  private var approvalButtonLayout: ApprovalButtonLayout {
+    #if os(iOS)
+      return .stacked
+    #else
+      return .inline
+    #endif
+  }
+
+  private enum ApprovalButtonLayout {
+    case inline
+    case stacked
+  }
+
+  private func approvalCard<Content: View>(
+    title: String,
+    icon: String,
+    tint: Color,
+    @ViewBuilder content: () -> Content
+  ) -> some View {
+    VStack(alignment: .leading, spacing: Spacing.sm) {
+      HStack(spacing: Spacing.xs) {
+        Image(systemName: icon)
+          .font(.system(size: TypeScale.mini, weight: .semibold))
+          .foregroundStyle(tint)
+
+        Text(title)
+          .font(.system(size: TypeScale.caption, weight: .semibold))
+          .foregroundStyle(Color.textSecondary)
+      }
+
+      content()
+    }
+    .padding(Spacing.md)
+    .background(Color.backgroundTertiary, in: RoundedRectangle(cornerRadius: Radius.lg, style: .continuous))
+    .overlay(
+      RoundedRectangle(cornerRadius: Radius.lg, style: .continuous)
+        .strokeBorder(tint.opacity(OpacityTier.light), lineWidth: 1)
+    )
+  }
+
+  private func summaryCard(_ text: String) -> some View {
+    HStack(alignment: .top, spacing: Spacing.sm) {
+      Image(systemName: headerIcon)
+        .font(.system(size: TypeScale.caption, weight: .semibold))
+        .foregroundStyle(headerColor)
+        .padding(.top, 1)
+
+      Text(text)
+        .font(.system(size: TypeScale.caption, weight: .medium))
+        .foregroundStyle(Color.textSecondary)
+        .lineLimit(4)
+    }
+    .padding(Spacing.md)
+    .background(headerColor.opacity(OpacityTier.light), in: RoundedRectangle(cornerRadius: Radius.lg, style: .continuous))
+  }
+
+  private func statusBadge(title: String, icon: String, tint: Color) -> some View {
+    HStack(spacing: Spacing.gap) {
+      Image(systemName: icon)
+        .font(.system(size: TypeScale.mini, weight: .semibold))
+
+      Text(title.uppercased())
+        .font(.system(size: TypeScale.mini, weight: .semibold, design: .monospaced))
+    }
+    .foregroundStyle(tint)
+    .padding(.horizontal, Spacing.sm_)
+    .padding(.vertical, Spacing.gap)
+    .background(tint.opacity(OpacityTier.light), in: Capsule())
+  }
+
+  private func metadataRow(title: String, value: String, multiLine: Bool) -> some View {
+    VStack(alignment: .leading, spacing: Spacing.xxs) {
+      Text(title)
+        .font(.system(size: TypeScale.mini, weight: .semibold, design: .monospaced))
+        .foregroundStyle(Color.textTertiary)
+      Text(value)
+        .font(.system(size: TypeScale.caption, weight: .medium, design: .monospaced))
+        .foregroundStyle(Color.textPrimary)
+        .lineLimit(multiLine ? 4 : 1)
+        .textSelection(.enabled)
+    }
+  }
+
+  private var trimmedDetail: String? {
+    guard let detail = approval.detail?.trimmingCharacters(in: .whitespacesAndNewlines),
+          !detail.isEmpty
+    else {
+      return nil
+    }
+    return detail
+  }
+
+  private func submissionText(_ promptId: String) -> String {
+    answerDrafts[promptId]?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+  }
+
+  // MARK: - Haptics
+
+  private func hapticApprove() {
+    #if os(iOS)
+      UINotificationFeedbackGenerator().notificationOccurred(.success)
+    #endif
+  }
+
+  private func hapticDeny() {
+    #if os(iOS)
+      UINotificationFeedbackGenerator().notificationOccurred(.warning)
+    #endif
+  }
+}

--- a/OrbitDockNative/OrbitDock/Views/Sessions/ControlDeck/ControlDeckAttachmentTray.swift
+++ b/OrbitDockNative/OrbitDock/Views/Sessions/ControlDeck/ControlDeckAttachmentTray.swift
@@ -1,0 +1,188 @@
+import SwiftUI
+#if os(macOS)
+  import AppKit
+#else
+  import UIKit
+#endif
+
+struct ControlDeckAttachmentTray: View {
+  let attachments: [ControlDeckAttachmentItem]
+  let onRemove: (String) -> Void
+
+  @State private var previewItem: ControlDeckAttachmentItem?
+
+  var body: some View {
+    ScrollView(.horizontal, showsIndicators: false) {
+      HStack(spacing: Spacing.xs) {
+        ForEach(attachments) { item in
+          chipView(item)
+            .onTapGesture {
+              if case .image = item.kind {
+                previewItem = item
+              }
+            }
+        }
+      }
+    }
+    .scrollIndicators(.hidden)
+    #if os(iOS)
+      .fullScreenCover(item: $previewItem) { item in
+        imagePreviewOverlay(item)
+      }
+    #else
+      .sheet(item: $previewItem) { item in
+        imagePreviewSheet(item)
+      }
+    #endif
+  }
+
+  // MARK: - Image Preview (iOS — full screen)
+
+  #if os(iOS)
+    @ViewBuilder
+    private func imagePreviewOverlay(_ item: ControlDeckAttachmentItem) -> some View {
+      if case let .image(img) = item.kind {
+        ZStack {
+          Color.black.ignoresSafeArea()
+
+          if let image = platformImage(from: previewData(for: img)) {
+            image
+              .resizable()
+              .aspectRatio(contentMode: .fit)
+              .padding(Spacing.md)
+          } else {
+            VStack(spacing: Spacing.sm) {
+              Image(systemName: "photo")
+                .font(.system(size: 28, weight: .semibold))
+                .foregroundStyle(.white.opacity(0.7))
+
+              Text("Unable to preview image")
+                .font(.system(size: TypeScale.body, weight: .semibold))
+                .foregroundStyle(.white.opacity(0.82))
+            }
+          }
+        }
+        .overlay(alignment: .topTrailing) {
+          Button { previewItem = nil } label: {
+            Image(systemName: "xmark.circle.fill")
+              .font(.system(size: 28))
+              .foregroundStyle(.white.opacity(0.8))
+              .padding(Spacing.lg)
+          }
+        }
+        .overlay(alignment: .bottom) {
+          Text(img.displayName)
+            .font(.system(size: TypeScale.caption, weight: .medium))
+            .foregroundStyle(.white.opacity(0.7))
+            .padding(.bottom, Spacing.xl)
+        }
+        .statusBarHidden()
+      }
+    }
+  #endif
+
+  // MARK: - Image Preview (macOS — sheet)
+
+  #if os(macOS)
+    @ViewBuilder
+    private func imagePreviewSheet(_ item: ControlDeckAttachmentItem) -> some View {
+      if case let .image(img) = item.kind, let image = platformImage(from: previewData(for: img)) {
+        ZoomableImagePreview(image: image, title: img.displayName) {
+          previewItem = nil
+        }
+        .frame(minWidth: 480, idealWidth: 720, minHeight: 420, idealHeight: 560)
+      }
+    }
+  #endif
+
+  private func chipView(_ item: ControlDeckAttachmentItem) -> some View {
+    HStack(spacing: Spacing.xs) {
+      chipIcon(item)
+      chipLabel(item)
+
+      Button { onRemove(item.id) } label: {
+        Image(systemName: "xmark")
+          .font(.system(size: 8, weight: .bold))
+          .foregroundStyle(Color.textTertiary)
+          .frame(width: 14, height: 14)
+          .background(Color.textQuaternary.opacity(OpacityTier.medium), in: Circle())
+      }
+      .buttonStyle(.plain)
+    }
+    .padding(.leading, Spacing.sm_)
+    .padding(.trailing, Spacing.xs)
+    .padding(.vertical, Spacing.xs)
+    .background(chipTint(item).opacity(OpacityTier.light), in: Capsule())
+    .overlay(Capsule().strokeBorder(chipTint(item).opacity(OpacityTier.medium), lineWidth: 0.5))
+  }
+
+  @ViewBuilder
+  private func chipIcon(_ item: ControlDeckAttachmentItem) -> some View {
+    switch item.kind {
+      case let .image(img):
+        if let thumbnailImage = platformImage(from: thumbnailData(for: img)) {
+          thumbnailImage
+            .resizable()
+            .aspectRatio(contentMode: .fill)
+            .frame(width: 20, height: 20)
+            .clipShape(RoundedRectangle(cornerRadius: 3, style: .continuous))
+        } else {
+          Image(systemName: "photo")
+            .font(.system(size: TypeScale.micro, weight: .semibold))
+            .foregroundStyle(chipTint(item))
+        }
+      case let .mention(mention):
+        Image(systemName: fileIcon(mention.name))
+          .font(.system(size: TypeScale.micro, weight: .semibold))
+          .foregroundStyle(chipTint(item))
+    }
+  }
+
+  private func platformImage(from data: Data?) -> Image? {
+    guard let data else { return nil }
+    #if os(macOS)
+      guard let nsImage = NSImage(data: data) else { return nil }
+      return Image(nsImage: nsImage)
+    #else
+      guard let uiImage = UIImage(data: data) else { return nil }
+      return Image(uiImage: uiImage)
+    #endif
+  }
+
+  private func thumbnailData(for image: ControlDeckImageDraft) -> Data? {
+    image.thumbnailData ?? image.uploadData
+  }
+
+  private func previewData(for image: ControlDeckImageDraft) -> Data? {
+    image.uploadData.isEmpty ? image.thumbnailData : image.uploadData
+  }
+
+  private func chipLabel(_ item: ControlDeckAttachmentItem) -> some View {
+    let name: String = switch item.kind {
+      case let .image(img): img.displayName
+      case let .mention(m): m.name
+    }
+    return Text(name)
+      .font(.system(size: TypeScale.caption, weight: .medium))
+      .foregroundStyle(Color.textPrimary)
+      .lineLimit(1)
+  }
+
+  private func chipTint(_ item: ControlDeckAttachmentItem) -> Color {
+    switch item.kind {
+      case .image: .providerClaude
+      case .mention: .providerCodex
+    }
+  }
+
+  private func fileIcon(_ name: String) -> String {
+    let ext = name.split(separator: ".").last?.lowercased() ?? ""
+    switch ext {
+      case "swift": return "swift"
+      case "rs": return "terminal"
+      case "md": return "doc.plaintext"
+      case "json", "yaml", "yml", "toml": return "curlybraces"
+      default: return "doc.text"
+    }
+  }
+}

--- a/OrbitDockNative/OrbitDock/Views/Sessions/ControlDeck/ControlDeckCompletionPanel.swift
+++ b/OrbitDockNative/OrbitDock/Views/Sessions/ControlDeck/ControlDeckCompletionPanel.swift
@@ -1,0 +1,219 @@
+import SwiftUI
+
+struct ControlDeckCompletionPanel: View {
+  let mode: ControlDeckCompletionMode
+  let suggestions: [ControlDeckCompletionSuggestion]
+  let selectedIndex: Int
+  let onSelect: (ControlDeckCompletionSuggestion) -> Void
+
+  @Environment(\.horizontalSizeClass) private var horizontalSizeClass
+
+  private var isCompactIOS: Bool {
+    #if os(iOS)
+      horizontalSizeClass == .compact
+    #else
+      false
+    #endif
+  }
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 0) {
+      HStack(spacing: Spacing.sm) {
+        HStack(spacing: Spacing.xs) {
+          Image(systemName: headerIcon)
+            .font(.system(size: TypeScale.micro, weight: .bold))
+            .foregroundStyle(headerTint)
+
+          Text(headerTitle)
+            .font(.system(size: TypeScale.mini, weight: .semibold))
+            .foregroundStyle(Color.textPrimary)
+
+          Text("\(suggestions.prefix(8).count)")
+            .font(.system(size: TypeScale.micro, weight: .bold, design: .monospaced))
+            .foregroundStyle(Color.textSecondary)
+            .padding(.horizontal, Spacing.xs)
+            .padding(.vertical, Spacing.gap)
+            .background(Color.backgroundPrimary, in: Capsule())
+        }
+        .padding(.horizontal, Spacing.sm)
+        .padding(.vertical, Spacing.xs)
+        .background(headerTint.opacity(OpacityTier.light), in: Capsule())
+
+        Spacer(minLength: 0)
+
+        if !isCompactIOS {
+          HStack(spacing: Spacing.xs) {
+            keyHint("\u{2191}\u{2193}")
+            keyHint("tab")
+            keyHint("esc")
+          }
+        }
+      }
+      .padding(.horizontal, isCompactIOS ? Spacing.sm : Spacing.md)
+      .padding(.top, isCompactIOS ? Spacing.sm : Spacing.md)
+      .padding(.bottom, isCompactIOS ? Spacing.xs : Spacing.sm)
+
+      Rectangle()
+        .fill(Color.panelBorder.opacity(OpacityTier.medium))
+        .frame(height: 1)
+        .padding(.horizontal, isCompactIOS ? Spacing.xs : Spacing.sm)
+
+      ScrollView {
+        VStack(alignment: .leading, spacing: Spacing.xs) {
+          if suggestions.isEmpty {
+            emptyState
+          } else {
+            ForEach(Array(suggestions.prefix(8).enumerated()), id: \.element.id) { index, suggestion in
+              suggestionRow(suggestion, index: index)
+            }
+          }
+        }
+        .padding(isCompactIOS ? Spacing.xs : Spacing.sm)
+      }
+      .scrollIndicators(.hidden)
+      .frame(maxHeight: isCompactIOS ? 188 : 224)
+    }
+    .background(Color.backgroundSecondary, in: RoundedRectangle(cornerRadius: Radius.lg, style: .continuous))
+    .overlay(
+      RoundedRectangle(cornerRadius: Radius.lg, style: .continuous)
+        .strokeBorder(Color.panelBorder, lineWidth: 1)
+    )
+    .shadow(color: .black.opacity(0.24), radius: 16, y: 6)
+  }
+
+  // MARK: - Helpers
+
+  private var headerIcon: String {
+    switch mode {
+      case .mention: "at"
+      case .skill: "bolt.fill"
+      case .command: "slash.circle"
+      case .inactive: "magnifyingglass"
+    }
+  }
+
+  private var headerTitle: String {
+    switch mode {
+      case .mention: "Files"
+      case .skill: "Skills"
+      case .command: "Commands"
+      case .inactive: "Suggestions"
+    }
+  }
+
+  private var headerTint: Color {
+    switch mode {
+      case .mention: .providerCodex
+      case .skill: .accent
+      case .command: .statusQuestion
+      case .inactive: .textSecondary
+    }
+  }
+
+  private func icon(_ kind: ControlDeckCompletionSuggestion.Kind) -> String {
+    switch kind {
+      case .file: "at"
+      case .skill: "bolt.fill"
+      case .command: "slash.circle"
+    }
+  }
+
+  private func tint(_ kind: ControlDeckCompletionSuggestion.Kind) -> Color {
+    switch kind {
+      case .file: .providerCodex
+      case .skill: .accent
+      case .command: .statusQuestion
+    }
+  }
+
+  private func keyHint(_ key: String) -> some View {
+    Text(key)
+      .font(.system(size: TypeScale.micro, weight: .semibold, design: .monospaced))
+      .foregroundStyle(Color.textTertiary)
+      .padding(.horizontal, Spacing.xs)
+      .padding(.vertical, Spacing.gap)
+      .background(Color.backgroundTertiary, in: RoundedRectangle(cornerRadius: Radius.xs, style: .continuous))
+      .overlay(
+        RoundedRectangle(cornerRadius: Radius.xs, style: .continuous)
+          .strokeBorder(Color.panelBorder, lineWidth: 0.5)
+      )
+  }
+
+  private func suggestionRow(_ suggestion: ControlDeckCompletionSuggestion, index: Int) -> some View {
+    let isSelected = index == selectedIndex
+
+    return Button { onSelect(suggestion) } label: {
+      HStack(spacing: Spacing.sm) {
+        ZStack {
+          RoundedRectangle(cornerRadius: Radius.sm, style: .continuous)
+            .fill(tint(suggestion.kind).opacity(isSelected ? OpacityTier.medium : OpacityTier.light))
+          Image(systemName: icon(suggestion.kind))
+            .font(.system(size: isCompactIOS ? TypeScale.mini : TypeScale.caption, weight: .bold))
+            .foregroundStyle(tint(suggestion.kind))
+        }
+        .frame(width: isCompactIOS ? 24 : 28, height: isCompactIOS ? 24 : 28)
+
+        VStack(alignment: .leading, spacing: Spacing.gap) {
+          Text(suggestion.title)
+            .font(.system(size: isCompactIOS ? TypeScale.caption : TypeScale.body, weight: .semibold))
+            .foregroundStyle(Color.textPrimary)
+            .lineLimit(1)
+
+          if let subtitle = suggestion.subtitle, !subtitle.isEmpty {
+            Text(subtitle)
+              .font(.system(size: TypeScale.micro, weight: .medium, design: .monospaced))
+              .foregroundStyle(isSelected ? Color.textSecondary : Color.textTertiary)
+              .lineLimit(1)
+          }
+        }
+
+        Spacer(minLength: 0)
+
+        if isSelected {
+          HStack(spacing: Spacing.xxs) {
+            Image(systemName: "arrow.turn.down.left")
+              .font(.system(size: TypeScale.micro, weight: .bold))
+            Text("Insert")
+              .font(.system(size: TypeScale.micro, weight: .semibold))
+          }
+          .foregroundStyle(Color.textSecondary)
+        }
+      }
+      .padding(.horizontal, isCompactIOS ? Spacing.sm : Spacing.md)
+      .padding(.vertical, isCompactIOS ? Spacing.sm_ : Spacing.sm)
+      .background(
+        RoundedRectangle(cornerRadius: Radius.md, style: .continuous)
+          .fill(isSelected ? headerTint.opacity(OpacityTier.light) : Color.backgroundPrimary)
+      )
+      .overlay(
+        RoundedRectangle(cornerRadius: Radius.md, style: .continuous)
+          .strokeBorder(
+            isSelected ? headerTint.opacity(OpacityTier.medium) : Color.panelBorder.opacity(0.55),
+            lineWidth: 1
+          )
+      )
+      .contentShape(Rectangle())
+    }
+    .buttonStyle(.plain)
+  }
+
+  private var emptyState: some View {
+    HStack(spacing: Spacing.sm) {
+      Image(systemName: "sparkles")
+        .font(.system(size: TypeScale.caption, weight: .semibold))
+        .foregroundStyle(Color.textQuaternary)
+
+      Text("No matches yet")
+        .font(.system(size: TypeScale.body, weight: .medium))
+        .foregroundStyle(Color.textSecondary)
+    }
+    .padding(.horizontal, Spacing.md)
+    .padding(.vertical, Spacing.md)
+    .frame(maxWidth: .infinity, alignment: .leading)
+    .background(Color.backgroundPrimary, in: RoundedRectangle(cornerRadius: Radius.md, style: .continuous))
+    .overlay(
+      RoundedRectangle(cornerRadius: Radius.md, style: .continuous)
+        .strokeBorder(Color.panelBorder.opacity(0.55), lineWidth: 1)
+    )
+  }
+}

--- a/OrbitDockNative/OrbitDock/Views/Sessions/ControlDeck/ControlDeckPreferencesEncoder.swift
+++ b/OrbitDockNative/OrbitDock/Views/Sessions/ControlDeck/ControlDeckPreferencesEncoder.swift
@@ -1,0 +1,47 @@
+import Foundation
+
+enum ControlDeckPreferencesEncoder {
+  static func encode(_ preferences: ControlDeckPreferences) -> ServerControlDeckPreferences {
+    ServerControlDeckPreferences(
+      density: encodeDensity(preferences.density),
+      showWhenEmpty: encodeEmptyVisibility(preferences.showWhenEmpty),
+      modules: preferences.modules.map { pref in
+        ServerControlDeckModulePreference(
+          module: encodeModule(pref.module),
+          visible: pref.visible
+        )
+      }
+    )
+  }
+
+  private static func encodeDensity(_ density: ControlDeckDensity) -> ServerControlDeckDensity {
+    switch density {
+      case .comfortable: .comfortable
+      case .compact: .compact
+    }
+  }
+
+  private static func encodeEmptyVisibility(_ vis: ControlDeckEmptyVisibility) -> ServerControlDeckEmptyVisibility {
+    switch vis {
+      case .auto: .auto
+      case .always: .always
+      case .hidden: .hidden
+    }
+  }
+
+  private static func encodeModule(_ module: ControlDeckStatusModule) -> ServerControlDeckModule {
+    switch module {
+      case .connection: .connection
+      case .autonomy: .autonomy
+      case .approvalMode: .approvalMode
+      case .collaborationMode: .collaborationMode
+      case .autoReview: .autoReview
+      case .tokens: .tokens
+      case .model: .model
+      case .effort: .effort
+      case .branch: .branch
+      case .cwd: .cwd
+      case .attachments: .attachments
+    }
+  }
+}

--- a/OrbitDockNative/OrbitDock/Views/Sessions/ControlDeck/ControlDeckPresentationBuilder.swift
+++ b/OrbitDockNative/OrbitDock/Views/Sessions/ControlDeck/ControlDeckPresentationBuilder.swift
@@ -1,0 +1,337 @@
+import Foundation
+
+enum ControlDeckPresentationBuilder {
+  static func build(
+    snapshot: ControlDeckSnapshot,
+    isLoading: Bool,
+    hasPendingApproval: Bool = false,
+    availableModels: [String] = []
+  ) -> ControlDeckPresentation {
+    let state = snapshot.state
+    let mode = resolveMode(state: state, hasPendingApproval: hasPendingApproval)
+
+    return ControlDeckPresentation(
+      mode: mode,
+      controlModeLabel: controlModeLabel(state.controlMode),
+      lifecycleLabel: lifecycleLabel(state.lifecycle),
+      lifecycleTint: lifecycleTint(state.lifecycle),
+      acceptsUserInput: state.acceptsUserInput,
+      supportsImages: snapshot.capabilities.supportsImages,
+      headerSubtitle: headerSubtitle(state: state, isLoading: isLoading),
+      statusModules: buildStatusModules(
+        state: state,
+        capabilities: snapshot.capabilities,
+        preferences: snapshot.preferences,
+        tokenStatus: snapshot.tokenStatus,
+        availableModels: availableModels
+      ),
+      placeholder: placeholder(for: mode),
+      sendTint: sendTint(for: mode)
+    )
+  }
+
+  // MARK: - Mode Resolution
+
+  private static func resolveMode(state: ControlDeckSessionState, hasPendingApproval: Bool = false) -> ControlDeckMode {
+    if state.lifecycle == .ended { return .disabled }
+    if hasPendingApproval { return .approval }
+    if state.steerable, !state.acceptsUserInput { return .steer }
+    if state.acceptsUserInput { return .compose }
+    return .disabled
+  }
+
+  private static func placeholder(for mode: ControlDeckMode) -> String {
+    switch mode {
+      case .compose: "Message the session\u{2026}"
+      case .steer: "Steer the session\u{2026}"
+      case .approval: "Respond to approval\u{2026}"
+      case .disabled: "Session ended"
+    }
+  }
+
+  private static func sendTint(for mode: ControlDeckMode) -> String {
+    switch mode {
+      case .compose: "accent"
+      case .steer: "accent"
+      case .approval: "accent"
+      case .disabled: "textQuaternary"
+    }
+  }
+
+  // MARK: - Status Modules
+
+  static func buildStatusModules(
+    state: ControlDeckSessionState,
+    capabilities: ControlDeckCapabilities,
+    preferences: ControlDeckPreferences,
+    tokenStatus: ControlDeckTokenStatus,
+    availableModels: [String] = []
+  ) -> [ControlDeckStatusModuleItem] {
+    let visibleSet = Set(
+      preferences.modules.filter(\.visible).map(\.module)
+    )
+    let available = Set(capabilities.availableStatusModules)
+
+    // Connection is an app-level concern, not a session concern — filter it out
+    return capabilities.availableStatusModules.compactMap { module in
+      guard module != .connection,
+            available.contains(module),
+            visibleSet.contains(module) else { return nil }
+      return moduleItem(
+        module,
+        state: state,
+        capabilities: capabilities,
+        tokenStatus: tokenStatus,
+        availableModels: availableModels
+      )
+    }
+  }
+
+  // MARK: - Private Helpers
+
+  private static func controlModeLabel(_ mode: ControlDeckControlMode) -> String {
+    switch mode {
+      case .direct: "Direct"
+      case .passive: "Passive"
+    }
+  }
+
+  private static func lifecycleLabel(_ lifecycle: ControlDeckLifecycle) -> String {
+    switch lifecycle {
+      case .open: "Open"
+      case .resumable: "Resumable"
+      case .ended: "Ended"
+    }
+  }
+
+  private static func lifecycleTint(_ lifecycle: ControlDeckLifecycle) -> String {
+    switch lifecycle {
+      case .open: "feedbackPositive"
+      case .resumable: "feedbackCaution"
+      case .ended: "statusEnded"
+    }
+  }
+
+  private static func headerSubtitle(state: ControlDeckSessionState, isLoading: Bool) -> String {
+    if isLoading { return "Syncing\u{2026}" }
+    switch state.lifecycle {
+      case .open: return "Ready"
+      case .resumable: return "Session paused"
+      case .ended: return "Session ended"
+    }
+  }
+
+  private static func moduleItem(
+    _ module: ControlDeckStatusModule,
+    state: ControlDeckSessionState,
+    capabilities: ControlDeckCapabilities,
+    tokenStatus: ControlDeckTokenStatus,
+    availableModels: [String] = []
+  ) -> ControlDeckStatusModuleItem? {
+    let folder = (state.currentCwd ?? state.projectPath).split(separator: "/").last.map(String.init) ?? "\u{2014}"
+    let effortOptions = ["low", "medium", "high"]
+
+    switch module {
+      case .connection:
+        return ControlDeckStatusModuleItem(
+          id: .connection,
+          label: "Connected",
+          icon: "wifi",
+          tintName: "feedbackPositive",
+          selectedValue: nil,
+          reviewerValue: nil,
+          interaction: .readOnly
+        )
+      case .autonomy:
+        return ControlDeckStatusModuleItem(
+          id: .autonomy,
+          label: optionLabel(
+            for: state.config.permissionMode,
+            options: capabilities.permissionModeOptions,
+            fallback: "Default"
+          ),
+          icon: "shield",
+          tintName: "accent",
+          selectedValue: state.config.permissionMode,
+          reviewerValue: nil,
+          interaction: .picker(options: pickerOptions(from: capabilities.permissionModeOptions))
+        )
+      case .approvalMode:
+        return ControlDeckStatusModuleItem(
+          id: .approvalMode,
+          label: optionLabel(
+            for: state.config.approvalPolicy,
+            options: capabilities.approvalModeOptions,
+            fallback: "Default"
+          ),
+          icon: "checkmark.shield.fill",
+          tintName: "accent",
+          selectedValue: state.config.approvalPolicy,
+          reviewerValue: state.config.approvalsReviewer?.rawValue,
+          interaction: .picker(options: pickerOptions(from: capabilities.approvalModeOptions))
+        )
+      case .collaborationMode:
+        return ControlDeckStatusModuleItem(
+          id: .collaborationMode,
+          label: optionLabel(
+            for: state.config.collaborationMode,
+            options: capabilities.collaborationModeOptions,
+            fallback: "Default"
+          ),
+          icon: "person.2",
+          tintName: "accent",
+          selectedValue: state.config.collaborationMode,
+          reviewerValue: nil,
+          interaction: .picker(options: pickerOptions(from: capabilities.collaborationModeOptions))
+        )
+      case .autoReview:
+        let currentAutoReview = autoReviewOption(
+          approvalPolicy: state.config.approvalPolicy,
+          sandboxMode: state.config.sandboxMode,
+          options: capabilities.autoReviewOptions
+        )
+        return ControlDeckStatusModuleItem(
+          id: .autoReview,
+          label: currentAutoReview?.label ?? "Custom",
+          icon: "eye",
+          tintName: autoReviewTintName(optionValue: currentAutoReview?.value),
+          selectedValue: currentAutoReview?.value,
+          reviewerValue: nil,
+          interaction: .picker(options: autoReviewPickerOptions(from: capabilities.autoReviewOptions))
+        )
+      case .tokens:
+        return ControlDeckStatusModuleItem(
+          id: .tokens,
+          label: tokenStatus.label,
+          icon: "memorychip",
+          tintName: tokenTintName(tokenStatus.tone),
+          selectedValue: nil,
+          reviewerValue: nil,
+          interaction: .readOnly
+        )
+      case .model:
+        let canPick = capabilities.allowPerTurnModelOverride && !availableModels.isEmpty
+        return ControlDeckStatusModuleItem(
+          id: .model,
+          label: shortModelLabel(state.config.model),
+          icon: "cpu",
+          tintName: "textTertiary",
+          selectedValue: state.config.model,
+          reviewerValue: nil,
+          interaction: canPick ? .picker(options: availableModels.map { .init(value: $0, label: $0) }) : .readOnly
+        )
+      case .effort:
+        return ControlDeckStatusModuleItem(
+          id: .effort,
+          label: state.config.effort?.capitalized ?? "Default",
+          icon: "gauge.medium",
+          tintName: "textTertiary",
+          selectedValue: state.config.effort,
+          reviewerValue: nil,
+          interaction: .picker(options: effortOptions.map { .init(value: $0, label: $0.capitalized) })
+        )
+      case .branch:
+        // Hide branch module when no git data — showing "—" with the branch icon
+        // looks like a signal strength indicator at small sizes
+        guard let branchName = state.gitBranch, !branchName.isEmpty else {
+          return nil
+        }
+        return ControlDeckStatusModuleItem(
+          id: .branch,
+          label: branchName,
+          icon: "arrow.triangle.branch",
+          tintName: "gitBranch",
+          selectedValue: nil,
+          reviewerValue: nil,
+          interaction: .readOnly
+        )
+      case .cwd:
+        return ControlDeckStatusModuleItem(
+          id: .cwd,
+          label: folder,
+          icon: "folder",
+          tintName: "textTertiary",
+          selectedValue: nil,
+          reviewerValue: nil,
+          interaction: .readOnly
+        )
+      case .attachments:
+        return ControlDeckStatusModuleItem(
+          id: .attachments,
+          label: "Attachments",
+          icon: "paperclip",
+          tintName: "textTertiary",
+          selectedValue: nil,
+          reviewerValue: nil,
+          interaction: .readOnly
+        )
+    }
+  }
+
+  // MARK: - Model Display
+
+  private static func shortModelLabel(_ model: String?) -> String {
+    guard let model else { return "Default" }
+    // Strip common prefixes for compact display
+    let shortened = model
+      .replacingOccurrences(of: "claude-", with: "")
+      .replacingOccurrences(of: "-20251001", with: "")
+    return shortened
+  }
+
+  private static func optionLabel(
+    for value: String?,
+    options: [ControlDeckPickerOption],
+    fallback: String
+  ) -> String {
+    guard let value else { return fallback }
+    return options.first(where: { $0.value.caseInsensitiveCompare(value) == .orderedSame })?.label ?? value
+  }
+
+  private static func pickerOptions(
+    from options: [ControlDeckPickerOption]
+  ) -> [ControlDeckStatusModuleItem.Option] {
+    options.map { option in
+      ControlDeckStatusModuleItem.Option(value: option.value, label: option.label)
+    }
+  }
+
+  private static func autoReviewPickerOptions(
+    from options: [ControlDeckAutoReviewOption]
+  ) -> [ControlDeckStatusModuleItem.Option] {
+    options.map { option in
+      ControlDeckStatusModuleItem.Option(value: option.value, label: option.label)
+    }
+  }
+
+  private static func autoReviewOption(
+    approvalPolicy: String?,
+    sandboxMode: String?,
+    options: [ControlDeckAutoReviewOption]
+  ) -> ControlDeckAutoReviewOption? {
+    options.first { option in
+      option.approvalPolicy == approvalPolicy && option.sandboxMode == sandboxMode
+    }
+  }
+
+  private static func autoReviewTintName(optionValue: String?) -> String {
+    switch optionValue {
+      case "locked": "autonomyLocked"
+      case "guarded": "autonomyGuarded"
+      case "autonomous": "autonomyAutonomous"
+      case "open": "autonomyOpen"
+      case "full_auto": "autonomyFullAuto"
+      case "unrestricted": "autonomyUnrestricted"
+      default: "accent"
+    }
+  }
+
+  private static func tokenTintName(_ tone: ControlDeckTokenStatus.Tone) -> String {
+    switch tone {
+      case .muted: "textQuaternary"
+      case .normal: "textTertiary"
+      case .caution: "feedbackCaution"
+      case .critical: "statusPermission"
+    }
+  }
+}

--- a/OrbitDockNative/OrbitDock/Views/Sessions/ControlDeck/ControlDeckScreen.swift
+++ b/OrbitDockNative/OrbitDock/Views/Sessions/ControlDeck/ControlDeckScreen.swift
@@ -1,0 +1,680 @@
+import ImageIO
+import SwiftUI
+import UniformTypeIdentifiers
+#if os(macOS)
+  import AppKit
+#endif
+#if os(iOS)
+  import UIKit
+#endif
+
+struct ControlDeckScreen: View {
+  let sessionId: String
+  let sessionStore: SessionStore
+  var chromeStyle: ControlDeckChromeStyle = .standalone
+
+  // Terminal integration — passed from SessionDetailView
+  var terminalTitle: String?
+  var sessionDisplayStatus: SessionDisplayStatus = .ended
+  var currentTool: String?
+  var onToggleTerminal: (() -> Void)?
+
+  @State private var viewModel = ControlDeckViewModel()
+  @State private var draft = ControlDeckDraft()
+  @State private var completionState = ControlDeckCompletionState()
+  @State private var focusState = ComposerFocusState()
+  @State private var isSubmitting = false
+  @State private var uploadedImageIds: [String: String] = [:]
+  @State private var isImportingAttachments = false
+  @State private var dictationController = LocalDictationController()
+  @State private var dictationDraftBase: String?
+  @AppStorage("localDictationEnabled") private var localDictationEnabled = true
+
+  private var canSubmit: Bool {
+    let mode = viewModel.presentation?.mode ?? .disabled
+    let modeAllowsInput = mode == .compose || mode == .steer
+    return modeAllowsInput && draft.hasContent && !isSubmitting
+  }
+
+  private var shouldShowDictation: Bool {
+    localDictationEnabled && LocalDictationAvailabilityResolver.current == .available
+  }
+
+  private var isDictationActive: Bool {
+    dictationController.state == .recording ||
+      dictationController.state == .requestingPermission ||
+      dictationController.state == .transcribing
+  }
+
+  private var dictationAction: (() -> Void)? {
+    shouldShowDictation ? { toggleDictation() } : nil
+  }
+
+  private var isSessionWorking: Bool {
+    sessionStore.session(sessionId).workStatus == .working
+  }
+
+  var body: some View {
+    Group {
+      if viewModel.isLoading, viewModel.snapshot == nil {
+        loadingView
+      } else if let error = viewModel.lastError, viewModel.snapshot == nil {
+        errorView(error)
+      } else {
+        ControlDeckView(
+          draft: $draft,
+          focusState: $focusState,
+          completionState: $completionState,
+          isSubmitting: isSubmitting,
+          canSubmit: canSubmit,
+          presentation: viewModel.presentation,
+          pendingApproval: viewModel.pendingApproval,
+          completionSuggestions: currentSuggestions,
+          errorMessage: viewModel.lastError,
+          chromeStyle: chromeStyle,
+          onTextChange: handleTextChange,
+          onKeyCommand: handleKeyCommand,
+          onFocusEvent: handleFocusEvent,
+          onPasteImage: pasteImageFromClipboard,
+          canPasteImage: { supportsImageClipboardPaste },
+          onAddImage: { isImportingAttachments = true },
+          onRemoveAttachment: { draft.attachments.remove(id: $0) },
+          onDropImages: handleDrop,
+          onSelectSuggestion: acceptSuggestion,
+          onSubmit: submitDraft,
+          onApprove: { Task { await viewModel.approveTool(decision: .approved) } },
+          onApproveForSession: { Task { await viewModel.approveTool(decision: .approvedForSession) } },
+          onDeny: { Task { await viewModel.approveTool(decision: .denied) } },
+          onAnswer: { answer, promptId in
+            Task { await viewModel.answerQuestion(answer: answer, questionId: promptId) }
+          },
+          onGrantPermission: { Task { await viewModel.respondToPermission(grant: true, scope: .turn) } },
+          onGrantPermissionForSession: { Task { await viewModel.respondToPermission(grant: true, scope: .session) } },
+          onDenyPermission: { Task { await viewModel.respondToPermission(grant: false) } },
+          terminalTitle: terminalTitle,
+          sessionDisplayStatus: sessionDisplayStatus,
+          currentTool: currentTool,
+          onToggleTerminal: onToggleTerminal,
+          onModuleAction: handleModuleAction,
+          onApprovalReviewerAction: handleApprovalReviewerAction,
+          isDictating: isDictationActive,
+          isSessionWorking: isSessionWorking,
+          onDictation: dictationAction,
+          onInterrupt: { Task { await viewModel.interruptSession() } }
+        )
+      }
+    }
+    .padding(.horizontal, chromeStyle == .embedded ? 0 : Spacing.sm)
+    .padding(.bottom, chromeStyle == .embedded ? 0 : Spacing.xs)
+    .task(id: sessionId) {
+      draft = ControlDeckDraft.restore(for: sessionId)
+      viewModel.bind(sessionId: sessionId, sessionStore: sessionStore)
+      await viewModel.refresh()
+    }
+    .onChange(of: draft) { _, newDraft in
+      ControlDeckDraft.save(newDraft, for: sessionId)
+    }
+    .onChange(of: sessionStore.session(sessionId).pendingApproval?.id) { _, _ in
+      viewModel.syncApproval()
+    }
+    .onChange(of: sessionStore.session(sessionId).approvalVersion) { _, _ in
+      viewModel.syncApproval()
+    }
+    .onChange(of: sessionStore.session(sessionId).workStatus) { _, _ in
+      viewModel.syncApproval()
+    }
+    .onChange(of: sessionStore.session(sessionId).acceptsUserInput) { _, _ in
+      viewModel.syncApproval()
+    }
+    .onChange(of: sessionStore.session(sessionId).steerable) { _, _ in
+      viewModel.syncApproval()
+    }
+    .onChange(of: sessionStore.session(sessionId).projectPath) { _, _ in
+      viewModel.syncApproval()
+    }
+    .onChange(of: sessionStore.session(sessionId).currentCwd) { _, _ in
+      viewModel.syncApproval()
+    }
+    .onChange(of: sessionStore.session(sessionId).branch) { _, _ in
+      viewModel.syncApproval()
+    }
+    .onChange(of: dictationController.liveTranscript) { _, transcript in
+      guard dictationController.isRecording else { return }
+      updateDictationLivePreview(transcript)
+    }
+    .onChange(of: localDictationEnabled) { _, enabled in
+      if !enabled {
+        Task { await dictationController.cancel(); dictationDraftBase = nil }
+      }
+    }
+    .task(id: viewModel.snapshot?.state.projectPath ?? "") {
+      guard let path = viewModel.snapshot?.state.projectPath, !path.isEmpty else { return }
+      await viewModel.projectFileIndex?.loadIfNeeded(path)
+    }
+    .fileImporter(
+      isPresented: $isImportingAttachments,
+      allowedContentTypes: [.item],
+      allowsMultipleSelection: true,
+      onCompletion: handleAttachmentImport
+    )
+  }
+
+  // MARK: - Loading / Error
+
+  private var loadingView: some View {
+    ProgressView()
+      .controlSize(.small)
+      .frame(maxWidth: .infinity, minHeight: 60)
+      .background(Color.backgroundSecondary)
+      .clipShape(RoundedRectangle(cornerRadius: Radius.xl, style: .continuous))
+      .overlay(
+        RoundedRectangle(cornerRadius: Radius.xl, style: .continuous)
+          .strokeBorder(Color.panelBorder, lineWidth: 1)
+      )
+  }
+
+  private func errorView(_ error: String) -> some View {
+    VStack(spacing: Spacing.sm) {
+      Text(error)
+        .font(.system(size: TypeScale.caption, weight: .medium, design: .monospaced))
+        .foregroundStyle(Color.statusPermission)
+        .lineLimit(3)
+      Button("Retry") { Task { await viewModel.refresh() } }
+        .buttonStyle(.bordered)
+        .controlSize(.small)
+    }
+    .padding(Spacing.lg)
+    .frame(maxWidth: .infinity)
+    .background(Color.backgroundSecondary)
+    .clipShape(RoundedRectangle(cornerRadius: Radius.xl, style: .continuous))
+    .overlay(
+      RoundedRectangle(cornerRadius: Radius.xl, style: .continuous)
+        .strokeBorder(Color.panelBorder, lineWidth: 1)
+    )
+  }
+
+  // MARK: - Text Change → Completions
+
+  private func handleTextChange(_ text: String) {
+    if let query = mentionQuery(in: text) {
+      completionState.activate(.mention(query: query))
+      return
+    }
+
+    if let query = skillQuery(in: text) {
+      if viewModel.skills.isEmpty {
+        Task { await viewModel.loadSkills() }
+      }
+      completionState.activate(.skill(query: query))
+      return
+    }
+
+    completionState.dismiss()
+  }
+
+  private var currentSuggestions: [ControlDeckCompletionSuggestion] {
+    switch completionState.mode {
+      case .inactive:
+        return []
+      case let .mention(query):
+        let files = viewModel.projectFileIndex?.search(query, in: viewModel.projectPath ?? "") ?? []
+        return files.prefix(8).map { file in
+          ControlDeckCompletionSuggestion(id: file.id, kind: .file, title: file.name, subtitle: file.relativePath)
+        }
+      case let .skill(query):
+        let normalizedQuery = query.lowercased()
+        let matching = viewModel.skills.filter { skill in
+          normalizedQuery.isEmpty || skill.name.lowercased().contains(normalizedQuery)
+        }
+        return matching.prefix(8).map { skill in
+          ControlDeckCompletionSuggestion(
+            id: skill.id,
+            kind: .skill,
+            title: skill.name,
+            subtitle: skill.shortDescription ?? skill.description
+          )
+        }
+      case .command:
+        return []
+    }
+  }
+
+  // MARK: - Keyboard Commands
+
+  private func handleKeyCommand(_ command: ComposerTextAreaKeyCommand) -> Bool {
+    if completionState.isActive {
+      let suggestions = currentSuggestions
+      switch command {
+        case .escape:
+          completionState.dismiss()
+          return true
+        case .upArrow, .controlP:
+          completionState.moveUp()
+          return true
+        case .downArrow, .controlN:
+          completionState.moveDown(itemCount: suggestions.count)
+          return true
+        case .tab, .returnKey:
+          guard suggestions.indices.contains(completionState.selectedIndex) else { return false }
+          acceptSuggestion(suggestions[completionState.selectedIndex])
+          return true
+        default:
+          return false
+      }
+    }
+
+    if command == .returnKey, canSubmit {
+      submitDraft()
+      return true
+    }
+
+    return false
+  }
+
+  // MARK: - Focus
+
+  private func handleFocusEvent(_ event: ComposerTextAreaFocusEvent) {
+    switch event {
+      case .began:
+        focusState.isFocused = true
+      case .ended:
+        focusState.isFocused = false
+    }
+  }
+
+  // MARK: - Module Actions
+
+  private func handleModuleAction(_ module: ControlDeckStatusModule, _ value: String) {
+    Task {
+      switch module {
+        case .model:
+          await viewModel.updateModel(value)
+        case .effort:
+          await viewModel.updateEffort(value)
+        case .autonomy:
+          await viewModel.updatePermissionMode(value)
+        case .approvalMode:
+          await viewModel.updateApprovalPolicy(value)
+        case .collaborationMode:
+          await viewModel.updateCollaborationMode(value)
+        case .autoReview:
+          await viewModel.updateAutoReview(value)
+        default:
+          break
+      }
+    }
+  }
+
+  private func handleApprovalReviewerAction(_ reviewer: ServerCodexApprovalsReviewer) {
+    Task {
+      await viewModel.updateApprovalsReviewer(reviewer)
+    }
+  }
+
+  // MARK: - Suggestion Acceptance
+
+  private func acceptSuggestion(_ suggestion: ControlDeckCompletionSuggestion) {
+    switch suggestion.kind {
+      case .file:
+        acceptFileSuggestion(suggestion)
+      case .skill:
+        acceptSkillSuggestion(suggestion)
+      case .command:
+        break
+    }
+  }
+
+  private func acceptFileSuggestion(_ suggestion: ControlDeckCompletionSuggestion) {
+    guard let projectPath = viewModel.projectPath,
+          let file = viewModel.projectFileIndex?.files(for: projectPath).first(where: { $0.id == suggestion.id })
+    else { return }
+
+    draft.text = replaceTrailingToken(in: draft.text, prefix: "@", with: "@\(file.name) ")
+    let absolutePath = (projectPath as NSString).appendingPathComponent(file.relativePath)
+    draft.attachments.appendMention(ControlDeckMentionDraft(
+      fileId: file.id,
+      name: file.name,
+      absolutePath: absolutePath,
+      relativePath: file.relativePath,
+      kind: .file
+    ))
+    completionState.dismiss()
+    focusState.requestFocus()
+    focusState.moveCursorToEnd()
+  }
+
+  private func acceptSkillSuggestion(_ suggestion: ControlDeckCompletionSuggestion) {
+    guard let skill = viewModel.skills.first(where: { $0.id == suggestion.id }) else { return }
+
+    draft.text = replaceTrailingToken(in: draft.text, prefix: "$", with: "$\(skill.name) ")
+    draft.selectedSkillPaths.insert(skill.path)
+    completionState.dismiss()
+    focusState.requestFocus()
+    focusState.moveCursorToEnd()
+  }
+
+  // MARK: - Submit
+
+  private func submitDraft() {
+    guard draft.hasContent, !isSubmitting else { return }
+
+    let shouldSteer = viewModel.presentation?.mode == .steer || isSessionWorking
+    isSubmitting = true
+    let currentDraft = draft
+
+    Task {
+      defer { isSubmitting = false }
+      do {
+        // Upload images first so both compose and steer can reference the same server attachment IDs.
+        var imageIds = uploadedImageIds
+        for image in currentDraft.attachments.images {
+          if imageIds[image.localId] == nil {
+            let attachmentId = try await viewModel.uploadImage(
+              data: image.uploadData,
+              mimeType: image.uploadMimeType,
+              displayName: image.displayName,
+              pixelWidth: image.pixelWidth,
+              pixelHeight: image.pixelHeight
+            )
+            imageIds[image.localId] = attachmentId
+          }
+        }
+
+        if shouldSteer {
+          try await viewModel.steerTurn(draft: currentDraft, uploadedImageIds: imageIds)
+          uploadedImageIds = [:]
+        } else {
+          try await viewModel.submitTurn(draft: currentDraft, uploadedImageIds: imageIds)
+          uploadedImageIds = [:]
+        }
+
+        draft.clearAfterSubmit()
+        ControlDeckDraft.clear(for: sessionId)
+        completionState.dismiss()
+        viewModel.lastError = nil
+        focusState.requestFocus()
+        await viewModel.refresh()
+      } catch {
+        viewModel.lastError = String(describing: error)
+      }
+    }
+  }
+
+  // MARK: - Token Parsing
+
+  private func mentionQuery(in text: String) -> String? {
+    guard let range = trailingTokenRange(in: text, prefix: "@") else { return nil }
+    let idx = text.index(after: range.lowerBound)
+    guard idx < range.upperBound || idx == text.endIndex else { return nil }
+    return String(text[idx ..< range.upperBound])
+  }
+
+  private func skillQuery(in text: String) -> String? {
+    guard let range = trailingTokenRange(in: text, prefix: "$") else { return nil }
+    return String(text[text.index(after: range.lowerBound) ..< range.upperBound])
+  }
+
+  private func trailingTokenRange(in text: String, prefix: Character) -> Range<String.Index>? {
+    guard let idx = text.lastIndex(of: prefix) else { return nil }
+    if prefix == "@", idx != text.startIndex {
+      let before = text[text.index(before: idx)]
+      guard before.isWhitespace else { return nil }
+    }
+    let after = text[text.index(after: idx)...]
+    guard !after.contains(where: \.isWhitespace) else { return nil }
+    return idx ..< text.endIndex
+  }
+
+  private func replaceTrailingToken(in text: String, prefix: Character, with replacement: String) -> String {
+    guard let range = trailingTokenRange(in: text, prefix: prefix) else {
+      return text + replacement
+    }
+    var updated = text
+    updated.replaceSubrange(range, with: replacement)
+    return updated
+  }
+
+  // MARK: - Image Handling
+
+  private func handleAttachmentImport(_ result: Result<[URL], Error>) {
+    guard case let .success(urls) = result, !urls.isEmpty else {
+      if case let .failure(error) = result {
+        viewModel.lastError = String(describing: error)
+      }
+      return
+    }
+
+    for url in urls {
+      do {
+        if let imagePayload = try Self.makeImagePayloadIfNeeded(from: url) {
+          draft.attachments.appendImage(imagePayload)
+        } else {
+          try appendFileMention(from: url)
+        }
+      } catch {
+        viewModel.lastError = String(describing: error)
+      }
+    }
+  }
+
+  private func appendFileMention(from url: URL) throws {
+    let requiresScope = url.startAccessingSecurityScopedResource()
+    defer { if requiresScope { url.stopAccessingSecurityScopedResource() } }
+
+    let standardizedURL = url.standardizedFileURL
+    let absolutePath = standardizedURL.path
+    guard !absolutePath.isEmpty else { return }
+
+    let projectPath = viewModel.projectPath?.trimmingCharacters(in: .whitespacesAndNewlines)
+    let relativePath: String?
+    if let projectPath, !projectPath.isEmpty, absolutePath.hasPrefix(projectPath + "/") {
+      relativePath = String(absolutePath.dropFirst(projectPath.count + 1))
+    } else {
+      relativePath = nil
+    }
+
+    _ = draft.attachments.appendMention(ControlDeckMentionDraft(
+      fileId: absolutePath,
+      name: standardizedURL.lastPathComponent,
+      absolutePath: absolutePath,
+      relativePath: relativePath,
+      kind: .file
+    ))
+  }
+
+  private static func makeImagePayloadIfNeeded(from url: URL) throws -> ControlDeckImageDraft? {
+    let utType = UTType(filenameExtension: url.pathExtension.lowercased())
+    guard utType?.conforms(to: .image) == true else { return nil }
+
+    let requiresScope = url.startAccessingSecurityScopedResource()
+    defer { if requiresScope { url.stopAccessingSecurityScopedResource() } }
+
+    let data = try Data(contentsOf: url)
+    let dims = imageDimensions(from: data)
+    return ControlDeckImageDraft(
+      localId: UUID().uuidString,
+      thumbnailData: data.count < 500_000 ? data : nil,
+      uploadData: data,
+      uploadMimeType: utType?.preferredMIMEType ?? "image/png",
+      displayName: url.lastPathComponent,
+      pixelWidth: dims.width,
+      pixelHeight: dims.height
+    )
+  }
+
+  private static func imageDimensions(from data: Data) -> (width: Int?, height: Int?) {
+    guard let source = CGImageSourceCreateWithData(data as CFData, nil),
+          let props = CGImageSourceCopyPropertiesAtIndex(source, 0, nil) as? [CFString: Any]
+    else { return (nil, nil) }
+    return (props[kCGImagePropertyPixelWidth] as? Int, props[kCGImagePropertyPixelHeight] as? Int)
+  }
+
+  // MARK: - Dictation
+
+  private func toggleDictation() {
+    guard shouldShowDictation else { return }
+    Task { @MainActor in
+      if dictationController.isRecording {
+        if let dictated = await dictationController.stop() {
+          let normalized = DictationTextFormatter.normalizeTranscription(dictated)
+          // Replace only the live preview portion, keeping user edits intact
+          if let base = dictationDraftBase {
+            // Remove the live preview suffix and apply final transcript
+            let currentWithoutPreview = removeLivePreviewSuffix(from: draft.text, base: base)
+            draft.text = DictationTextFormatter.merge(existing: currentWithoutPreview, dictated: normalized)
+          } else {
+            draft.text = DictationTextFormatter.merge(existing: draft.text, dictated: normalized)
+          }
+        }
+        dictationDraftBase = nil
+        focusState.moveCursorToEnd()
+        Platform.services.playHaptic(.action)
+      } else {
+        // Snapshot current text as the base — live preview appends after this
+        dictationDraftBase = draft.text
+        await dictationController.start()
+        if dictationController.isRecording {
+          Platform.services.playHaptic(.action)
+        } else {
+          dictationDraftBase = nil
+          if dictationController.errorMessage != nil {
+            viewModel.lastError = dictationController.errorMessage
+            Platform.services.playHaptic(.error)
+          }
+        }
+      }
+    }
+  }
+
+  private func updateDictationLivePreview(_ transcript: String) {
+    guard let base = dictationDraftBase else { return }
+    let normalized = DictationTextFormatter.normalizeTranscription(transcript)
+    // Always merge against the snapshot base so user edits before dictation are preserved
+    let merged = DictationTextFormatter.merge(existing: base, dictated: normalized)
+    guard merged != draft.text else { return }
+    draft.text = merged
+    focusState.moveCursorToEnd()
+  }
+
+  private func removeLivePreviewSuffix(from current: String, base: String) -> String {
+    // If the current text starts with the base, return just the base
+    // (user edits during dictation are in the base region)
+    current.hasPrefix(base) ? base : current
+  }
+}
+
+// MARK: - Platform Clipboard + Drop
+
+#if os(macOS)
+  extension ControlDeckScreen {
+    var supportsImageClipboardPaste: Bool {
+      NSPasteboard.general.availableType(from: [.tiff, .png]) != nil
+    }
+
+    @discardableResult
+    func pasteImageFromClipboard() -> Bool {
+      let pb = NSPasteboard.general
+      guard let imageType = pb.availableType(from: [.tiff, .png]),
+            let data = pb.data(forType: imageType),
+            let normalized = Self.normalizedPNG(from: data)
+      else { return false }
+
+      let dims = Self.imageDimensions(from: normalized)
+      draft.attachments.appendImage(ControlDeckImageDraft(
+        localId: UUID().uuidString,
+        thumbnailData: normalized.count < 500_000 ? normalized : nil,
+        uploadData: normalized,
+        uploadMimeType: "image/png",
+        displayName: "Clipboard Image",
+        pixelWidth: dims.width,
+        pixelHeight: dims.height
+      ))
+      return true
+    }
+
+    func handleDrop(_ providers: [NSItemProvider]) -> Bool {
+      var handled = false
+      for provider in providers {
+        if provider.hasItemConformingToTypeIdentifier(UTType.fileURL.identifier) {
+          provider.loadItem(forTypeIdentifier: UTType.fileURL.identifier, options: nil) { item, _ in
+            guard let url = Self.droppedFileURL(from: item),
+                  url.isFileURL,
+                  UTType(filenameExtension: url.pathExtension)?.conforms(to: .image) == true,
+                  let payload = try? Self.makeImagePayloadIfNeeded(from: url)
+            else { return }
+            Task { @MainActor in draft.attachments.appendImage(payload) }
+          }
+          handled = true
+        }
+      }
+      return handled
+    }
+
+    private static func normalizedPNG(from data: Data) -> Data? {
+      guard let source = CGImageSourceCreateWithData(data as CFData, nil),
+            let cgImage = CGImageSourceCreateImageAtIndex(source, 0, nil)
+      else { return nil }
+      let out = NSMutableData()
+      guard let dest = CGImageDestinationCreateWithData(out, UTType.png.identifier as CFString, 1, nil)
+      else { return nil }
+      CGImageDestinationAddImage(dest, cgImage, nil)
+      guard CGImageDestinationFinalize(dest) else { return nil }
+      return out as Data
+    }
+
+    private static func droppedFileURL(from item: NSSecureCoding?) -> URL? {
+      (item as? URL) ?? (item as? NSURL) as URL? ?? (item as? Data).flatMap { URL(
+        dataRepresentation: $0,
+        relativeTo: nil
+      ) }
+    }
+  }
+#endif
+
+#if os(iOS)
+  extension ControlDeckScreen {
+    var supportsImageClipboardPaste: Bool {
+      UIPasteboard.general.hasImages
+    }
+
+    @discardableResult
+    func pasteImageFromClipboard() -> Bool {
+      guard let image = UIPasteboard.general.image, let data = image.pngData() else { return false }
+      let dims = Self.imageDimensions(from: data)
+      draft.attachments.appendImage(ControlDeckImageDraft(
+        localId: UUID().uuidString,
+        thumbnailData: data.count < 500_000 ? data : nil,
+        uploadData: data,
+        uploadMimeType: "image/png",
+        displayName: "Clipboard Image",
+        pixelWidth: dims.width,
+        pixelHeight: dims.height
+      ))
+      return true
+    }
+
+    func handleDrop(_ providers: [NSItemProvider]) -> Bool {
+      var handled = false
+      for provider in providers {
+        if provider.canLoadObject(ofClass: UIImage.self) {
+          provider.loadObject(ofClass: UIImage.self) { object, _ in
+            guard let image = object as? UIImage, let data = image.pngData() else { return }
+            let dims = Self.imageDimensions(from: data)
+            let payload = ControlDeckImageDraft(
+              localId: UUID().uuidString,
+              thumbnailData: data.count < 500_000 ? data : nil,
+              uploadData: data,
+              uploadMimeType: "image/png",
+              displayName: "Dropped Image",
+              pixelWidth: dims.width,
+              pixelHeight: dims.height
+            )
+            Task { @MainActor in draft.attachments.appendImage(payload) }
+          }
+          handled = true
+        }
+      }
+      return handled
+    }
+  }
+#endif

--- a/OrbitDockNative/OrbitDock/Views/Sessions/ControlDeck/ControlDeckSnapshotMapper.swift
+++ b/OrbitDockNative/OrbitDock/Views/Sessions/ControlDeck/ControlDeckSnapshotMapper.swift
@@ -1,0 +1,248 @@
+import Foundation
+
+nonisolated enum ControlDeckSnapshotMapper {
+  static func map(_ payload: ServerControlDeckSnapshotPayload) -> ControlDeckSnapshot {
+    ControlDeckSnapshot(
+      revision: payload.revision,
+      sessionId: payload.sessionId,
+      state: mapState(payload.state),
+      capabilities: mapCapabilities(payload.capabilities),
+      preferences: mapPreferences(payload.preferences),
+      tokenUsage: mapTokenUsage(payload.tokenUsage),
+      tokenUsageSnapshotKind: mapSnapshotKind(payload.tokenUsageSnapshotKind),
+      tokenStatus: mapTokenStatus(payload.tokenStatus)
+    )
+  }
+
+  static func mapState(_ state: ServerControlDeckState) -> ControlDeckSessionState {
+    ControlDeckSessionState(
+      provider: mapProvider(state.provider),
+      controlMode: mapControlMode(state.controlMode),
+      lifecycle: mapLifecycle(state.lifecycleState),
+      acceptsUserInput: state.acceptsUserInput,
+      steerable: state.steerable,
+      projectPath: state.projectPath,
+      currentCwd: state.currentCwd,
+      gitBranch: state.gitBranch,
+      config: mapConfig(state.config)
+    )
+  }
+
+  static func mapCapabilities(_ caps: ServerControlDeckCapabilities) -> ControlDeckCapabilities {
+    ControlDeckCapabilities(
+      supportsSkills: caps.supportsSkills,
+      supportsMentions: caps.supportsMentions,
+      supportsImages: caps.supportsImages,
+      supportsSteer: caps.supportsSteer,
+      allowPerTurnModelOverride: caps.allowPerTurnModelOverride,
+      allowPerTurnEffortOverride: caps.allowPerTurnEffortOverride,
+      approvalModeOptions: caps.approvalModeOptions.map(mapPickerOption),
+      permissionModeOptions: caps.permissionModeOptions.map(mapPickerOption),
+      collaborationModeOptions: caps.collaborationModeOptions.map(mapPickerOption),
+      autoReviewOptions: caps.autoReviewOptions.map(mapAutoReviewOption),
+      availableStatusModules: caps.availableStatusModules.compactMap(mapModule)
+    )
+  }
+
+  static func mapPreferences(_ prefs: ServerControlDeckPreferences) -> ControlDeckPreferences {
+    ControlDeckPreferences(
+      density: mapDensity(prefs.density),
+      showWhenEmpty: mapEmptyVisibility(prefs.showWhenEmpty),
+      modules: prefs.modules.compactMap { pref in
+        guard let module = mapModule(pref.module) else { return nil }
+        return ControlDeckModulePreference(module: module, visible: pref.visible)
+      }
+    )
+  }
+
+  static func mapSkill(_ skill: ServerSkillMetadata) -> ControlDeckSkill {
+    ControlDeckSkill(
+      name: skill.name,
+      path: skill.path,
+      description: skill.description,
+      shortDescription: skill.shortDescription
+    )
+  }
+
+  // MARK: - Private
+
+  private static func mapProvider(_ provider: ServerProvider) -> ControlDeckProvider {
+    switch provider {
+      case .claude: .claude
+      case .codex: .codex
+    }
+  }
+
+  private static func mapControlMode(_ mode: ServerSessionControlMode) -> ControlDeckControlMode {
+    switch mode {
+      case .direct: .direct
+      case .passive: .passive
+    }
+  }
+
+  private static func mapLifecycle(_ state: ServerSessionLifecycleState) -> ControlDeckLifecycle {
+    switch state {
+      case .open: .open
+      case .resumable: .resumable
+      case .ended: .ended
+    }
+  }
+
+  private static func mapConfig(_ config: ServerControlDeckConfigState) -> ControlDeckConfig {
+    ControlDeckConfig(
+      model: config.model,
+      effort: config.effort,
+      approvalPolicy: config.approvalPolicy,
+      approvalPolicyDetails: config.approvalPolicyDetails,
+      sandboxMode: config.sandboxMode,
+      approvalsReviewer: config.approvalsReviewer,
+      permissionMode: config.permissionMode,
+      collaborationMode: config.collaborationMode
+    )
+  }
+
+  private static func mapModule(_ module: ServerControlDeckModule) -> ControlDeckStatusModule? {
+    switch module {
+      case .connection: nil // App-level concern, not a session module
+      case .autonomy: .autonomy
+      case .approvalMode: .approvalMode
+      case .collaborationMode: .collaborationMode
+      case .autoReview: .autoReview
+      case .tokens: .tokens
+      case .model: .model
+      case .effort: .effort
+      case .branch: .branch
+      case .cwd: .cwd
+      case .attachments: nil // The deck already renders real attachments inline
+    }
+  }
+
+  private static func mapDensity(_ density: ServerControlDeckDensity) -> ControlDeckDensity {
+    switch density {
+      case .comfortable: .comfortable
+      case .compact: .compact
+    }
+  }
+
+  private static func mapEmptyVisibility(_ vis: ServerControlDeckEmptyVisibility) -> ControlDeckEmptyVisibility {
+    switch vis {
+      case .auto: .auto
+      case .always: .always
+      case .hidden: .hidden
+    }
+  }
+
+  static func mapTokenUsage(_ usage: ServerTokenUsage) -> ControlDeckTokenUsage {
+    ControlDeckTokenUsage(
+      inputTokens: usage.inputTokens,
+      outputTokens: usage.outputTokens,
+      cachedTokens: usage.cachedTokens,
+      contextWindow: usage.contextWindow
+    )
+  }
+
+  static func mapTokenStatus(_ status: ServerControlDeckTokenStatus) -> ControlDeckTokenStatus {
+    ControlDeckTokenStatus(
+      label: status.label,
+      tone: mapTokenTone(status.tone)
+    )
+  }
+
+  // MARK: - Approval Mapping
+
+  static func mapApproval(_ request: ServerApprovalRequest) -> ControlDeckApproval {
+    let kind: ControlDeckApproval.Kind
+    let title: String
+
+    switch request.type {
+      case .exec:
+        title = request.toolName ?? "Tool Execution"
+        kind = .tool(
+          toolName: request.toolName,
+          command: request.command,
+          filePath: request.filePath,
+          diff: request.diff
+        )
+      case .patch:
+        title = request.filePath.map { "Edit \($0)" } ?? "File Edit"
+        kind = .tool(
+          toolName: request.toolName,
+          command: nil,
+          filePath: request.filePath,
+          diff: request.diff
+        )
+      case .question:
+        title = "Question"
+        let prompts = request.questionPrompts.map { prompt in
+          ControlDeckApproval.Prompt(
+            id: prompt.id,
+            question: prompt.question,
+            options: prompt.options.map(\.label),
+            allowsMultipleSelection: prompt.allowsMultipleSelection,
+            allowsOther: prompt.allowsOther,
+            isSecret: prompt.isSecret
+          )
+        }
+        kind = .question(prompts: prompts)
+      case .permissions:
+        title = "Permission Request"
+        let descriptions = request.requestedPermissions?.map(describePermission) ?? []
+        kind = .permission(reason: request.permissionReason, descriptions: descriptions)
+    }
+
+    return ControlDeckApproval(
+      requestId: request.id,
+      sessionId: request.sessionId,
+      kind: kind,
+      title: title,
+      detail: request.question ?? request.permissionReason
+    )
+  }
+
+  private static func describePermission(_ perm: ServerPermissionDescriptor) -> String {
+    switch perm {
+      case let .filesystem(readPaths, writePaths):
+        let parts = (readPaths.isEmpty ? [] : ["read: \(readPaths.joined(separator: ", "))"]) +
+          (writePaths.isEmpty ? [] : ["write: \(writePaths.joined(separator: ", "))"])
+        return "Filesystem \(parts.joined(separator: "; "))"
+      case let .network(hosts):
+        return "Network: \(hosts.joined(separator: ", "))"
+      case let .macOs(entitlement, details):
+        return details ?? entitlement
+      case let .generic(permission, details):
+        return details ?? permission
+    }
+  }
+
+  private static func mapSnapshotKind(_ kind: ServerTokenUsageSnapshotKind) -> ControlDeckTokenUsageSnapshotKind {
+    switch kind {
+      case .unknown: .unknown
+      case .contextTurn: .contextTurn
+      case .lifetimeTotals: .lifetimeTotals
+      case .mixedLegacy: .mixedLegacy
+      case .compactionReset: .compactionReset
+    }
+  }
+
+  private static func mapPickerOption(_ option: ServerControlDeckPickerOption) -> ControlDeckPickerOption {
+    ControlDeckPickerOption(value: option.value, label: option.label)
+  }
+
+  private static func mapAutoReviewOption(_ option: ServerControlDeckAutoReviewOption) -> ControlDeckAutoReviewOption {
+    ControlDeckAutoReviewOption(
+      value: option.value,
+      label: option.label,
+      approvalPolicy: option.approvalPolicy,
+      sandboxMode: option.sandboxMode
+    )
+  }
+
+  private static func mapTokenTone(_ tone: ServerControlDeckTokenStatusTone) -> ControlDeckTokenStatus.Tone {
+    switch tone {
+      case .muted: .muted
+      case .normal: .normal
+      case .caution: .caution
+      case .critical: .critical
+    }
+  }
+}

--- a/OrbitDockNative/OrbitDock/Views/Sessions/ControlDeck/ControlDeckStatusBar.swift
+++ b/OrbitDockNative/OrbitDock/Views/Sessions/ControlDeck/ControlDeckStatusBar.swift
@@ -1,0 +1,449 @@
+import SwiftUI
+
+struct ControlDeckStatusBar: View {
+  let modules: [ControlDeckStatusModuleItem]
+  var onModuleAction: ((ControlDeckStatusModule, String) -> Void)?
+  var onApprovalReviewerAction: ((ServerCodexApprovalsReviewer) -> Void)?
+
+  // Action buttons
+  var supportsImages: Bool = false
+  var canPasteImage: Bool = false
+  var canSubmit: Bool = false
+  var isSubmitting: Bool = false
+  var sendTint: String = "accent"
+  var onAddImage: (() -> Void)?
+  var onPasteImage: (() -> Void)?
+  var onSubmit: (() -> Void)?
+  var isDictating: Bool = false
+  var isSessionWorking: Bool = false
+  var onDictation: (() -> Void)?
+  var onInterrupt: (() -> Void)?
+
+  @Environment(\.horizontalSizeClass) private var horizontalSizeClass
+
+  private var isCompactIOS: Bool {
+    #if os(iOS)
+      horizontalSizeClass == .compact
+    #else
+      false
+    #endif
+  }
+
+  private var minimumBarHeight: CGFloat {
+    #if os(iOS)
+      44
+    #else
+      28
+    #endif
+  }
+
+  private var actionButtonSize: CGFloat {
+    #if os(iOS)
+      isCompactIOS ? 30 : 32
+    #else
+      26
+    #endif
+  }
+
+  private var sendButtonSize: CGFloat {
+    #if os(iOS)
+      isCompactIOS ? 30 : 34
+    #else
+      28
+    #endif
+  }
+
+  var body: some View {
+    HStack(spacing: isCompactIOS ? Spacing.xs : Spacing.sm_) {
+      // Action buttons (left edge)
+      actionButtons
+
+      // Scrollable status modules (fills middle)
+      ScrollView(.horizontal, showsIndicators: false) {
+        HStack(spacing: isCompactIOS ? Spacing.xs : Spacing.sm) {
+          if !controlModules.isEmpty {
+            controlModuleRow(controlModules)
+          }
+
+          if !metadataModules.isEmpty {
+            if !controlModules.isEmpty {
+              divider
+            }
+
+            metadataModuleRow(metadataModules)
+          }
+        }
+      }
+      .scrollIndicators(.hidden)
+
+      // Send cluster (right edge)
+      sendCluster
+    }
+    .frame(minHeight: minimumBarHeight, alignment: .center)
+  }
+
+  // MARK: - Action Buttons
+
+  private var actionButtons: some View {
+    HStack(spacing: isCompactIOS ? Spacing.xs : Spacing.xxs) {
+      if supportsImages {
+        ghostButton(icon: "paperclip", tint: .accent, action: { onAddImage?() })
+      }
+
+      if let onDictation {
+        ghostButton(
+          icon: isDictating ? "stop.fill" : "mic.fill",
+          tint: isDictating ? .statusError : .accent,
+          action: onDictation
+        )
+      }
+    }
+  }
+
+  // MARK: - Send Cluster
+
+  private var sendCluster: some View {
+    HStack(spacing: isCompactIOS ? Spacing.xs : Spacing.sm_) {
+      #if os(macOS)
+        if canSubmit, !isSubmitting {
+          Text("\u{2318}\u{21A9}")
+            .font(.system(size: TypeScale.micro, weight: .medium, design: .monospaced))
+            .foregroundStyle(Color.textQuaternary)
+        }
+      #endif
+
+      sendButton
+    }
+  }
+
+  @ViewBuilder
+  private var sendButton: some View {
+    if isSessionWorking, !canSubmit {
+      Button(action: { onInterrupt?() }) {
+        HStack(spacing: isCompactIOS ? 0 : Spacing.gap) {
+          Image(systemName: "stop.fill")
+            .font(.system(size: TypeScale.caption, weight: .bold))
+          if !isCompactIOS {
+            Text("Stop")
+              .font(.system(size: TypeScale.micro, weight: .semibold))
+          }
+        }
+        .foregroundStyle(Color.statusError)
+        .frame(minWidth: sendButtonSize, minHeight: sendButtonSize)
+        .padding(.horizontal, isCompactIOS ? 0 : Spacing.sm_)
+        .background(Color.statusError.opacity(OpacityTier.light), in: Capsule())
+        .overlay(
+          Capsule()
+            .strokeBorder(Color.statusError.opacity(OpacityTier.medium), lineWidth: 0.75)
+        )
+      }
+      .buttonStyle(.plain)
+    } else {
+      Button(action: { onSubmit?() }) {
+        Group {
+          if isSubmitting {
+            ProgressView()
+              .controlSize(.mini)
+              .tint(.white)
+          } else {
+            Image(systemName: "arrow.up")
+              .font(.system(size: TypeScale.caption, weight: .bold))
+              .foregroundStyle(canSubmit ? Color.backgroundPrimary : Color.textQuaternary)
+          }
+        }
+        .frame(width: sendButtonSize, height: sendButtonSize)
+        .background(canSubmit ? resolvedSendTint : Color.backgroundTertiary, in: Circle())
+        .overlay(
+          Circle()
+            .strokeBorder(
+              canSubmit
+                ? resolvedSendTint.opacity(OpacityTier.medium)
+                : Color.panelBorder.opacity(OpacityTier.medium),
+              lineWidth: 0.75
+            )
+        )
+        .themeShadow(canSubmit ? Shadow.glow(color: resolvedSendTint, intensity: 0.18) : Shadow.sm)
+      }
+      .buttonStyle(.plain)
+      .disabled(!canSubmit || isSubmitting)
+    }
+  }
+
+  private var resolvedSendTint: Color {
+    switch sendTint {
+      case "accent": .accent
+      case "feedbackCaution": .feedbackCaution
+      case "feedbackPositive": .feedbackPositive
+      default: .accent
+    }
+  }
+
+  // MARK: - Module View
+
+  @ViewBuilder
+  private func moduleView(_ module: ControlDeckStatusModuleItem) -> some View {
+    if let specialized = specializedControlView(module) {
+      specialized
+    } else {
+      genericModuleView(module)
+    }
+  }
+
+  @ViewBuilder
+  private func genericModuleView(_ module: ControlDeckStatusModuleItem) -> some View {
+    switch module.interaction {
+      case .readOnly:
+        moduleLabel(module)
+
+      case let .picker(options):
+        if options.isEmpty {
+          moduleLabel(module)
+            .opacity(0.85)
+        } else {
+          Menu {
+            ForEach(options) { option in
+              Button {
+                onModuleAction?(module.id, option.value)
+              } label: {
+                HStack {
+                  Text(option.label)
+                  if option.value.caseInsensitiveCompare(module.selectedValue ?? "") == .orderedSame {
+                    Image(systemName: "checkmark")
+                  }
+                }
+              }
+            }
+          } label: {
+            moduleLabel(module, interactive: true)
+          }
+          .menuStyle(.borderlessButton)
+          .fixedSize()
+        }
+    }
+  }
+
+  private func moduleLabel(_ module: ControlDeckStatusModuleItem, interactive: Bool = false) -> some View {
+    HStack(spacing: Spacing.xxs) {
+      Image(systemName: module.icon)
+        .font(.system(size: IconScale.sm, weight: .semibold))
+        .frame(width: 12)
+        .foregroundStyle(tintColor(module.tintName))
+      Text(module.label)
+        .font(.system(size: TypeScale.micro, weight: .medium, design: .monospaced))
+        .lineLimit(1)
+        .foregroundStyle(moduleTextColor(module, interactive: interactive))
+      if interactive {
+        Image(systemName: "chevron.up.chevron.down")
+          .font(.system(size: IconScale.xs, weight: .semibold))
+          .foregroundStyle(Color.textQuaternary)
+      }
+    }
+    .padding(.horizontal, interactive ? Spacing.sm_ : 0)
+    .padding(.vertical, interactive ? Spacing.gap : 0)
+    .background(
+      interactive
+        ? Color.backgroundTertiary.opacity(0.72)
+        : Color.clear,
+      in: Capsule()
+    )
+    .overlay(
+      Capsule()
+        .strokeBorder(
+          interactive ? Color.panelBorder.opacity(OpacityTier.medium) : .clear,
+          lineWidth: 0.5
+        )
+    )
+  }
+
+  // MARK: - Ghost Button
+
+  private func ghostButton(
+    icon: String,
+    tint: Color,
+    isEnabled: Bool = true,
+    action: @escaping () -> Void
+  ) -> some View {
+    Button(action: action) {
+      Image(systemName: icon)
+        .font(.system(size: isCompactIOS ? IconScale.lg : IconScale.lg, weight: .semibold))
+        .foregroundStyle(isEnabled ? tint : Color.textQuaternary)
+        .frame(width: actionButtonSize, height: actionButtonSize)
+        .contentShape(Rectangle())
+    }
+    .buttonStyle(.plain)
+    .disabled(!isEnabled)
+  }
+
+  private var divider: some View {
+    Rectangle()
+      .fill(Color.panelBorder.opacity(OpacityTier.medium))
+      .frame(width: 1, height: 12)
+  }
+
+  private func controlModuleRow(_ modules: [ControlDeckStatusModuleItem]) -> some View {
+    HStack(spacing: isCompactIOS ? Spacing.xs : Spacing.xs) {
+      ForEach(modules) { module in
+        moduleView(module)
+      }
+    }
+  }
+
+  private func metadataModuleRow(_ modules: [ControlDeckStatusModuleItem]) -> some View {
+    HStack(spacing: isCompactIOS ? Spacing.xs : Spacing.xs) {
+      ForEach(Array(modules.enumerated()), id: \.element.id) { index, module in
+        if index > 0 {
+          Text("\u{00B7}")
+            .font(.system(size: TypeScale.micro, weight: .medium))
+            .foregroundStyle(Color.textQuaternary)
+        }
+
+        moduleView(module)
+      }
+    }
+  }
+
+  private var controlModules: [ControlDeckStatusModuleItem] {
+    modules.filter { module in
+      switch module.id {
+        case .autonomy, .approvalMode, .collaborationMode, .autoReview, .effort:
+          true
+        default:
+          false
+      }
+    }
+  }
+
+  private var metadataModules: [ControlDeckStatusModuleItem] {
+    modules.filter { module in
+      switch module.id {
+        case .autonomy, .approvalMode, .collaborationMode, .autoReview, .effort:
+          false
+        default:
+          true
+      }
+    }
+  }
+
+  private func specializedControlView(_ module: ControlDeckStatusModuleItem) -> AnyView? {
+    switch module.id {
+      case .autonomy:
+        return AnyView(
+          ClaudePermissionPill(
+            currentMode: ClaudePermissionMode(fromServer: module.selectedValue),
+            size: .statusBar,
+            onUpdate: { mode in
+              onModuleAction?(module.id, mode.rawValue)
+            }
+          )
+        )
+      case .approvalMode:
+        return AnyView(
+          CodexApprovalPill(
+            currentMode: CodexApprovalMode.from(rawValue: module.selectedValue),
+            currentReviewer: CodexApprovalsReviewer.from(rawValue: module.reviewerValue),
+            supportedModes: CodexApprovalMode.supportedCases(from: pickerOptions(for: module)),
+            size: .statusBar,
+            onUpdate: { mode in
+              onModuleAction?(module.id, mode.rawValue)
+            },
+            onReviewerUpdate: { reviewer in
+              onApprovalReviewerAction?(ServerCodexApprovalsReviewer(rawValue: reviewer.rawValue) ?? .user)
+            }
+          )
+        )
+      case .collaborationMode:
+        return AnyView(
+          CodexModePill(
+            currentMode: CodexCollaborationMode.from(rawValue: module.selectedValue),
+            supportedModes: codexCollaborationModes(for: module),
+            size: .statusBar,
+            onUpdate: { mode in
+              onModuleAction?(module.id, mode.rawValue)
+            }
+          )
+        )
+      case .autoReview:
+        guard let level = AutonomyLevel.fromAutoReviewValue(module.selectedValue) else {
+          return nil
+        }
+        return AnyView(
+          CodexAutoReviewPill(
+            currentLevel: level,
+            supportedLevels: AutonomyLevel.supportedAutoReviewCases(from: pickerOptions(for: module)),
+            size: .statusBar,
+            onUpdate: { level in
+              onModuleAction?(module.id, autoReviewValue(for: level))
+            }
+          )
+        )
+      case .effort:
+        return AnyView(
+          EffortPill(
+            currentLevel: EffortLevel.fromControlDeckValue(module.selectedValue),
+            supportedLevels: EffortLevel.supportedControlDeckCases(from: pickerOptions(for: module)),
+            size: .statusBar,
+            onUpdate: { level in
+              onModuleAction?(module.id, level.rawValue)
+            }
+          )
+        )
+      default:
+        return nil
+    }
+  }
+
+  private func pickerOptions(for module: ControlDeckStatusModuleItem) -> [ControlDeckStatusModuleItem.Option] {
+    switch module.interaction {
+      case let .picker(options):
+        options
+      case .readOnly:
+        []
+    }
+  }
+
+  private func codexCollaborationModes(for module: ControlDeckStatusModuleItem) -> [CodexCollaborationMode] {
+    let modes = pickerOptions(for: module).compactMap { option in
+      CodexCollaborationMode(rawValue: option.value)
+    }
+    return modes.isEmpty ? CodexCollaborationMode.allCases : modes
+  }
+
+  private func autoReviewValue(for level: AutonomyLevel) -> String {
+    switch level {
+      case .locked: "locked"
+      case .guarded: "guarded"
+      case .autonomous: "autonomous"
+      case .open: "open"
+      case .fullAuto: "full_auto"
+      case .unrestricted: "unrestricted"
+    }
+  }
+
+  private func moduleTextColor(_ module: ControlDeckStatusModuleItem, interactive: Bool) -> Color {
+    if module.id == .tokens {
+      return tintColor(module.tintName)
+    }
+    return interactive ? Color.textPrimary : Color.textSecondary
+  }
+
+  private func tintColor(_ name: String) -> Color {
+    switch name {
+      case "accent": .accent
+      case "feedbackPositive": .feedbackPositive
+      case "feedbackCaution": .feedbackCaution
+      case "statusPermission": .statusPermission
+      case "statusEnded": .statusEnded
+      case "gitBranch": .gitBranch
+      case "textTertiary": .textTertiary
+      case "textSecondary": .textSecondary
+      case "textQuaternary": .textQuaternary
+      case "autonomyLocked": .autonomyLocked
+      case "autonomyGuarded": .autonomyGuarded
+      case "autonomyAutonomous": .autonomyAutonomous
+      case "autonomyOpen": .autonomyOpen
+      case "autonomyFullAuto": .autonomyFullAuto
+      case "autonomyUnrestricted": .autonomyUnrestricted
+      default: .textTertiary
+    }
+  }
+}

--- a/OrbitDockNative/OrbitDock/Views/Sessions/ControlDeck/ControlDeckStatusControls.swift
+++ b/OrbitDockNative/OrbitDock/Views/Sessions/ControlDeck/ControlDeckStatusControls.swift
@@ -1,0 +1,623 @@
+import SwiftUI
+
+enum CodexApprovalsReviewer: String, CaseIterable, Identifiable {
+  case user
+  case guardianSubagent = "guardian_subagent"
+
+  var id: String { rawValue }
+
+  var displayName: String {
+    switch self {
+      case .user: "You Review"
+      case .guardianSubagent: "Guardian Review"
+    }
+  }
+
+  var compactStatusName: String {
+    switch self {
+      case .user: "You"
+      case .guardianSubagent: "Guardian"
+    }
+  }
+
+  var icon: String {
+    switch self {
+      case .user: "person.crop.circle"
+      case .guardianSubagent: "shield.lefthalf.filled"
+    }
+  }
+
+  var color: Color {
+    switch self {
+      case .user: .textSecondary
+      case .guardianSubagent: .autonomyGuarded
+    }
+  }
+
+  var description: String {
+    switch self {
+      case .user:
+        "Approval requests come straight to you when Codex needs a review decision."
+      case .guardianSubagent:
+        "Codex routes approval requests through the Guardian reviewer subagent first, so it can gather context and apply a risk-based decision before involving you."
+    }
+  }
+
+  static func from(rawValue: String?) -> CodexApprovalsReviewer {
+    guard let rawValue, let reviewer = CodexApprovalsReviewer(rawValue: rawValue) else {
+      return .user
+    }
+    return reviewer
+  }
+}
+
+enum CodexApprovalMode: String, CaseIterable, Identifiable {
+  case untrusted
+  case onFailure = "on-failure"
+  case onRequest = "on-request"
+  case never
+
+  var id: String {
+    rawValue
+  }
+
+  var displayName: String {
+    switch self {
+      case .untrusted: "Review Writes"
+      case .onFailure: "Ask If Blocked"
+      case .onRequest: "Ask When Useful"
+      case .never: "Don't Interrupt"
+    }
+  }
+
+  var compactStatusName: String {
+    switch self {
+      case .untrusted: "Writes"
+      case .onFailure: "Blocked"
+      case .onRequest: "Useful"
+      case .never: "Quiet"
+    }
+  }
+
+  var icon: String {
+    switch self {
+      case .untrusted: "lock.shield.fill"
+      case .onFailure: "shield.lefthalf.filled"
+      case .onRequest: "checkmark.shield.fill"
+      case .never: "bolt.fill"
+    }
+  }
+
+  var color: Color {
+    switch self {
+      case .untrusted: .autonomyLocked
+      case .onFailure: .autonomyGuarded
+      case .onRequest: .autonomyAutonomous
+      case .never: .autonomyFullAuto
+    }
+  }
+
+  var description: String {
+    switch self {
+      case .untrusted:
+        "Reads can continue quietly, but Codex stops and asks before it edits files, writes data, or runs commands."
+      case .onFailure:
+        "Codex tries the work inside the sandbox first. You only get interrupted when the sandbox blocks what it wants to do."
+      case .onRequest:
+        "Codex can choose to pause and ask when it thinks a handoff is useful, even if the sandbox has not blocked the work."
+      case .never:
+        "Codex will not stop to ask for approval. Use this only when you intentionally want uninterrupted execution."
+    }
+  }
+
+  static func from(rawValue: String?) -> CodexApprovalMode {
+    guard let rawValue, let mode = CodexApprovalMode(rawValue: rawValue) else {
+      return .onRequest
+    }
+    return mode
+  }
+
+  static func supportedCases(from options: [ControlDeckStatusModuleItem.Option]) -> [CodexApprovalMode] {
+    let modes = options.compactMap { CodexApprovalMode(rawValue: $0.value) }
+    return modes.isEmpty ? allCases : modes
+  }
+}
+
+struct CodexApprovalPill: View {
+  enum PillSize {
+    case regular
+    case statusBar
+
+    var iconFontSize: CGFloat {
+      switch self {
+        case .regular: TypeScale.body
+        case .statusBar:
+          #if os(iOS)
+            IconScale.xs
+          #else
+            IconScale.sm
+          #endif
+      }
+    }
+
+    var textFontSize: CGFloat {
+      switch self {
+        case .regular: TypeScale.body
+        case .statusBar:
+          #if os(iOS)
+            TypeScale.mini
+          #else
+            TypeScale.micro
+          #endif
+      }
+    }
+
+    var horizontalPadding: CGFloat {
+      switch self {
+        case .regular: CGFloat(Spacing.md)
+        case .statusBar:
+          #if os(iOS)
+            CGFloat(Spacing.sm_)
+          #else
+            CGFloat(Spacing.sm)
+          #endif
+      }
+    }
+
+    var verticalPadding: CGFloat {
+      switch self {
+        case .regular: CGFloat(Spacing.sm)
+        case .statusBar:
+          #if os(iOS)
+            CGFloat(Spacing.gap)
+          #else
+            CGFloat(Spacing.xs)
+          #endif
+      }
+    }
+
+    var spacing: CGFloat {
+      switch self {
+        case .regular: CGFloat(Spacing.xs)
+        case .statusBar: CGFloat(Spacing.xs)
+      }
+    }
+
+    var height: CGFloat? {
+      switch self {
+        case .regular:
+          nil
+        case .statusBar:
+          #if os(iOS)
+            24
+          #else
+            20
+          #endif
+      }
+    }
+  }
+
+  let currentMode: CodexApprovalMode
+  var currentReviewer: CodexApprovalsReviewer = .user
+  var supportedModes: [CodexApprovalMode] = CodexApprovalMode.allCases
+  var size: PillSize = .regular
+  var onUpdate: ((CodexApprovalMode) -> Void)?
+  var onReviewerUpdate: ((CodexApprovalsReviewer) -> Void)?
+  @State private var showPopover = false
+
+  private var title: String {
+    #if os(iOS)
+      if size == .statusBar { return currentMode.compactStatusName }
+    #endif
+    return currentMode.displayName
+  }
+
+  var body: some View {
+    Button {
+      showPopover.toggle()
+    } label: {
+      HStack(spacing: size.spacing) {
+        Image(systemName: currentMode.icon)
+          .font(.system(size: size.iconFontSize, weight: .semibold))
+        Text(title)
+          .font(.system(size: size.textFontSize, weight: .semibold))
+      }
+      .foregroundStyle(currentMode.color)
+      .padding(.horizontal, size.horizontalPadding)
+      .padding(.vertical, size.verticalPadding)
+      .frame(height: size.height)
+      .background(currentMode.color.opacity(OpacityTier.light), in: Capsule())
+      .overlay(
+        Capsule()
+          .strokeBorder(currentMode.color.opacity(OpacityTier.medium), lineWidth: 0.75)
+      )
+      .if(size == .regular) { $0.themeShadow(Shadow.sm) }
+    }
+    .buttonStyle(.plain)
+    .fixedSize()
+    .platformPopover(isPresented: $showPopover) {
+      ScrollView {
+        VStack(alignment: .leading, spacing: Spacing.md) {
+          VStack(alignment: .leading, spacing: Spacing.xs) {
+            Text("Codex Approvals")
+              .font(.system(size: TypeScale.subhead, weight: .semibold))
+              .foregroundStyle(Color.textPrimary)
+
+            Text("Choose when Codex should pause and who reviews approval requests first.")
+              .font(.system(size: TypeScale.caption))
+              .foregroundStyle(Color.textSecondary)
+              .fixedSize(horizontal: false, vertical: true)
+          }
+
+          settingsSection(
+            title: "When Codex Interrupts You",
+            detail: "This is the provider approval policy."
+          ) {
+            ForEach(supportedModes) { mode in
+              selectionRow(
+                title: mode.displayName,
+                detail: mode.description,
+                icon: mode.icon,
+                tint: mode.color,
+                isSelected: mode == currentMode
+              ) {
+                onUpdate?(mode)
+                showPopover = false
+              }
+            }
+          }
+
+          settingsSection(
+            title: "Who Reviews Approval Requests",
+            detail: "Codex calls this approvals reviewer."
+          ) {
+            ForEach(CodexApprovalsReviewer.allCases) { reviewer in
+              selectionRow(
+                title: reviewer.displayName,
+                detail: reviewer.description,
+                icon: reviewer.icon,
+                tint: reviewer.color,
+                isSelected: reviewer == currentReviewer
+              ) {
+                onReviewerUpdate?(reviewer)
+                showPopover = false
+              }
+            }
+          }
+        }
+        .padding(Spacing.lg)
+      }
+      #if os(iOS)
+        .frame(maxWidth: .infinity)
+        .navigationTitle("Approval")
+        .navigationBarTitleDisplayMode(.inline)
+      #endif
+        .ifMacOS { $0.frame(width: 320) }
+      .background(Color.backgroundSecondary)
+    }
+  }
+
+  private func settingsSection<Content: View>(
+    title: String,
+    detail: String,
+    @ViewBuilder content: () -> Content
+  ) -> some View {
+    VStack(alignment: .leading, spacing: Spacing.sm) {
+      VStack(alignment: .leading, spacing: Spacing.xxs) {
+        Text(title)
+          .font(.system(size: TypeScale.caption, weight: .semibold))
+          .foregroundStyle(Color.textPrimary)
+
+        Text(detail)
+          .font(.system(size: TypeScale.micro))
+          .foregroundStyle(Color.textTertiary)
+          .fixedSize(horizontal: false, vertical: true)
+      }
+
+      VStack(alignment: .leading, spacing: Spacing.xxs) {
+        content()
+      }
+    }
+  }
+
+  private func selectionRow(
+    title: String,
+    detail: String,
+    icon: String,
+    tint: Color,
+    isSelected: Bool,
+    action: @escaping () -> Void
+  ) -> some View {
+    Button(action: action) {
+      HStack(alignment: .top, spacing: Spacing.sm) {
+        Image(systemName: icon)
+          .font(.system(size: TypeScale.caption, weight: .semibold))
+          .foregroundStyle(tint)
+          .frame(width: 18, height: 18)
+
+        VStack(alignment: .leading, spacing: Spacing.xxs) {
+          Text(title)
+            .font(.system(size: TypeScale.body, weight: .semibold))
+            .foregroundStyle(Color.textPrimary)
+
+          Text(detail)
+            .font(.system(size: TypeScale.caption))
+            .foregroundStyle(Color.textTertiary)
+            .fixedSize(horizontal: false, vertical: true)
+        }
+
+        Spacer(minLength: Spacing.sm)
+
+        if isSelected {
+          Image(systemName: "checkmark.circle.fill")
+            .font(.system(size: TypeScale.caption, weight: .semibold))
+            .foregroundStyle(Color.accent)
+        }
+      }
+      .padding(.vertical, Spacing.xs)
+      .contentShape(Rectangle())
+    }
+    .buttonStyle(.plain)
+  }
+}
+
+extension AutonomyLevel {
+  static func fromAutoReviewValue(_ value: String?) -> AutonomyLevel? {
+    switch value {
+      case "locked": .locked
+      case "guarded": .guarded
+      case "autonomous": .autonomous
+      case "open": .open
+      case "full_auto": .fullAuto
+      case "unrestricted": .unrestricted
+      default: nil
+    }
+  }
+
+  static func supportedAutoReviewCases(
+    from options: [ControlDeckStatusModuleItem.Option]
+  ) -> [AutonomyLevel] {
+    let levels = options.compactMap { option in
+      fromAutoReviewValue(option.value)
+    }
+    return levels.isEmpty ? allCases : levels
+  }
+}
+
+struct CodexAutoReviewPill: View {
+  let currentLevel: AutonomyLevel
+  var supportedLevels: [AutonomyLevel] = AutonomyLevel.allCases
+  var size: CodexApprovalPill.PillSize = .regular
+  var onUpdate: ((AutonomyLevel) -> Void)?
+  @State private var showPopover = false
+
+  private var title: String {
+    #if os(iOS)
+      if size == .statusBar {
+        switch currentLevel {
+          case .locked: return "You"
+          case .guarded: return "Sandbox"
+          case .autonomous: return "OrbitDock"
+          case .open: return "OrbitDock+"
+          case .fullAuto: return "Codex"
+          case .unrestricted: return "None"
+        }
+      }
+    #endif
+    return currentLevel.controlDeckAutoReviewLabel
+  }
+
+  var body: some View {
+    Button {
+      showPopover.toggle()
+    } label: {
+      HStack(spacing: size.spacing) {
+        Image(systemName: currentLevel.autoReviewStatusIcon)
+          .font(.system(size: size.iconFontSize, weight: .semibold))
+        Text(title)
+          .font(.system(size: size.textFontSize, weight: .semibold))
+      }
+      .foregroundStyle(currentLevel.color)
+      .padding(.horizontal, size.horizontalPadding)
+      .padding(.vertical, size.verticalPadding)
+      .frame(height: size.height)
+      .background(currentLevel.color.opacity(OpacityTier.light), in: Capsule())
+      .overlay(
+        Capsule()
+          .strokeBorder(currentLevel.color.opacity(OpacityTier.medium), lineWidth: 0.75)
+      )
+      .if(size == .regular) { $0.themeShadow(Shadow.sm) }
+    }
+    .buttonStyle(.plain)
+    .fixedSize()
+    .platformPopover(isPresented: $showPopover) {
+      ScrollView {
+        VStack(alignment: .leading, spacing: Spacing.md) {
+          VStack(alignment: .leading, spacing: Spacing.xs) {
+            Text("If Work Gets Blocked")
+              .font(.system(size: TypeScale.subhead, weight: .semibold))
+              .foregroundStyle(Color.textPrimary)
+
+            Text("Choose who gets the first chance to handle blocked work before it comes back to you.")
+              .font(.system(size: TypeScale.caption))
+              .foregroundStyle(Color.textSecondary)
+              .fixedSize(horizontal: false, vertical: true)
+          }
+
+          ForEach(supportedLevels) { level in
+            Button {
+              onUpdate?(level)
+              showPopover = false
+            } label: {
+              HStack(alignment: .top, spacing: Spacing.sm) {
+                Image(systemName: level.autoReviewStatusIcon)
+                  .font(.system(size: TypeScale.caption, weight: .semibold))
+                  .foregroundStyle(level.color)
+                  .frame(width: 18, height: 18)
+
+                VStack(alignment: .leading, spacing: Spacing.xxs) {
+                  Text(level.controlDeckAutoReviewLabel)
+                    .font(.system(size: TypeScale.body, weight: .semibold))
+                    .foregroundStyle(Color.textPrimary)
+
+                  Text(level.controlDeckAutoReviewSummary)
+                    .font(.system(size: TypeScale.caption))
+                    .foregroundStyle(Color.textTertiary)
+                    .fixedSize(horizontal: false, vertical: true)
+                }
+
+                Spacer(minLength: Spacing.sm)
+
+                if level == currentLevel {
+                  Image(systemName: "checkmark.circle.fill")
+                    .font(.system(size: TypeScale.caption, weight: .semibold))
+                    .foregroundStyle(Color.accent)
+                }
+              }
+              .padding(.vertical, Spacing.xs)
+            }
+            .buttonStyle(.plain)
+          }
+        }
+        .padding(Spacing.lg)
+      }
+      #if os(iOS)
+        .frame(maxWidth: .infinity)
+        .navigationTitle("Auto Review")
+        .navigationBarTitleDisplayMode(.inline)
+      #endif
+        .ifMacOS { $0.frame(width: 340) }
+        .background(Color.backgroundSecondary)
+    }
+  }
+}
+
+extension EffortLevel {
+  static func fromControlDeckValue(_ value: String?) -> EffortLevel {
+    guard let value, let level = EffortLevel(rawValue: value) else {
+      return .default
+    }
+    return level
+  }
+
+  static func supportedControlDeckCases(
+    from options: [ControlDeckStatusModuleItem.Option]
+  ) -> [EffortLevel] {
+    let levels = options.compactMap { option in
+      EffortLevel(rawValue: option.value)
+    }
+    return levels.isEmpty ? concreteCases : levels
+  }
+}
+
+struct EffortPill: View {
+  let currentLevel: EffortLevel
+  var supportedLevels: [EffortLevel] = EffortLevel.concreteCases
+  var size: CodexApprovalPill.PillSize = .regular
+  var onUpdate: ((EffortLevel) -> Void)?
+  @State private var showPopover = false
+
+  private var title: String {
+    #if os(iOS)
+      if size == .statusBar, currentLevel == .default {
+        return "Auto"
+      }
+    #endif
+    return currentLevel.displayName
+  }
+
+  var body: some View {
+    Button {
+      showPopover.toggle()
+    } label: {
+      HStack(spacing: size.spacing) {
+        Image(systemName: currentLevel.icon)
+          .font(.system(size: size.iconFontSize, weight: .semibold))
+        Text(title)
+          .font(.system(size: size.textFontSize, weight: .semibold))
+      }
+      .foregroundStyle(currentLevel == .default ? Color.accent : currentLevel.color)
+      .padding(.horizontal, size.horizontalPadding)
+      .padding(.vertical, size.verticalPadding)
+      .frame(height: size.height)
+      .background((currentLevel == .default ? Color.accent : currentLevel.color).opacity(OpacityTier.light), in: Capsule())
+      .overlay(
+        Capsule()
+          .strokeBorder((currentLevel == .default ? Color.accent : currentLevel.color).opacity(OpacityTier.medium), lineWidth: 0.75)
+      )
+      .if(size == .regular) { $0.themeShadow(Shadow.sm) }
+    }
+    .buttonStyle(.plain)
+    .fixedSize()
+    .platformPopover(isPresented: $showPopover) {
+      ScrollView {
+        VStack(alignment: .leading, spacing: Spacing.md) {
+          VStack(alignment: .leading, spacing: Spacing.xs) {
+            Text("Reasoning Effort")
+              .font(.system(size: TypeScale.subhead, weight: .semibold))
+              .foregroundStyle(Color.textPrimary)
+
+            Text("Controls how much extra reasoning time Codex spends before responding.")
+              .font(.system(size: TypeScale.caption))
+              .foregroundStyle(Color.textSecondary)
+              .fixedSize(horizontal: false, vertical: true)
+          }
+
+          ForEach(supportedLevels) { level in
+            Button {
+              onUpdate?(level)
+              showPopover = false
+            } label: {
+              HStack(alignment: .top, spacing: Spacing.sm) {
+                Image(systemName: level.icon)
+                  .font(.system(size: TypeScale.caption, weight: .semibold))
+                  .foregroundStyle(level.color)
+                  .frame(width: 18, height: 18)
+
+                VStack(alignment: .leading, spacing: Spacing.xxs) {
+                  HStack(spacing: Spacing.xs) {
+                    Text(level.displayName)
+                      .font(.system(size: TypeScale.body, weight: .semibold))
+                      .foregroundStyle(Color.textPrimary)
+
+                    if !level.speedLabel.isEmpty {
+                      Text(level.speedLabel)
+                        .font(.system(size: TypeScale.micro, weight: .bold, design: .monospaced))
+                        .foregroundStyle(Color.textTertiary)
+                        .padding(.horizontal, Spacing.xs)
+                        .padding(.vertical, 1)
+                        .background(Color.backgroundPrimary, in: Capsule())
+                    }
+                  }
+
+                  Text(level.description)
+                    .font(.system(size: TypeScale.caption))
+                    .foregroundStyle(Color.textTertiary)
+                    .fixedSize(horizontal: false, vertical: true)
+                }
+
+                Spacer(minLength: Spacing.sm)
+
+                if level == currentLevel {
+                  Image(systemName: "checkmark.circle.fill")
+                    .font(.system(size: TypeScale.caption, weight: .semibold))
+                    .foregroundStyle(Color.accent)
+                }
+              }
+              .padding(.vertical, Spacing.xs)
+            }
+            .buttonStyle(.plain)
+          }
+        }
+        .padding(Spacing.lg)
+      }
+      #if os(iOS)
+        .frame(maxWidth: .infinity)
+        .navigationTitle("Reasoning Effort")
+        .navigationBarTitleDisplayMode(.inline)
+      #endif
+        .ifMacOS { $0.frame(width: 320) }
+        .background(Color.backgroundSecondary)
+    }
+  }
+}

--- a/OrbitDockNative/OrbitDock/Views/Sessions/ControlDeck/ControlDeckSubmitEncoder.swift
+++ b/OrbitDockNative/OrbitDock/Views/Sessions/ControlDeck/ControlDeckSubmitEncoder.swift
@@ -1,0 +1,94 @@
+import Foundation
+
+enum ControlDeckSubmitEncoder {
+  static func encode(
+    draft: ControlDeckDraft,
+    uploadedImageIds: [String: String],
+    availableSkills: [ControlDeckSkill]
+  ) -> ServerControlDeckSubmitTurnRequest {
+    ServerControlDeckSubmitTurnRequest(
+      text: draft.trimmedText,
+      attachments: encodeAttachments(draft.attachments, uploadedImageIds: uploadedImageIds),
+      skills: encodeSkills(selectedPaths: draft.selectedSkillPaths, availableSkills: availableSkills),
+      overrides: encodeOverrides(model: draft.modelOverride, effort: draft.effortOverride)
+    )
+  }
+
+  // MARK: - Attachments
+
+  static func encodeSteerImages(
+    _ state: ControlDeckAttachmentState,
+    uploadedImageIds: [String: String]
+  ) -> [ServerImageInput] {
+    state.images.compactMap { image in
+      guard let serverId = uploadedImageIds[image.localId] else { return nil }
+      return ServerImageInput(
+        inputType: "attachment",
+        value: serverId,
+        displayName: image.displayName,
+        pixelWidth: image.pixelWidth,
+        pixelHeight: image.pixelHeight
+      )
+    }
+  }
+
+  static func encodeSteerMentions(_ state: ControlDeckAttachmentState) -> [ServerMentionInput] {
+    state.mentions.map { mention in
+      ServerMentionInput(name: mention.name, path: mention.absolutePath)
+    }
+  }
+
+  private static func encodeAttachments(
+    _ state: ControlDeckAttachmentState,
+    uploadedImageIds: [String: String]
+  ) -> [ServerControlDeckAttachmentRef] {
+    state.items.compactMap { item in
+      switch item.kind {
+        case let .image(image):
+          guard let serverId = uploadedImageIds[image.localId] else { return nil }
+          return .image(ServerControlDeckImageAttachmentRef(
+            attachmentId: serverId,
+            displayName: image.displayName
+          ))
+        case let .mention(mention):
+          return .mention(ServerControlDeckMentionRef(
+            mentionId: mention.fileId,
+            kind: encodeMentionKind(mention.kind),
+            name: mention.name,
+            path: mention.absolutePath,
+            relativePath: mention.relativePath
+          ))
+      }
+    }
+  }
+
+  // MARK: - Skills
+
+  private static func encodeSkills(
+    selectedPaths: Set<String>,
+    availableSkills: [ControlDeckSkill]
+  ) -> [ServerControlDeckSkillRef] {
+    availableSkills
+      .filter { selectedPaths.contains($0.path) }
+      .map { ServerControlDeckSkillRef(name: $0.name, path: $0.path) }
+  }
+
+  // MARK: - Overrides
+
+  private static func encodeOverrides(model: String?, effort: String?) -> ServerControlDeckTurnOverrides? {
+    guard model != nil || effort != nil else { return nil }
+    return ServerControlDeckTurnOverrides(model: model, effort: effort)
+  }
+
+  // MARK: - Mention Kind
+
+  private static func encodeMentionKind(_ kind: ControlDeckMentionKind) -> ServerControlDeckMentionKind {
+    switch kind {
+      case .file: .file
+      case .mcpResource: .mcpResource
+      case .url: .url
+      case .symbol: .symbol
+      case .generic: .generic
+    }
+  }
+}

--- a/OrbitDockNative/OrbitDock/Views/Sessions/ControlDeck/ControlDeckView.swift
+++ b/OrbitDockNative/OrbitDock/Views/Sessions/ControlDeck/ControlDeckView.swift
@@ -1,0 +1,275 @@
+import SwiftUI
+import UniformTypeIdentifiers
+
+enum ControlDeckChromeStyle {
+  case standalone
+  case embedded
+}
+
+struct ControlDeckView: View {
+  // State from parent
+  @Binding var draft: ControlDeckDraft
+  @Binding var focusState: ComposerFocusState
+  @Binding var completionState: ControlDeckCompletionState
+  let isSubmitting: Bool
+  let canSubmit: Bool
+  let presentation: ControlDeckPresentation?
+  let pendingApproval: ControlDeckApproval?
+  let completionSuggestions: [ControlDeckCompletionSuggestion]
+  let errorMessage: String?
+  var chromeStyle: ControlDeckChromeStyle = .standalone
+
+  // Compose callbacks
+  let onTextChange: (String) -> Void
+  let onKeyCommand: (ComposerTextAreaKeyCommand) -> Bool
+  let onFocusEvent: (ComposerTextAreaFocusEvent) -> Void
+  let onPasteImage: () -> Bool
+  let canPasteImage: () -> Bool
+  let onAddImage: () -> Void
+  let onRemoveAttachment: (String) -> Void
+  let onDropImages: ([NSItemProvider]) -> Bool
+  let onSelectSuggestion: (ControlDeckCompletionSuggestion) -> Void
+  let onSubmit: () -> Void
+
+  // Approval callbacks
+  var onApprove: (() -> Void)?
+  var onApproveForSession: (() -> Void)?
+  var onDeny: (() -> Void)?
+  var onAnswer: ((String, String?) -> Void)?
+  var onGrantPermission: (() -> Void)?
+  var onGrantPermissionForSession: (() -> Void)?
+  var onDenyPermission: (() -> Void)?
+
+  // Terminal integration
+  var terminalTitle: String?
+  var sessionDisplayStatus: SessionDisplayStatus = .ended
+  var currentTool: String?
+  var onToggleTerminal: (() -> Void)?
+  var onModuleAction: ((ControlDeckStatusModule, String) -> Void)?
+  var onApprovalReviewerAction: ((ServerCodexApprovalsReviewer) -> Void)?
+  var isDictating: Bool = false
+  var isSessionWorking: Bool = false
+  var onDictation: (() -> Void)?
+  var onInterrupt: (() -> Void)?
+
+  @Environment(\.horizontalSizeClass) private var horizontalSizeClass
+
+  private var isApprovalMode: Bool {
+    presentation?.mode == .approval && pendingApproval != nil
+  }
+
+  private var isCompactIOS: Bool {
+    #if os(iOS)
+      horizontalSizeClass == .compact
+    #else
+      false
+    #endif
+  }
+
+  private var shouldOverlayCompletions: Bool {
+    isCompactIOS
+  }
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 0) {
+      if isApprovalMode, let approval = pendingApproval {
+        // Approval zone replaces the editor + submit bar
+        ControlDeckApprovalZone(
+          approval: approval,
+          onApprove: { onApprove?() },
+          onApproveForSession: { onApproveForSession?() },
+          onDeny: { onDeny?() },
+          onAnswer: { answer, promptId in onAnswer?(answer, promptId) },
+          onGrantPermission: { onGrantPermission?() },
+          onGrantPermissionForSession: { onGrantPermissionForSession?() },
+          onDenyPermission: { onDenyPermission?() }
+        )
+      } else {
+        composeContent
+      }
+
+      // Unified action + status bar — always visible (anchors across mode shifts)
+      if let presentation {
+        ControlDeckStatusBar(
+          modules: presentation.statusModules,
+          onModuleAction: onModuleAction,
+          onApprovalReviewerAction: onApprovalReviewerAction,
+          supportsImages: !isApprovalMode && (presentation.supportsImages),
+          canPasteImage: !isApprovalMode && canPasteImage(),
+          canSubmit: !isApprovalMode && canSubmit,
+          isSubmitting: isSubmitting,
+          sendTint: presentation.sendTint,
+          onAddImage: onAddImage,
+          onPasteImage: { _ = onPasteImage() },
+          onSubmit: onSubmit,
+          isDictating: isDictating,
+          isSessionWorking: isSessionWorking,
+          onDictation: onDictation,
+          onInterrupt: onInterrupt
+        )
+        .padding(.horizontal, Spacing.md)
+        .padding(.bottom, Spacing.sm)
+        .padding(.top, Spacing.xs)
+      }
+    }
+    .background(backgroundStyle)
+    .clipShape(containerShape)
+    .overlay(containerOverlay)
+    .overlay(alignment: .bottomLeading) {
+      if shouldOverlayCompletions, !isApprovalMode, completionState.isActive, !completionSuggestions.isEmpty {
+        completionPanel
+          .padding(.horizontal, Spacing.md)
+          .padding(.bottom, 54)
+          .transition(.move(edge: .bottom).combined(with: .opacity))
+      }
+    }
+    .shadow(color: shadowColor, radius: shadowRadius, y: 0)
+    .animation(.spring(response: 0.35, dampingFraction: 0.8), value: isApprovalMode)
+    .animation(.easeInOut(duration: 0.2), value: focusState.isFocused)
+    .animation(.easeInOut(duration: 0.25), value: isSteerMode)
+  }
+
+  private var isSteerMode: Bool {
+    presentation?.mode == .steer
+  }
+
+  private var hasBorderHighlight: Bool {
+    if isApprovalMode { return true }
+    if isSteerMode { return true }
+    return focusState.isFocused
+  }
+
+  private var borderColor: Color {
+    if isApprovalMode {
+      switch pendingApproval?.kind {
+        case .tool: return Color.feedbackCaution.opacity(0.5)
+        case .permission: return Color.statusPermission.opacity(0.5)
+        case .question: return Color.accent.opacity(0.5)
+        case .none: return Color.panelBorder
+      }
+    }
+    if isSteerMode { return Color.statusWorking.opacity(0.5) }
+    return focusState.isFocused ? Color.accent.opacity(0.5) : Color.panelBorder
+  }
+
+  private var borderGlowColor: Color {
+    if isApprovalMode { return .clear }
+    if isSteerMode { return Color.statusWorking.opacity(0.12) }
+    if focusState.isFocused { return Color.accent.opacity(0.12) }
+    return .clear
+  }
+
+  private var backgroundStyle: Color {
+    chromeStyle == .embedded ? .clear : Color.backgroundSecondary
+  }
+
+  private var containerShape: some Shape {
+    RoundedRectangle(cornerRadius: chromeStyle == .embedded ? Radius.lg : Radius.xl, style: .continuous)
+  }
+
+  @ViewBuilder
+  private var containerOverlay: some View {
+    if chromeStyle == .standalone {
+      RoundedRectangle(cornerRadius: Radius.xl, style: .continuous)
+        .strokeBorder(
+          borderColor,
+          lineWidth: hasBorderHighlight ? 1.5 : 1
+        )
+    } else {
+      EmptyView()
+    }
+  }
+
+  private var shadowColor: Color {
+    chromeStyle == .embedded ? .clear : borderGlowColor
+  }
+
+  private var shadowRadius: CGFloat {
+    chromeStyle == .embedded ? 0 : 16
+  }
+
+  // MARK: - Compose Content
+
+  private var composeContent: some View {
+    Group {
+      // Attachment chips
+      if draft.attachments.hasItems {
+        ControlDeckAttachmentTray(
+          attachments: draft.attachments.items,
+          onRemove: onRemoveAttachment
+        )
+        .padding(.horizontal, Spacing.md)
+        .padding(.top, Spacing.sm)
+        .padding(.bottom, Spacing.xs)
+      }
+
+      // Text editor
+      editorSection
+        .padding(.horizontal, Spacing.md)
+        .padding(.top, draft.attachments.hasItems ? 0 : Spacing.sm)
+
+      // Completion panel
+      if !shouldOverlayCompletions, completionState.isActive, !completionSuggestions.isEmpty {
+        completionPanel
+          .padding(.horizontal, Spacing.md)
+          .padding(.top, Spacing.xs)
+      }
+
+      // Error
+      if let errorMessage, !errorMessage.isEmpty {
+        Text(errorMessage)
+          .font(.system(size: TypeScale.caption, weight: .medium, design: .monospaced))
+          .foregroundStyle(Color.statusPermission)
+          .textSelection(.enabled)
+          .lineLimit(2)
+          .padding(.horizontal, Spacing.lg)
+          .padding(.top, Spacing.xs)
+      }
+    }
+  }
+
+  // MARK: - Editor
+
+  private var editorSection: some View {
+    ZStack(alignment: .topLeading) {
+      if draft.text.isEmpty {
+        Text(presentation?.placeholder ?? "Message the session\u{2026}")
+          .font(.system(size: TypeScale.body))
+          .foregroundStyle(Color.textTertiary)
+          .padding(.top, Spacing.xxs)
+          .padding(.leading, Spacing.xxs)
+          .allowsHitTesting(false)
+      }
+
+      ComposerTextArea(
+        text: $draft.text,
+        placeholder: "",
+        focusRequestSignal: $focusState.focusRequestSignal,
+        blurRequestSignal: $focusState.blurRequestSignal,
+        moveCursorToEndSignal: $focusState.moveCursorToEndSignal,
+        measuredHeight: $focusState.measuredHeight,
+        isEnabled: !isSubmitting,
+        minLines: 1,
+        maxLines: 8,
+        onPasteImage: onPasteImage,
+        canPasteImage: canPasteImage,
+        onKeyCommand: onKeyCommand,
+        onFocusEvent: onFocusEvent
+      )
+    }
+    .frame(height: max(focusState.measuredHeight, 20))
+    .onDrop(of: [.image, .fileURL], isTargeted: nil, perform: onDropImages)
+    .onChange(of: draft.text) { _, newValue in
+      onTextChange(newValue)
+    }
+  }
+
+  private var completionPanel: some View {
+    ControlDeckCompletionPanel(
+      mode: completionState.mode,
+      suggestions: completionSuggestions,
+      selectedIndex: completionState.selectedIndex,
+      onSelect: onSelectSuggestion
+    )
+  }
+}

--- a/OrbitDockNative/OrbitDock/Views/Sessions/ControlDeck/ControlDeckViewModel.swift
+++ b/OrbitDockNative/OrbitDock/Views/Sessions/ControlDeck/ControlDeckViewModel.swift
@@ -1,0 +1,421 @@
+import Foundation
+
+@MainActor
+@Observable
+final class ControlDeckViewModel {
+  // MARK: - Deck-native state (no Server* types)
+
+  private(set) var snapshot: ControlDeckSnapshot?
+  private(set) var presentation: ControlDeckPresentation?
+  private(set) var pendingApproval: ControlDeckApproval?
+  private(set) var skills: [ControlDeckSkill] = []
+  private(set) var isLoading = false
+  var lastError: String?
+
+  // MARK: - Binding
+
+  @ObservationIgnored private var currentSessionId: String?
+  @ObservationIgnored private var currentSessionStore: SessionStore?
+
+  func bind(sessionId: String, sessionStore: SessionStore) {
+    currentSessionId = sessionId
+    currentSessionStore = sessionStore
+  }
+
+  // MARK: - Bootstrap
+
+  func refresh() async {
+    guard let sessionId = currentSessionId, let store = currentSessionStore else { return }
+
+    isLoading = true
+    lastError = nil
+
+    do {
+      let serverSnapshot = try await store.fetchControlDeckSnapshot(sessionId: sessionId)
+      applySnapshotPayload(serverSnapshot)
+      await loadCodexModelsIfNeeded(for: serverSnapshot.state.provider)
+    } catch {
+      lastError = String(describing: error)
+    }
+
+    isLoading = false
+  }
+
+  // MARK: - Skills
+
+  func loadSkills() async {
+    guard let sessionId = currentSessionId, let store = currentSessionStore else { return }
+    do {
+      try await store.listSkills(sessionId: sessionId)
+      let serverSkills = store.session(sessionId).skills
+      skills = serverSkills.filter(\.enabled).map(ControlDeckSnapshotMapper.mapSkill)
+    } catch {
+      lastError = String(describing: error)
+    }
+  }
+
+  // MARK: - Submit / Steer
+
+  func submitTurn(
+    draft: ControlDeckDraft,
+    uploadedImageIds: [String: String]
+  ) async throws {
+    guard let sessionId = currentSessionId, let store = currentSessionStore else { return }
+
+    let request = ControlDeckSubmitEncoder.encode(
+      draft: draft,
+      uploadedImageIds: uploadedImageIds,
+      availableSkills: skills
+    )
+
+    try await store.submitControlDeckTurn(sessionId: sessionId, request: request)
+  }
+
+  func steerTurn(
+    draft: ControlDeckDraft,
+    uploadedImageIds: [String: String]
+  ) async throws {
+    guard let sessionId = currentSessionId, let store = currentSessionStore else { return }
+    try await store.steerTurn(
+      sessionId: sessionId,
+      content: draft.trimmedText,
+      images: ControlDeckSubmitEncoder.encodeSteerImages(
+        draft.attachments,
+        uploadedImageIds: uploadedImageIds
+      ),
+      mentions: ControlDeckSubmitEncoder.encodeSteerMentions(draft.attachments)
+    )
+  }
+
+  func interruptSession() async {
+    guard let sessionId = currentSessionId, let store = currentSessionStore else { return }
+    do {
+      try await store.interruptSession(sessionId)
+    } catch {
+      lastError = String(describing: error)
+    }
+  }
+
+  // MARK: - Image Upload
+
+  /// Uploads an image and returns the server attachment ID (ServerImageInput.value).
+  func uploadImage(
+    data: Data,
+    mimeType: String,
+    displayName: String,
+    pixelWidth: Int?,
+    pixelHeight: Int?
+  ) async throws -> String {
+    guard let sessionId = currentSessionId, let store = currentSessionStore else {
+      throw ControlDeckError.notBound
+    }
+
+    let result = try await store.clients.controlDeck.uploadImageAttachment(
+      sessionId: sessionId,
+      data: data,
+      mimeType: mimeType,
+      displayName: displayName,
+      pixelWidth: pixelWidth,
+      pixelHeight: pixelHeight
+    )
+    return result.attachmentId
+  }
+
+  // MARK: - Preferences
+
+  func updatePreferences(_ preferences: ControlDeckPreferences) async throws {
+    guard let store = currentSessionStore else { return }
+
+    let serverPrefs = ControlDeckPreferencesEncoder.encode(preferences)
+    let updated = try await store.updateControlDeckPreferences(serverPrefs)
+
+    if var current = snapshot {
+      current = ControlDeckSnapshot(
+        revision: current.revision,
+        sessionId: current.sessionId,
+        state: current.state,
+        capabilities: current.capabilities,
+        preferences: ControlDeckSnapshotMapper.mapPreferences(updated),
+        tokenUsage: current.tokenUsage,
+        tokenUsageSnapshotKind: current.tokenUsageSnapshotKind,
+        tokenStatus: current.tokenStatus
+      )
+      snapshot = current
+      presentation = ControlDeckPresentationBuilder.build(
+        snapshot: current,
+        isLoading: false,
+        hasPendingApproval: pendingApproval != nil,
+        availableModels: availableModels
+      )
+    }
+  }
+
+  // MARK: - Approval Sync
+
+  /// Call from a task that observes session changes to keep approval in sync.
+  func syncApproval() {
+    guard let sessionId = currentSessionId, let store = currentSessionStore else {
+      pendingApproval = nil
+      return
+    }
+    let session = store.session(sessionId)
+    if let serverApproval = session.pendingApproval {
+      pendingApproval = ControlDeckSnapshotMapper.mapApproval(serverApproval)
+    } else {
+      pendingApproval = nil
+    }
+
+    // Sync live session flags into the snapshot so mode resolves correctly
+    if let snap = snapshot {
+      let resolvedProjectPath = session.projectPath.trimmingCharacters(in: .whitespacesAndNewlines)
+      let projectPath = resolvedProjectPath.isEmpty ? snap.state.projectPath : resolvedProjectPath
+      let currentCwd = nonEmpty(session.currentCwd) ?? snap.state.currentCwd
+      let gitBranch = nonEmpty(session.branch) ?? snap.state.gitBranch
+
+      let updatedState = ControlDeckSessionState(
+        provider: snap.state.provider,
+        controlMode: snap.state.controlMode,
+        lifecycle: snap.state.lifecycle,
+        acceptsUserInput: session.acceptsUserInput,
+        steerable: session.steerable,
+        projectPath: projectPath,
+        currentCwd: currentCwd,
+        gitBranch: gitBranch,
+        config: snap.state.config
+      )
+      let updatedSnap = ControlDeckSnapshot(
+        revision: snap.revision,
+        sessionId: snap.sessionId,
+        state: updatedState,
+        capabilities: snap.capabilities,
+        preferences: snap.preferences,
+        tokenUsage: snap.tokenUsage,
+        tokenUsageSnapshotKind: snap.tokenUsageSnapshotKind,
+        tokenStatus: snap.tokenStatus
+      )
+      snapshot = updatedSnap
+      presentation = ControlDeckPresentationBuilder.build(
+        snapshot: updatedSnap,
+        isLoading: false,
+        hasPendingApproval: pendingApproval != nil,
+        availableModels: availableModels
+      )
+    }
+  }
+
+  // MARK: - Approval Actions
+
+  func approveTool(decision: ApprovalsClient.ToolApprovalDecision, message: String? = nil) async {
+    guard let sessionId = currentSessionId,
+          let store = currentSessionStore,
+          let requestId = pendingApproval?.requestId else { return }
+    do {
+      _ = try await store.approveTool(
+        sessionId: sessionId,
+        requestId: requestId,
+        decision: decision,
+        message: message
+      )
+      syncApproval()
+    } catch {
+      lastError = String(describing: error)
+    }
+  }
+
+  func answerQuestion(answer: String, questionId: String? = nil) async {
+    guard let sessionId = currentSessionId,
+          let store = currentSessionStore,
+          let requestId = pendingApproval?.requestId else { return }
+    do {
+      _ = try await store.answerQuestion(
+        sessionId: sessionId,
+        requestId: requestId,
+        answer: answer,
+        questionId: questionId
+      )
+      syncApproval()
+    } catch {
+      lastError = String(describing: error)
+    }
+  }
+
+  func respondToPermission(grant: Bool, scope: ServerPermissionGrantScope = .turn) async {
+    guard let sessionId = currentSessionId,
+          let store = currentSessionStore,
+          let requestId = pendingApproval?.requestId else { return }
+    do {
+      _ = try await store.respondToPermissionRequest(
+        sessionId: sessionId,
+        requestId: requestId,
+        scope: scope,
+        grantRequestedPermissions: grant
+      )
+      syncApproval()
+    } catch {
+      lastError = String(describing: error)
+    }
+  }
+
+  // MARK: - Session Config Mutations
+
+  func updateModel(_ model: String) async {
+    guard let sessionId = currentSessionId, let store = currentSessionStore else { return }
+    do {
+      var request = ServerControlDeckConfigUpdateRequest()
+      request.model = model
+      let updated = try await store.clients.controlDeck.updateConfig(sessionId, request: request)
+      applySnapshotPayload(updated)
+    } catch {
+      lastError = String(describing: error)
+    }
+  }
+
+  func updateEffort(_ effort: String) async {
+    guard let sessionId = currentSessionId, let store = currentSessionStore else { return }
+    do {
+      var request = ServerControlDeckConfigUpdateRequest()
+      request.effort = effort
+      let updated = try await store.clients.controlDeck.updateConfig(sessionId, request: request)
+      applySnapshotPayload(updated)
+    } catch {
+      lastError = String(describing: error)
+    }
+  }
+
+  func updatePermissionMode(_ mode: String) async {
+    guard let sessionId = currentSessionId, let store = currentSessionStore else { return }
+    do {
+      var request = ServerControlDeckConfigUpdateRequest()
+      request.permissionMode = mode
+      let updated = try await store.clients.controlDeck.updateConfig(sessionId, request: request)
+      applySnapshotPayload(updated)
+    } catch {
+      lastError = String(describing: error)
+    }
+  }
+
+  func updateApprovalPolicy(_ policy: String) async {
+    guard let sessionId = currentSessionId, let store = currentSessionStore else { return }
+    do {
+      var request = ServerControlDeckConfigUpdateRequest()
+      request.approvalPolicy = policy
+      let updated = try await store.clients.controlDeck.updateConfig(sessionId, request: request)
+      applySnapshotPayload(updated)
+    } catch {
+      lastError = String(describing: error)
+    }
+  }
+
+  func updateApprovalsReviewer(_ reviewer: ServerCodexApprovalsReviewer) async {
+    guard let sessionId = currentSessionId, let store = currentSessionStore else { return }
+    do {
+      var request = ServerControlDeckConfigUpdateRequest()
+      request.approvalsReviewer = reviewer
+      let updated = try await store.clients.controlDeck.updateConfig(sessionId, request: request)
+      applySnapshotPayload(updated)
+    } catch {
+      lastError = String(describing: error)
+    }
+  }
+
+  func updateCollaborationMode(_ mode: String) async {
+    guard let sessionId = currentSessionId, let store = currentSessionStore else { return }
+    do {
+      var request = ServerControlDeckConfigUpdateRequest()
+      request.collaborationMode = mode
+      let updated = try await store.clients.controlDeck.updateConfig(sessionId, request: request)
+      applySnapshotPayload(updated)
+    } catch {
+      lastError = String(describing: error)
+    }
+  }
+
+  func updateAutoReview(_ value: String) async {
+    guard let sessionId = currentSessionId,
+          let store = currentSessionStore,
+          let option = snapshot?.capabilities.autoReviewOptions.first(where: { $0.value == value })
+    else { return }
+    do {
+      var request = ServerControlDeckConfigUpdateRequest()
+      request.approvalPolicy = option.approvalPolicy
+      request.sandboxMode = option.sandboxMode
+      let updated = try await store.clients.controlDeck.updateConfig(sessionId, request: request)
+      applySnapshotPayload(updated)
+    } catch {
+      lastError = String(describing: error)
+    }
+  }
+
+  // MARK: - Forwarded Infrastructure
+
+  var projectFileIndex: ProjectFileIndex? {
+    currentSessionStore?.projectFileIndex
+  }
+
+  var projectPath: String? {
+    snapshot?.state.projectPath
+  }
+
+  var canSubmit: Bool {
+    snapshot?.state.acceptsUserInput ?? false
+  }
+
+  var availableModels: [String] {
+    guard let store = currentSessionStore, let snap = snapshot else { return [] }
+    switch snap.state.provider {
+      case .claude:
+        return ServerClaudeModelOption.defaults.map(\.value)
+      case .codex:
+        return store.codexModels.map(\.model)
+    }
+  }
+
+  private func nonEmpty(_ value: String?) -> String? {
+    guard let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines),
+          !trimmed.isEmpty
+    else {
+      return nil
+    }
+    return trimmed
+  }
+
+  private func applySnapshotPayload(_ payload: ServerControlDeckSnapshotPayload) {
+    lastError = nil
+    snapshot = ControlDeckSnapshotMapper.map(payload)
+    syncApproval()
+  }
+
+  private func loadCodexModelsIfNeeded(for provider: ServerProvider) async {
+    guard provider == .codex, let store = currentSessionStore else { return }
+    guard store.codexModels.isEmpty else {
+      rebuildPresentation()
+      return
+    }
+
+    if let models = try? await store.clients.usage.listCodexModels() {
+      store.codexModels = models
+    }
+
+    rebuildPresentation()
+  }
+
+  private func rebuildPresentation() {
+    guard let snapshot else {
+      presentation = nil
+      return
+    }
+
+    presentation = ControlDeckPresentationBuilder.build(
+      snapshot: snapshot,
+      isLoading: isLoading,
+      hasPendingApproval: pendingApproval != nil,
+      availableModels: availableModels
+    )
+  }
+}
+
+// MARK: - Errors
+
+enum ControlDeckError: Error {
+  case notBound
+}

--- a/OrbitDockNative/OrbitDock/Views/Sessions/ControlDeck/Models/ControlDeckApproval.swift
+++ b/OrbitDockNative/OrbitDock/Views/Sessions/ControlDeck/Models/ControlDeckApproval.swift
@@ -1,0 +1,35 @@
+import Foundation
+
+/// Deck-native model for a pending approval request.
+/// Maps from ServerApprovalRequest — no transport types leak into the deck UI.
+struct ControlDeckApproval: Equatable, Sendable {
+  let requestId: String
+  let sessionId: String
+  let kind: Kind
+  let title: String
+  let detail: String?
+
+  enum Kind: Equatable, Sendable {
+    /// Tool execution or patch — approve/deny
+    case tool(toolName: String?, command: String?, filePath: String?, diff: String?)
+    /// Question prompt — user must answer
+    case question(prompts: [Prompt])
+    /// Permission request — user grants/denies permissions
+    case permission(reason: String?, descriptions: [String])
+  }
+
+  struct Prompt: Equatable, Sendable, Identifiable {
+    let id: String
+    let question: String
+    let options: [String]
+    let allowsMultipleSelection: Bool
+    let allowsOther: Bool
+    let isSecret: Bool
+  }
+}
+
+/// Approval scope when granting tool permissions
+enum ControlDeckApprovalScope: String, CaseIterable, Sendable {
+  case turn
+  case session
+}

--- a/OrbitDockNative/OrbitDock/Views/Sessions/ControlDeck/Models/ControlDeckAttachment.swift
+++ b/OrbitDockNative/OrbitDock/Views/Sessions/ControlDeck/Models/ControlDeckAttachment.swift
@@ -1,0 +1,97 @@
+import Foundation
+
+// MARK: - Attachment State
+
+struct ControlDeckAttachmentState: Equatable {
+  var items: [ControlDeckAttachmentItem] = []
+
+  var hasItems: Bool {
+    !items.isEmpty
+  }
+
+  var images: [ControlDeckImageDraft] {
+    items.compactMap { item in
+      if case let .image(draft) = item.kind { return draft }
+      return nil
+    }
+  }
+
+  var mentions: [ControlDeckMentionDraft] {
+    items.compactMap { item in
+      if case let .mention(draft) = item.kind { return draft }
+      return nil
+    }
+  }
+
+  mutating func appendImage(_ image: ControlDeckImageDraft) {
+    items.append(ControlDeckAttachmentItem(
+      id: image.localId,
+      kind: .image(image)
+    ))
+  }
+
+  @discardableResult
+  mutating func appendMention(_ mention: ControlDeckMentionDraft) -> Bool {
+    let alreadyAttached = mentions.contains { $0.absolutePath == mention.absolutePath }
+    guard !alreadyAttached else { return false }
+    items.append(ControlDeckAttachmentItem(
+      id: mention.fileId,
+      kind: .mention(mention)
+    ))
+    return true
+  }
+
+  mutating func remove(id: String) {
+    items.removeAll { $0.id == id }
+  }
+
+  mutating func clearAll() {
+    items = []
+  }
+}
+
+// MARK: - Attachment Item
+
+struct ControlDeckAttachmentItem: Identifiable, Equatable {
+  let id: String
+  let kind: Kind
+
+  enum Kind: Equatable {
+    case image(ControlDeckImageDraft)
+    case mention(ControlDeckMentionDraft)
+  }
+}
+
+// MARK: - Image Draft
+
+struct ControlDeckImageDraft: Equatable {
+  let localId: String
+  let thumbnailData: Data?
+  let uploadData: Data
+  let uploadMimeType: String
+  let displayName: String
+  let pixelWidth: Int?
+  let pixelHeight: Int?
+
+  static func == (lhs: Self, rhs: Self) -> Bool {
+    lhs.localId == rhs.localId
+  }
+}
+
+// MARK: - Mention Draft
+
+struct ControlDeckMentionDraft: Equatable {
+  let fileId: String
+  let name: String
+  let absolutePath: String
+  let relativePath: String?
+  let kind: ControlDeckMentionKind
+}
+
+enum ControlDeckMentionKind: String, Sendable {
+  case file
+  case mcpResource
+  case url
+  case symbol
+  case generic
+}

--- a/OrbitDockNative/OrbitDock/Views/Sessions/ControlDeck/Models/ControlDeckCompletionState.swift
+++ b/OrbitDockNative/OrbitDock/Views/Sessions/ControlDeck/Models/ControlDeckCompletionState.swift
@@ -1,0 +1,57 @@
+import Foundation
+
+struct ControlDeckCompletionState: Equatable {
+  var mode: ControlDeckCompletionMode = .inactive
+  var selectedIndex: Int = 0
+
+  var isActive: Bool {
+    mode != .inactive
+  }
+
+  var query: String {
+    switch mode {
+      case .inactive: ""
+      case let .mention(q): q
+      case let .skill(q): q
+      case let .command(q): q
+    }
+  }
+
+  mutating func activate(_ newMode: ControlDeckCompletionMode) {
+    mode = newMode
+    selectedIndex = 0
+  }
+
+  mutating func dismiss() {
+    mode = .inactive
+    selectedIndex = 0
+  }
+
+  mutating func moveUp() {
+    selectedIndex = max(0, selectedIndex - 1)
+  }
+
+  mutating func moveDown(itemCount: Int) {
+    selectedIndex = min(max(0, itemCount - 1), selectedIndex + 1)
+  }
+}
+
+enum ControlDeckCompletionMode: Equatable {
+  case inactive
+  case mention(query: String)
+  case skill(query: String)
+  case command(query: String)
+}
+
+struct ControlDeckCompletionSuggestion: Identifiable, Equatable {
+  let id: String
+  let kind: Kind
+  let title: String
+  let subtitle: String?
+
+  enum Kind: Equatable {
+    case file
+    case skill
+    case command
+  }
+}

--- a/OrbitDockNative/OrbitDock/Views/Sessions/ControlDeck/Models/ControlDeckDraft.swift
+++ b/OrbitDockNative/OrbitDock/Views/Sessions/ControlDeck/Models/ControlDeckDraft.swift
@@ -1,0 +1,45 @@
+import Foundation
+
+struct ControlDeckDraft: Equatable {
+  var text: String = ""
+  var attachments = ControlDeckAttachmentState()
+  var selectedSkillPaths: Set<String> = []
+  var modelOverride: String?
+  var effortOverride: String?
+
+  var trimmedText: String {
+    text.trimmingCharacters(in: .whitespacesAndNewlines)
+  }
+
+  var hasContent: Bool {
+    !trimmedText.isEmpty || attachments.hasItems
+  }
+
+  mutating func clearAfterSubmit() {
+    text = ""
+    attachments.clearAll()
+    selectedSkillPaths = []
+    modelOverride = nil
+    effortOverride = nil
+  }
+
+  // MARK: - Draft Persistence (survives navigation)
+
+  private static var cache: [String: ControlDeckDraft] = [:]
+
+  static func restore(for sessionId: String) -> ControlDeckDraft {
+    cache[sessionId] ?? ControlDeckDraft()
+  }
+
+  static func save(_ draft: ControlDeckDraft, for sessionId: String) {
+    if draft.hasContent {
+      cache[sessionId] = draft
+    } else {
+      cache.removeValue(forKey: sessionId)
+    }
+  }
+
+  static func clear(for sessionId: String) {
+    cache.removeValue(forKey: sessionId)
+  }
+}

--- a/OrbitDockNative/OrbitDock/Views/Sessions/ControlDeck/Models/ControlDeckPresentation.swift
+++ b/OrbitDockNative/OrbitDock/Views/Sessions/ControlDeck/Models/ControlDeckPresentation.swift
@@ -1,0 +1,52 @@
+import Foundation
+
+/// The deck's active interaction mode, derived from session state.
+enum ControlDeckMode: Equatable, Sendable {
+  /// Normal compose — session accepts new turns
+  case compose
+  /// Steer — session is working, user can send steering feedback
+  case steer
+  /// Approval — session is waiting for user to respond to a pending approval
+  case approval
+  /// Disabled — session ended or not accepting input
+  case disabled
+}
+
+struct ControlDeckPresentation: Equatable, Sendable {
+  let mode: ControlDeckMode
+  let controlModeLabel: String
+  let lifecycleLabel: String
+  let lifecycleTint: String
+  let acceptsUserInput: Bool
+  let supportsImages: Bool
+  let headerSubtitle: String
+  let statusModules: [ControlDeckStatusModuleItem]
+  let placeholder: String
+  let sendTint: String
+}
+
+struct ControlDeckStatusModuleItem: Identifiable, Equatable, Sendable {
+  let id: ControlDeckStatusModule
+  let label: String
+  let icon: String
+  let tintName: String
+  let selectedValue: String?
+  let reviewerValue: String?
+  let interaction: Interaction
+
+  enum Interaction: Equatable, Sendable {
+    /// Read-only display, no tap action
+    case readOnly
+    /// Tappable — opens a picker with the given options. Current value is `label`.
+    case picker(options: [Option])
+  }
+
+  struct Option: Identifiable, Equatable, Sendable {
+    let value: String
+    let label: String
+
+    var id: String {
+      value
+    }
+  }
+}

--- a/OrbitDockNative/OrbitDock/Views/Sessions/ControlDeck/Models/ControlDeckSkill.swift
+++ b/OrbitDockNative/OrbitDock/Views/Sessions/ControlDeck/Models/ControlDeckSkill.swift
@@ -1,0 +1,12 @@
+import Foundation
+
+struct ControlDeckSkill: Identifiable, Equatable, Sendable {
+  let name: String
+  let path: String
+  let description: String
+  let shortDescription: String?
+
+  var id: String {
+    path
+  }
+}

--- a/OrbitDockNative/OrbitDock/Views/Sessions/ControlDeck/Models/ControlDeckSnapshot.swift
+++ b/OrbitDockNative/OrbitDock/Views/Sessions/ControlDeck/Models/ControlDeckSnapshot.swift
@@ -1,0 +1,160 @@
+import Foundation
+
+// MARK: - Snapshot (top-level bootstrap response, deck-native)
+
+struct ControlDeckSnapshot: Sendable {
+  let revision: UInt64
+  let sessionId: String
+  let state: ControlDeckSessionState
+  let capabilities: ControlDeckCapabilities
+  let preferences: ControlDeckPreferences
+  let tokenUsage: ControlDeckTokenUsage
+  let tokenUsageSnapshotKind: ControlDeckTokenUsageSnapshotKind
+  let tokenStatus: ControlDeckTokenStatus
+}
+
+// MARK: - Session State
+
+struct ControlDeckSessionState: Sendable {
+  let provider: ControlDeckProvider
+  let controlMode: ControlDeckControlMode
+  let lifecycle: ControlDeckLifecycle
+  let acceptsUserInput: Bool
+  let steerable: Bool
+  let projectPath: String
+  let currentCwd: String?
+  let gitBranch: String?
+  let config: ControlDeckConfig
+}
+
+enum ControlDeckProvider: String, Sendable {
+  case claude
+  case codex
+}
+
+enum ControlDeckControlMode: String, Sendable {
+  case direct
+  case passive
+}
+
+enum ControlDeckLifecycle: String, Sendable {
+  case open
+  case resumable
+  case ended
+}
+
+struct ControlDeckConfig: Sendable {
+  let model: String?
+  let effort: String?
+  let approvalPolicy: String?
+  let approvalPolicyDetails: ServerCodexApprovalPolicy?
+  let sandboxMode: String?
+  let approvalsReviewer: ServerCodexApprovalsReviewer?
+  let permissionMode: String?
+  let collaborationMode: String?
+}
+
+// MARK: - Capabilities
+
+struct ControlDeckCapabilities: Sendable {
+  let supportsSkills: Bool
+  let supportsMentions: Bool
+  let supportsImages: Bool
+  let supportsSteer: Bool
+  let allowPerTurnModelOverride: Bool
+  let allowPerTurnEffortOverride: Bool
+  let approvalModeOptions: [ControlDeckPickerOption]
+  let permissionModeOptions: [ControlDeckPickerOption]
+  let collaborationModeOptions: [ControlDeckPickerOption]
+  let autoReviewOptions: [ControlDeckAutoReviewOption]
+  let availableStatusModules: [ControlDeckStatusModule]
+}
+
+struct ControlDeckPickerOption: Identifiable, Equatable, Sendable {
+  let value: String
+  let label: String
+
+  var id: String {
+    value
+  }
+}
+
+struct ControlDeckAutoReviewOption: Identifiable, Equatable, Sendable {
+  let value: String
+  let label: String
+  let approvalPolicy: String?
+  let sandboxMode: String?
+
+  var id: String {
+    value
+  }
+}
+
+// MARK: - Preferences
+
+struct ControlDeckPreferences: Equatable, Sendable {
+  let density: ControlDeckDensity
+  let showWhenEmpty: ControlDeckEmptyVisibility
+  let modules: [ControlDeckModulePreference]
+}
+
+enum ControlDeckDensity: String, Sendable {
+  case comfortable
+  case compact
+}
+
+enum ControlDeckEmptyVisibility: String, Sendable {
+  case auto
+  case always
+  case hidden
+}
+
+struct ControlDeckModulePreference: Equatable, Sendable {
+  let module: ControlDeckStatusModule
+  let visible: Bool
+}
+
+// MARK: - Token Usage
+
+struct ControlDeckTokenUsage: Sendable {
+  let inputTokens: UInt64
+  let outputTokens: UInt64
+  let cachedTokens: UInt64
+  let contextWindow: UInt64
+}
+
+enum ControlDeckTokenUsageSnapshotKind: Sendable {
+  case unknown
+  case contextTurn
+  case lifetimeTotals
+  case mixedLegacy
+  case compactionReset
+}
+
+struct ControlDeckTokenStatus: Sendable {
+  let label: String
+  let tone: Tone
+
+  enum Tone: Sendable {
+    case muted
+    case normal
+    case caution
+    case critical
+  }
+}
+
+// MARK: - Status Modules
+
+enum ControlDeckStatusModule: String, Hashable, Sendable {
+  case connection
+  case autonomy
+  case approvalMode
+  case collaborationMode
+  case autoReview
+  case tokens
+  case model
+  case effort
+  case branch
+  case cwd
+  case attachments
+}

--- a/OrbitDockNative/OrbitDock/Views/Sessions/ControlDeck/ZoomableImagePreview.swift
+++ b/OrbitDockNative/OrbitDock/Views/Sessions/ControlDeck/ZoomableImagePreview.swift
@@ -1,0 +1,112 @@
+import SwiftUI
+
+#if os(macOS)
+  struct ZoomableImagePreview: View {
+    let image: Image
+    let title: String
+    let onDismiss: () -> Void
+
+    @State private var scale: CGFloat = 1.0
+    @State private var lastScale: CGFloat = 1.0
+    @State private var offset: CGSize = .zero
+    @State private var lastOffset: CGSize = .zero
+
+    var body: some View {
+      VStack(spacing: 0) {
+        toolbar
+        zoomableContent
+      }
+      .background(Color.black)
+    }
+
+    private var toolbar: some View {
+      HStack {
+        Text(title)
+          .font(.system(size: TypeScale.body, weight: .semibold))
+          .foregroundStyle(.white)
+
+        Spacer()
+
+        HStack(spacing: Spacing.sm) {
+          Button { withAnimation(.spring(response: 0.3)) { resetZoom() } } label: {
+            Image(systemName: "arrow.counterclockwise")
+              .font(.system(size: TypeScale.caption, weight: .medium))
+              .foregroundStyle(.white.opacity(0.7))
+          }
+          .buttonStyle(.plain)
+          .disabled(scale == 1.0 && offset == .zero)
+
+          Text("\(Int(scale * 100))%")
+            .font(.system(size: TypeScale.micro, weight: .medium, design: .monospaced))
+            .foregroundStyle(.white.opacity(0.5))
+
+          Button("Done") { onDismiss() }
+            .keyboardShortcut(.cancelAction)
+        }
+      }
+      .padding(.horizontal, Spacing.md)
+      .padding(.vertical, Spacing.sm)
+      .background(.black)
+    }
+
+    private var zoomableContent: some View {
+      GeometryReader { geo in
+        image
+          .resizable()
+          .aspectRatio(contentMode: .fit)
+          .scaleEffect(scale)
+          .offset(offset)
+          .frame(width: geo.size.width, height: geo.size.height)
+          .clipped()
+          .contentShape(Rectangle())
+          .gesture(magnification)
+          .gesture(drag)
+          .onTapGesture(count: 2) {
+            withAnimation(.spring(response: 0.3)) {
+              if scale > 1.05 {
+                resetZoom()
+              } else {
+                scale = 2.5
+                lastScale = 2.5
+              }
+            }
+          }
+      }
+    }
+
+    private var magnification: some Gesture {
+      MagnifyGesture()
+        .onChanged { value in
+          let newScale = lastScale * value.magnification
+          scale = max(0.5, min(newScale, 8.0))
+        }
+        .onEnded { _ in
+          lastScale = scale
+          if scale < 1.0 {
+            withAnimation(.spring(response: 0.3)) { resetZoom() }
+          }
+        }
+    }
+
+    private var drag: some Gesture {
+      DragGesture()
+        .onChanged { value in
+          guard scale > 1.0 else { return }
+          offset = CGSize(
+            width: lastOffset.width + value.translation.width,
+            height: lastOffset.height + value.translation.height
+          )
+        }
+        .onEnded { _ in
+          lastOffset = offset
+        }
+    }
+
+    private func resetZoom() {
+      scale = 1.0
+      lastScale = 1.0
+      offset = .zero
+      lastOffset = .zero
+    }
+  }
+#endif

--- a/orbitdock-server/crates/connector-codex/src/config.rs
+++ b/orbitdock-server/crates/connector-codex/src/config.rs
@@ -7,8 +7,8 @@ use codex_core::models_manager::collaboration_mode_presets::CollaborationModesCo
 use codex_core::models_manager::manager::RefreshStrategy;
 use codex_core::{AuthManager, ModelProviderInfo, ThreadManager};
 use codex_protocol::config_types::{
-  CollaborationMode, CollaborationModeMask, ModeKind, Personality, ReasoningSummary, ServiceTier,
-  Settings,
+  ApprovalsReviewer, CollaborationMode, CollaborationModeMask, ModeKind, Personality,
+  ReasoningSummary, ServiceTier, Settings,
 };
 use codex_protocol::openai_models::{
   default_input_modalities, ConfigShellToolType, ModelInfo, ModelInstructionsVariables,
@@ -374,6 +374,13 @@ impl CodexConnector {
       ));
     }
 
+    if let Some(reviewer) = control_plane.approvals_reviewer.as_deref() {
+      cli_overrides.push((
+        "approvals_reviewer".to_string(),
+        toml::Value::String(reviewer.to_string()),
+      ));
+    }
+
     if apply_runtime_defaults {
       let show_raw_reasoning =
         parse_bool_env(ENV_CODEX_SHOW_RAW_REASONING).unwrap_or(DEFAULT_CODEX_SHOW_RAW_REASONING);
@@ -453,8 +460,10 @@ impl CodexConnector {
     );
     let service_tier = parse_service_tier_override(control_plane.service_tier.as_deref());
     let personality = parse_personality(control_plane.personality.as_deref());
+    let approvals_reviewer = parse_approvals_reviewer(control_plane.approvals_reviewer.as_deref());
 
     if collaboration_mode.is_none()
+      && approvals_reviewer.is_none()
       && service_tier.is_none()
       && personality.is_none()
       && control_plane.multi_agent.is_none()
@@ -472,7 +481,7 @@ impl CodexConnector {
         model: None,
         effort: None,
         summary: None,
-        approvals_reviewer: None,
+        approvals_reviewer,
         service_tier,
         collaboration_mode,
         personality,
@@ -567,6 +576,14 @@ pub async fn discover_models_for_context(
   }
 
   Ok(models)
+}
+
+pub(crate) fn parse_approvals_reviewer(value: Option<&str>) -> Option<ApprovalsReviewer> {
+  match value.map(str::trim).filter(|value| !value.is_empty()) {
+    Some("user") => Some(ApprovalsReviewer::User),
+    Some("guardian_subagent") => Some(ApprovalsReviewer::GuardianSubagent),
+    _ => None,
+  }
 }
 
 pub(crate) fn apply_orbitdock_provider_defaults(config: &mut Config) {

--- a/orbitdock-server/crates/connector-codex/src/lib.rs
+++ b/orbitdock-server/crates/connector-codex/src/lib.rs
@@ -47,6 +47,7 @@ pub struct CodexConnector {
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct CodexControlPlane {
+  pub approvals_reviewer: Option<String>,
   pub collaboration_mode: Option<String>,
   pub multi_agent: Option<bool>,
   pub personality: Option<String>,
@@ -63,6 +64,7 @@ pub struct CodexConfigOverrides {
 pub struct UpdateConfigOptions<'a> {
   pub approval_policy: Option<&'a str>,
   pub sandbox_mode: Option<&'a str>,
+  pub approvals_reviewer: Option<&'a str>,
   pub permission_mode: Option<&'a str>,
   pub collaboration_mode: Option<&'a str>,
   pub multi_agent: Option<bool>,

--- a/orbitdock-server/crates/connector-codex/src/runtime.rs
+++ b/orbitdock-server/crates/connector-codex/src/runtime.rs
@@ -1,3 +1,4 @@
+use super::event_mapping::OutputBufferState;
 use super::workers::iso_now;
 use super::CodexConnector;
 use codex_core::{CodexThread, ThreadManager};
@@ -16,7 +17,7 @@ use tracing::{debug, error, info};
 
 /// Groups the shared Arc<Mutex> state threaded through the event loop.
 pub(super) struct EventLoopState {
-  pub(super) output_buffers: Arc<tokio::sync::Mutex<HashMap<String, String>>>,
+  pub(super) output_buffers: Arc<tokio::sync::Mutex<HashMap<String, OutputBufferState>>>,
   pub(super) delta_buffers: Arc<tokio::sync::Mutex<HashMap<String, String>>>,
   pub(super) streaming_message: Arc<tokio::sync::Mutex<Option<StreamingMessage>>>,
   pub(super) raw_tool_calls: Arc<tokio::sync::Mutex<HashMap<String, RawToolCallContext>>>,
@@ -149,7 +150,9 @@ impl CodexConnector {
       Arc::new(tokio::sync::Mutex::new(Option::<ReasoningEffort>::None));
 
     let state = EventLoopState {
-      output_buffers: Arc::new(tokio::sync::Mutex::new(HashMap::<String, String>::new())),
+      output_buffers: Arc::new(tokio::sync::Mutex::new(
+        HashMap::<String, OutputBufferState>::new(),
+      )),
       delta_buffers: Arc::new(tokio::sync::Mutex::new(HashMap::<String, String>::new())),
       streaming_message: Arc::new(tokio::sync::Mutex::new(Option::<StreamingMessage>::None)),
       raw_tool_calls: Arc::new(tokio::sync::Mutex::new(

--- a/orbitdock-server/crates/connector-codex/src/session.rs
+++ b/orbitdock-server/crates/connector-codex/src/session.rs
@@ -133,6 +133,7 @@ pub enum CodexAction {
   UpdateConfig {
     approval_policy: Option<String>,
     sandbox_mode: Option<String>,
+    approvals_reviewer: Option<String>,
     permission_mode: Option<String>,
     collaboration_mode: Option<String>,
     multi_agent: Option<bool>,
@@ -255,6 +256,7 @@ impl std::fmt::Debug for CodexAction {
       Self::UpdateConfig {
         approval_policy,
         sandbox_mode,
+        approvals_reviewer,
         permission_mode,
         collaboration_mode,
         multi_agent,
@@ -267,6 +269,7 @@ impl std::fmt::Debug for CodexAction {
         .debug_struct("UpdateConfig")
         .field("approval_policy", approval_policy)
         .field("sandbox_mode", sandbox_mode)
+        .field("approvals_reviewer", approvals_reviewer)
         .field("permission_mode", permission_mode)
         .field("collaboration_mode", collaboration_mode)
         .field("multi_agent", multi_agent)
@@ -661,6 +664,7 @@ impl CodexSession {
       CodexAction::UpdateConfig {
         approval_policy,
         sandbox_mode,
+        approvals_reviewer,
         permission_mode,
         collaboration_mode,
         multi_agent,
@@ -674,6 +678,7 @@ impl CodexSession {
           .update_config(UpdateConfigOptions {
             approval_policy: approval_policy.as_deref(),
             sandbox_mode: sandbox_mode.as_deref(),
+            approvals_reviewer: approvals_reviewer.as_deref(),
             permission_mode: permission_mode.as_deref(),
             collaboration_mode: collaboration_mode.as_deref(),
             multi_agent,

--- a/orbitdock-server/crates/connector-codex/src/session_ops.rs
+++ b/orbitdock-server/crates/connector-codex/src/session_ops.rs
@@ -17,11 +17,11 @@ use codex_protocol::request_permissions::{PermissionGrantScope, RequestPermissio
 use codex_protocol::request_user_input::{RequestUserInputAnswer, RequestUserInputResponse};
 use codex_protocol::user_input::UserInput;
 use codex_utils_absolute_path::AbsolutePathBuf;
-use tracing::{info, warn};
+use tracing::warn;
 
 use super::config::{
-  collaboration_mode_for_update, parse_personality, parse_service_tier_override,
-  preferred_reasoning_summary, reasoning_summary_for_model,
+  collaboration_mode_for_update, parse_approvals_reviewer, parse_personality,
+  parse_service_tier_override, preferred_reasoning_summary, reasoning_summary_for_model,
 };
 use super::{
   CodexConfigOverrides, CodexConnector, CodexControlPlane, SteerOutcome, UpdateConfigOptions,
@@ -163,10 +163,6 @@ impl CodexConnector {
       self.thread.submit(override_op).await.map_err(|e| {
         ConnectorError::ProviderError(format!("Failed to override turn context: {}", e))
       })?;
-      info!(
-        "Submitted per-turn overrides: model={:?}, effort={:?}, summary={:?}",
-        model, effort, summary
-      );
     }
 
     let mut items = vec![UserInput::Text {
@@ -216,7 +212,6 @@ impl CodexConnector {
       .await
       .map_err(|e| ConnectorError::ProviderError(format!("Failed to send message: {}", e)))?;
 
-    info!("Sent user message");
     Ok(())
   }
 
@@ -260,12 +255,8 @@ impl CodexConnector {
     }
 
     match self.thread.steer_input(items, None).await {
-      Ok(turn_id) => {
-        info!("Steered active turn: {}", turn_id);
-        Ok(SteerOutcome::Accepted)
-      }
+      Ok(_turn_id) => Ok(SteerOutcome::Accepted),
       Err(SteerInputError::NoActiveTurn(items)) => {
-        info!("No active turn for steer, falling back to send_message");
         self
           .thread
           .submit(Op::UserInput {
@@ -299,7 +290,6 @@ impl CodexConnector {
       .submit(op)
       .await
       .map_err(|e| ConnectorError::ProviderError(format!("Failed to list skills: {}", e)))?;
-    info!("Requested skills list");
     Ok(())
   }
 
@@ -450,7 +440,6 @@ impl CodexConnector {
       .submit(op)
       .await
       .map_err(|e| ConnectorError::ProviderError(format!("Failed to list MCP tools: {}", e)))?;
-    info!("Requested MCP tools list");
     Ok(())
   }
 
@@ -463,7 +452,6 @@ impl CodexConnector {
     self.thread.submit(op).await.map_err(|e| {
       ConnectorError::ProviderError(format!("Failed to refresh MCP servers: {}", e))
     })?;
-    info!("Requested MCP servers refresh");
     Ok(())
   }
 
@@ -474,7 +462,6 @@ impl CodexConnector {
       .await
       .map_err(|e| ConnectorError::ProviderError(format!("Failed to interrupt: {}", e)))?;
 
-    info!("Interrupted turn");
     Ok(())
   }
 
@@ -483,7 +470,6 @@ impl CodexConnector {
     request_id: &str,
     decision: CodexExecApproval,
   ) -> Result<(), ConnectorError> {
-    let label = decision.label();
     let review = match decision {
       CodexExecApproval::Approved => ReviewDecision::Approved,
       CodexExecApproval::ApprovedForSession => ReviewDecision::ApprovedForSession,
@@ -512,7 +498,6 @@ impl CodexConnector {
       .await
       .map_err(|e| ConnectorError::ProviderError(format!("Failed to approve exec: {}", e)))?;
 
-    info!("Sent exec approval: {} = {}", request_id, label);
     Ok(())
   }
 
@@ -521,7 +506,6 @@ impl CodexConnector {
     request_id: &str,
     decision: CodexPatchApproval,
   ) -> Result<(), ConnectorError> {
-    let label = decision.label();
     let review = match decision {
       CodexPatchApproval::Approved => ReviewDecision::Approved,
       CodexPatchApproval::ApprovedForSession => ReviewDecision::ApprovedForSession,
@@ -540,7 +524,6 @@ impl CodexConnector {
       .await
       .map_err(|e| ConnectorError::ProviderError(format!("Failed to approve patch: {}", e)))?;
 
-    info!("Sent patch approval: {} = {}", request_id, label);
     Ok(())
   }
 
@@ -567,7 +550,6 @@ impl CodexConnector {
       .await
       .map_err(|e| ConnectorError::ProviderError(format!("Failed to answer question: {}", e)))?;
 
-    info!("Sent question answer: {}", request_id);
     Ok(())
   }
 
@@ -597,7 +579,6 @@ impl CodexConnector {
       ConnectorError::ProviderError(format!("Failed to respond to permission request: {}", e))
     })?;
 
-    info!("Sent permission response: {}", request_id);
     Ok(())
   }
 
@@ -612,7 +593,6 @@ impl CodexConnector {
       .await
       .map_err(|e| ConnectorError::ProviderError(format!("Failed to set thread name: {}", e)))?;
 
-    info!("Set thread name: {}", name);
     Ok(())
   }
 
@@ -623,9 +603,10 @@ impl CodexConnector {
     let UpdateConfigOptions {
       approval_policy,
       sandbox_mode,
+      approvals_reviewer,
       permission_mode,
       collaboration_mode,
-      multi_agent,
+      multi_agent: _,
       personality,
       service_tier,
       developer_instructions,
@@ -678,6 +659,7 @@ impl CodexConnector {
       let current = self.current_reasoning_effort.lock().await;
       *current
     };
+    let approvals_reviewer = parse_approvals_reviewer(approvals_reviewer);
     let collaboration_mode = collaboration_mode_for_update(
       self.thread_manager.as_ref(),
       collaboration_mode,
@@ -686,8 +668,6 @@ impl CodexConnector {
       current_effort,
       developer_instructions,
     );
-    let collaboration_mode_log = collaboration_mode.clone();
-
     let op = Op::OverrideTurnContext {
       cwd: None,
       approval_policy: policy,
@@ -696,7 +676,7 @@ impl CodexConnector {
       model: model.map(ToString::to_string),
       effort: effort.and_then(parse_reasoning_effort).map(Some),
       summary: None,
-      approvals_reviewer: None,
+      approvals_reviewer,
       service_tier: parse_service_tier_override(service_tier),
       collaboration_mode,
       personality: parse_personality(personality),
@@ -708,19 +688,6 @@ impl CodexConnector {
       .await
       .map_err(|e| ConnectorError::ProviderError(format!("Failed to update config: {}", e)))?;
 
-    info!(
-            "Updated session config: approval={:?}, sandbox={:?}, permission_mode={:?}, collaboration_mode={:?}, multi_agent={:?}, personality={:?}, service_tier={:?}, developer_instructions={:?}, model={:?}, effort={:?}",
-            approval_policy,
-            sandbox_mode,
-            permission_mode,
-            collaboration_mode_log,
-            multi_agent,
-            personality,
-            service_tier,
-            developer_instructions.map(|_| "[set]"),
-            model,
-            effort
-        );
     Ok(())
   }
 
@@ -730,7 +697,6 @@ impl CodexConnector {
       .submit(Op::Compact)
       .await
       .map_err(|e| ConnectorError::ProviderError(format!("Failed to compact: {}", e)))?;
-    info!("Sent compact");
     Ok(())
   }
 
@@ -740,7 +706,6 @@ impl CodexConnector {
       .submit(Op::Undo)
       .await
       .map_err(|e| ConnectorError::ProviderError(format!("Failed to undo: {}", e)))?;
-    info!("Sent undo");
     Ok(())
   }
 
@@ -750,7 +715,6 @@ impl CodexConnector {
       .submit(Op::ThreadRollback { num_turns })
       .await
       .map_err(|e| ConnectorError::ProviderError(format!("Failed to thread rollback: {}", e)))?;
-    info!("Sent thread rollback: {} turns", num_turns);
     Ok(())
   }
 
@@ -775,7 +739,6 @@ impl CodexConnector {
       .submit(Op::Shutdown)
       .await
       .map_err(|e| ConnectorError::ProviderError(format!("Failed to shutdown: {}", e)))?;
-    info!("Sent shutdown");
     Ok(())
   }
 }

--- a/orbitdock-server/crates/connector-codex/src/tests.rs
+++ b/orbitdock-server/crates/connector-codex/src/tests.rs
@@ -4,7 +4,7 @@ use super::config::{
   model_rejects_reasoning_summary, parse_personality, parse_reasoning_summary,
   parse_service_tier_override, reasoning_summary_for_model, should_disable_reasoning_summary,
 };
-use super::event_mapping::{guardian, messages, streaming};
+use super::event_mapping::{guardian, messages, runtime_signals, streaming};
 use super::runtime::StreamingMessage;
 use super::timeline::{
   hook_completed_text, hook_output_text, hook_run_is_error, hook_started_text,
@@ -18,9 +18,10 @@ use codex_protocol::config_types::{ModeKind, ReasoningSummary, ServiceTier};
 use codex_protocol::models::{FunctionCallOutputPayload, ResponseItem};
 use codex_protocol::openai_models::ReasoningEffort;
 use codex_protocol::protocol::{
-  AgentStatus, CodexErrorInfo, HookEventName, HookExecutionMode, HookHandlerType, HookOutputEntry,
-  HookOutputEntryKind, HookRunStatus, HookRunSummary, HookScope, RawResponseItemEvent,
-  RealtimeHandoffRequested, RealtimeTranscriptEntry, StreamErrorEvent, WarningEvent,
+  AgentStatus, CodexErrorInfo, HookCompletedEvent, HookEventName, HookExecutionMode,
+  HookHandlerType, HookOutputEntry, HookOutputEntryKind, HookRunStatus, HookRunSummary, HookScope,
+  HookStartedEvent, RawResponseItemEvent, RealtimeHandoffRequested, RealtimeTranscriptEntry,
+  StreamErrorEvent, WarningEvent,
 };
 use orbitdock_connector_core::ConnectorEvent;
 use orbitdock_protocol::conversation_contracts::ConversationRow;
@@ -339,6 +340,20 @@ fn runtime_warning_preserves_other_warnings() {
 }
 
 #[test]
+fn runtime_warning_suppresses_codex_hooks_notice() {
+  let msg_counter = AtomicU64::new(0);
+  let events = super::event_mapping::runtime_signals::handle_warning(
+    "event-1",
+    WarningEvent {
+      message: "Under-development features enabled: codex_hooks. Under-development features are incomplete and may behave unpredictably. To suppress this warning, set suppress...".to_string(),
+    },
+    &msg_counter,
+  );
+
+  assert!(events.is_empty());
+}
+
+#[test]
 fn realtime_handoff_text_prefers_messages() {
   let handoff = RealtimeHandoffRequested {
     handoff_id: "handoff-1".to_string(),
@@ -569,6 +584,86 @@ fn hook_helpers_render_user_prompt_submit_label() {
     hook_completed_text(&run),
     "prompt submit hook completed via prompt-submit-hook.sh"
   );
+}
+
+#[test]
+fn suppresses_non_error_hook_started_rows() {
+  let events = runtime_signals::handle_hook_started(HookStartedEvent {
+    turn_id: None,
+    run: HookRunSummary {
+      id: "hook-quiet-start".to_string(),
+      event_name: HookEventName::UserPromptSubmit,
+      handler_type: HookHandlerType::Command,
+      execution_mode: HookExecutionMode::Sync,
+      scope: HookScope::Turn,
+      source_path: PathBuf::from("/tmp/hooks.json"),
+      display_order: 0,
+      status: HookRunStatus::Running,
+      status_message: None,
+      started_at: 1,
+      completed_at: None,
+      duration_ms: None,
+      entries: vec![],
+    },
+  });
+
+  assert!(events.is_empty());
+}
+
+#[test]
+fn suppresses_non_error_hook_completed_rows() {
+  let events = runtime_signals::handle_hook_completed(HookCompletedEvent {
+    turn_id: None,
+    run: HookRunSummary {
+      id: "hook-quiet-complete".to_string(),
+      event_name: HookEventName::SessionStart,
+      handler_type: HookHandlerType::Command,
+      execution_mode: HookExecutionMode::Sync,
+      scope: HookScope::Thread,
+      source_path: PathBuf::from("/tmp/hooks.json"),
+      display_order: 0,
+      status: HookRunStatus::Completed,
+      status_message: None,
+      started_at: 1,
+      completed_at: Some(2),
+      duration_ms: Some(1),
+      entries: vec![],
+    },
+  });
+
+  assert!(events.is_empty());
+}
+
+#[test]
+fn surfaces_failed_hook_completed_rows() {
+  let events = runtime_signals::handle_hook_completed(HookCompletedEvent {
+    turn_id: None,
+    run: HookRunSummary {
+      id: "hook-error-complete".to_string(),
+      event_name: HookEventName::SessionStart,
+      handler_type: HookHandlerType::Command,
+      execution_mode: HookExecutionMode::Sync,
+      scope: HookScope::Thread,
+      source_path: PathBuf::from("/tmp/hooks.json"),
+      display_order: 0,
+      status: HookRunStatus::Failed,
+      status_message: Some("Broken config".to_string()),
+      started_at: 1,
+      completed_at: Some(2),
+      duration_ms: Some(1),
+      entries: vec![],
+    },
+  });
+
+  assert_eq!(events.len(), 1);
+  let ConnectorEvent::ConversationRowCreated(entry) = &events[0] else {
+    panic!("expected hook failure row");
+  };
+  let ConversationRow::Hook(hook) = &entry.row else {
+    panic!("expected hook row");
+  };
+  assert_eq!(hook.id, "hook-hook-error-complete");
+  assert!(hook.title.contains("failed via hooks.json"));
 }
 
 #[test]

--- a/orbitdock-server/crates/protocol/src/control_deck.rs
+++ b/orbitdock-server/crates/protocol/src/control_deck.rs
@@ -1,0 +1,239 @@
+use serde::{Deserialize, Serialize};
+
+use crate::{
+  CodexApprovalPolicy, CodexApprovalsReviewer, CodexConfigMode, Provider, SessionControlMode,
+  SessionLifecycleState, TokenUsage, TokenUsageSnapshotKind,
+};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ControlDeckDensity {
+  Comfortable,
+  Compact,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ControlDeckEmptyVisibility {
+  Auto,
+  Always,
+  Hidden,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ControlDeckModule {
+  Connection,
+  Autonomy,
+  ApprovalMode,
+  CollaborationMode,
+  AutoReview,
+  Tokens,
+  Model,
+  Effort,
+  Branch,
+  Cwd,
+  Attachments,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ControlDeckModulePreference {
+  pub module: ControlDeckModule,
+  pub visible: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ControlDeckPreferences {
+  pub density: ControlDeckDensity,
+  pub show_when_empty: ControlDeckEmptyVisibility,
+  #[serde(default, skip_serializing_if = "Vec::is_empty")]
+  pub modules: Vec<ControlDeckModulePreference>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ControlDeckConfigState {
+  #[serde(default, skip_serializing_if = "Option::is_none")]
+  pub model: Option<String>,
+  #[serde(default, skip_serializing_if = "Option::is_none")]
+  pub effort: Option<String>,
+  #[serde(default, skip_serializing_if = "Option::is_none")]
+  pub approval_policy: Option<String>,
+  #[serde(default, skip_serializing_if = "Option::is_none")]
+  pub approval_policy_details: Option<CodexApprovalPolicy>,
+  #[serde(default, skip_serializing_if = "Option::is_none")]
+  pub sandbox_mode: Option<String>,
+  #[serde(default, skip_serializing_if = "Option::is_none")]
+  pub approvals_reviewer: Option<CodexApprovalsReviewer>,
+  #[serde(default, skip_serializing_if = "Option::is_none")]
+  pub permission_mode: Option<String>,
+  #[serde(default, skip_serializing_if = "Option::is_none")]
+  pub collaboration_mode: Option<String>,
+  #[serde(default, skip_serializing_if = "Option::is_none")]
+  pub developer_instructions: Option<String>,
+  #[serde(default, skip_serializing_if = "Option::is_none")]
+  pub codex_config_mode: Option<CodexConfigMode>,
+  #[serde(default, skip_serializing_if = "Option::is_none")]
+  pub codex_config_profile: Option<String>,
+  #[serde(default, skip_serializing_if = "Option::is_none")]
+  pub codex_model_provider: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ControlDeckState {
+  pub provider: Provider,
+  pub control_mode: SessionControlMode,
+  pub lifecycle_state: SessionLifecycleState,
+  pub accepts_user_input: bool,
+  pub steerable: bool,
+  pub project_path: String,
+  #[serde(default, skip_serializing_if = "Option::is_none")]
+  pub current_cwd: Option<String>,
+  #[serde(default, skip_serializing_if = "Option::is_none")]
+  pub git_branch: Option<String>,
+  pub config: ControlDeckConfigState,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ControlDeckPickerOption {
+  pub value: String,
+  pub label: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ControlDeckAutoReviewOption {
+  pub value: String,
+  pub label: String,
+  #[serde(default, skip_serializing_if = "Option::is_none")]
+  pub approval_policy: Option<String>,
+  #[serde(default, skip_serializing_if = "Option::is_none")]
+  pub approval_policy_details: Option<CodexApprovalPolicy>,
+  #[serde(default, skip_serializing_if = "Option::is_none")]
+  pub sandbox_mode: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ControlDeckCapabilities {
+  pub supports_skills: bool,
+  pub supports_mentions: bool,
+  pub supports_images: bool,
+  pub supports_steer: bool,
+  pub allow_per_turn_model_override: bool,
+  pub allow_per_turn_effort_override: bool,
+  #[serde(default)]
+  pub approval_mode_options: Vec<ControlDeckPickerOption>,
+  #[serde(default)]
+  pub permission_mode_options: Vec<ControlDeckPickerOption>,
+  #[serde(default)]
+  pub collaboration_mode_options: Vec<ControlDeckPickerOption>,
+  #[serde(default)]
+  pub auto_review_options: Vec<ControlDeckAutoReviewOption>,
+  #[serde(default)]
+  pub available_status_modules: Vec<ControlDeckModule>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ControlDeckTokenStatusTone {
+  Muted,
+  Normal,
+  Caution,
+  Critical,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ControlDeckTokenStatus {
+  pub label: String,
+  pub tone: ControlDeckTokenStatusTone,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ControlDeckSnapshot {
+  pub revision: u64,
+  pub session_id: String,
+  pub state: ControlDeckState,
+  pub capabilities: ControlDeckCapabilities,
+  pub preferences: ControlDeckPreferences,
+  pub token_usage: TokenUsage,
+  pub token_usage_snapshot_kind: TokenUsageSnapshotKind,
+  pub token_status: ControlDeckTokenStatus,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct ControlDeckConfigUpdate {
+  #[serde(default, skip_serializing_if = "Option::is_none")]
+  pub model: Option<String>,
+  #[serde(default, skip_serializing_if = "Option::is_none")]
+  pub effort: Option<String>,
+  #[serde(default, skip_serializing_if = "Option::is_none")]
+  pub approval_policy: Option<String>,
+  #[serde(default, skip_serializing_if = "Option::is_none")]
+  pub approval_policy_details: Option<CodexApprovalPolicy>,
+  #[serde(default, skip_serializing_if = "Option::is_none")]
+  pub sandbox_mode: Option<String>,
+  #[serde(default, skip_serializing_if = "Option::is_none")]
+  pub approvals_reviewer: Option<CodexApprovalsReviewer>,
+  #[serde(default, skip_serializing_if = "Option::is_none")]
+  pub permission_mode: Option<String>,
+  #[serde(default, skip_serializing_if = "Option::is_none")]
+  pub collaboration_mode: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ControlDeckMentionKind {
+  File,
+  McpResource,
+  Url,
+  Symbol,
+  Generic,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ControlDeckMentionRef {
+  #[serde(default, skip_serializing_if = "Option::is_none")]
+  pub mention_id: Option<String>,
+  pub kind: ControlDeckMentionKind,
+  pub name: String,
+  pub path: String,
+  #[serde(default, skip_serializing_if = "Option::is_none")]
+  pub relative_path: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ControlDeckImageAttachmentRef {
+  pub attachment_id: String,
+  #[serde(default, skip_serializing_if = "Option::is_none")]
+  pub display_name: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum ControlDeckAttachmentRef {
+  Mention(ControlDeckMentionRef),
+  Image(ControlDeckImageAttachmentRef),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ControlDeckSkillRef {
+  pub name: String,
+  pub path: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct ControlDeckTurnOverrides {
+  #[serde(default, skip_serializing_if = "Option::is_none")]
+  pub model: Option<String>,
+  #[serde(default, skip_serializing_if = "Option::is_none")]
+  pub effort: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ControlDeckSubmitTurnRequest {
+  pub text: String,
+  #[serde(default, skip_serializing_if = "Vec::is_empty")]
+  pub attachments: Vec<ControlDeckAttachmentRef>,
+  #[serde(default, skip_serializing_if = "Vec::is_empty")]
+  pub skills: Vec<ControlDeckSkillRef>,
+  #[serde(default, skip_serializing_if = "Option::is_none")]
+  pub overrides: Option<ControlDeckTurnOverrides>,
+}

--- a/orbitdock-server/crates/protocol/src/types.rs
+++ b/orbitdock-server/crates/protocol/src/types.rs
@@ -101,6 +101,22 @@ impl CodexApprovalMode {
   }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CodexApprovalsReviewer {
+  User,
+  GuardianSubagent,
+}
+
+impl CodexApprovalsReviewer {
+  pub fn as_str(self) -> &'static str {
+    match self {
+      Self::User => "user",
+      Self::GuardianSubagent => "guardian_subagent",
+    }
+  }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct CodexGranularApprovalPolicy {
   pub sandbox_approval: bool,
@@ -1437,6 +1453,8 @@ pub struct CodexSessionOverrides {
   #[serde(default, skip_serializing_if = "Option::is_none")]
   pub sandbox_mode: Option<String>,
   #[serde(default, skip_serializing_if = "Option::is_none")]
+  pub approvals_reviewer: Option<CodexApprovalsReviewer>,
+  #[serde(default, skip_serializing_if = "Option::is_none")]
   pub collaboration_mode: Option<String>,
   #[serde(default, skip_serializing_if = "Option::is_none")]
   pub multi_agent: Option<bool>,
@@ -1796,6 +1814,30 @@ pub struct DashboardSnapshot {
   pub sessions: Vec<SessionListItem>,
   pub conversations: Vec<DashboardConversationItem>,
   pub counts: DashboardCounts,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct UsageSummaryModelCost {
+  pub model: String,
+  pub cost_usd: f64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct UsageSummaryBucket {
+  pub session_count: u64,
+  pub total_tokens: u64,
+  pub input_tokens: u64,
+  pub output_tokens: u64,
+  pub cached_tokens: u64,
+  pub total_cost_usd: f64,
+  #[serde(default)]
+  pub cost_by_model: Vec<UsageSummaryModelCost>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct UsageSummarySnapshot {
+  pub today: UsageSummaryBucket,
+  pub all_time: UsageSummaryBucket,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/orbitdock-server/crates/server/src/domain/control_deck.rs
+++ b/orbitdock-server/crates/server/src/domain/control_deck.rs
@@ -1,0 +1,522 @@
+use orbitdock_protocol::{
+  ControlDeckAttachmentRef, ControlDeckCapabilities, ControlDeckConfigState,
+  ControlDeckDensity, ControlDeckEmptyVisibility, ControlDeckImageAttachmentRef,
+  ControlDeckMentionRef, ControlDeckModule, ControlDeckModulePreference,
+  ControlDeckPickerOption, ControlDeckPreferences, ControlDeckSkillRef, ControlDeckSnapshot,
+  ControlDeckState, ControlDeckSubmitTurnRequest, ControlDeckTokenStatus,
+  ControlDeckTokenStatusTone, ControlDeckTurnOverrides, ImageInput, MentionInput, Provider,
+  SessionState, SkillInput, TokenUsage, TokenUsageSnapshotKind,
+};
+
+pub(crate) const CONTROL_DECK_PREFERENCES_CONFIG_KEY: &str = "control_deck_preferences_v1";
+
+pub(crate) fn default_control_deck_preferences() -> ControlDeckPreferences {
+  ControlDeckPreferences {
+    density: ControlDeckDensity::Comfortable,
+    show_when_empty: ControlDeckEmptyVisibility::Auto,
+    modules: default_control_deck_module_preferences(),
+  }
+}
+
+/// Default module preferences include all possible modules. The capabilities
+/// builder filters which ones are actually available per provider.
+pub(crate) fn default_control_deck_module_preferences() -> Vec<ControlDeckModulePreference> {
+  all_control_deck_modules()
+    .into_iter()
+    .map(|module| ControlDeckModulePreference {
+      module,
+      visible: true,
+    })
+    .collect()
+}
+
+/// All possible modules (superset). Used for default preferences.
+fn all_control_deck_modules() -> Vec<ControlDeckModule> {
+  vec![
+    ControlDeckModule::Autonomy,
+    ControlDeckModule::ApprovalMode,
+    ControlDeckModule::CollaborationMode,
+    ControlDeckModule::AutoReview,
+    ControlDeckModule::Attachments,
+    ControlDeckModule::Model,
+    ControlDeckModule::Effort,
+    ControlDeckModule::Tokens,
+    ControlDeckModule::Branch,
+    ControlDeckModule::Cwd,
+  ]
+}
+
+/// Shared modules shown for all providers.
+fn shared_status_modules() -> Vec<ControlDeckModule> {
+  vec![
+    ControlDeckModule::Model,
+    ControlDeckModule::Effort,
+    ControlDeckModule::Tokens,
+    ControlDeckModule::Branch,
+    ControlDeckModule::Cwd,
+  ]
+}
+
+fn picker_option(value: &str, label: &str) -> ControlDeckPickerOption {
+  ControlDeckPickerOption {
+    value: value.to_string(),
+    label: label.to_string(),
+  }
+}
+
+fn claude_permission_mode_options() -> Vec<ControlDeckPickerOption> {
+  vec![
+    picker_option("plan", "Plan Mode"),
+    picker_option("dontAsk", "Don't Ask"),
+    picker_option("default", "Default"),
+    picker_option("acceptEdits", "Accept Edits"),
+    picker_option("bypassPermissions", "Bypass Permissions"),
+  ]
+}
+
+fn codex_approval_mode_options() -> Vec<ControlDeckPickerOption> {
+  vec![
+    picker_option("untrusted", "Trusted Only"),
+    picker_option("on-failure", "On Failure"),
+    picker_option("on-request", "Default"),
+    picker_option("never", "Never Ask"),
+  ]
+}
+
+fn codex_collaboration_mode_options() -> Vec<ControlDeckPickerOption> {
+  vec![
+    picker_option("default", "Default"),
+    picker_option("plan", "Plan"),
+  ]
+}
+
+/// Provider-aware module list. Claude and Codex have different control surfaces.
+pub(crate) fn control_deck_status_modules(provider: Provider) -> Vec<ControlDeckModule> {
+  let mut modules = Vec::new();
+
+  match provider {
+    Provider::Claude => {
+      modules.push(ControlDeckModule::Autonomy);
+    }
+    Provider::Codex => {
+      modules.push(ControlDeckModule::ApprovalMode);
+      modules.push(ControlDeckModule::CollaborationMode);
+      modules.push(ControlDeckModule::Attachments);
+    }
+  }
+
+  modules.extend(shared_status_modules());
+  modules
+}
+
+pub(crate) fn build_control_deck_capabilities(
+  provider: Provider,
+  steerable: bool,
+  _codex_config_mode: Option<orbitdock_protocol::CodexConfigMode>,
+) -> ControlDeckCapabilities {
+  ControlDeckCapabilities {
+    supports_skills: provider == Provider::Codex,
+    supports_mentions: provider == Provider::Codex,
+    supports_images: true,
+    supports_steer: steerable,
+    allow_per_turn_model_override: provider == Provider::Claude || provider == Provider::Codex,
+    allow_per_turn_effort_override: provider == Provider::Codex,
+    approval_mode_options: if provider == Provider::Codex {
+      codex_approval_mode_options()
+    } else {
+      Vec::new()
+    },
+    permission_mode_options: if provider == Provider::Claude {
+      claude_permission_mode_options()
+    } else {
+      Vec::new()
+    },
+    collaboration_mode_options: if provider == Provider::Codex {
+      codex_collaboration_mode_options()
+    } else {
+      Vec::new()
+    },
+    auto_review_options: Vec::new(),
+    available_status_modules: control_deck_status_modules(provider),
+  }
+}
+
+pub(crate) fn build_control_deck_snapshot(
+  session: &SessionState,
+  preferences: ControlDeckPreferences,
+) -> ControlDeckSnapshot {
+  let state = ControlDeckState {
+    provider: session.provider,
+    control_mode: session.control_mode,
+    lifecycle_state: session.lifecycle_state,
+    accepts_user_input: session.accepts_user_input,
+    steerable: session.steerable,
+    project_path: session.project_path.clone(),
+    current_cwd: session.current_cwd.clone(),
+    git_branch: session.git_branch.clone(),
+    config: ControlDeckConfigState {
+      model: session.model.clone(),
+      effort: session.effort.clone(),
+      approval_policy: session.approval_policy.clone(),
+      approval_policy_details: session.approval_policy_details.clone(),
+      sandbox_mode: session.sandbox_mode.clone(),
+      approvals_reviewer: session
+        .codex_config_overrides
+        .as_ref()
+        .and_then(|overrides| overrides.approvals_reviewer),
+      permission_mode: session.permission_mode.clone(),
+      collaboration_mode: session.collaboration_mode.clone(),
+      developer_instructions: session.developer_instructions.clone(),
+      codex_config_mode: session.codex_config_mode,
+      codex_config_profile: session.codex_config_profile.clone(),
+      codex_model_provider: session.codex_model_provider.clone(),
+    },
+  };
+
+  ControlDeckSnapshot {
+    revision: session.revision.unwrap_or_default(),
+    session_id: session.id.clone(),
+    capabilities: build_control_deck_capabilities(
+      session.provider,
+      session.steerable,
+      session.codex_config_mode,
+    ),
+    preferences,
+    state,
+    token_usage: session.token_usage.clone(),
+    token_usage_snapshot_kind: session.token_usage_snapshot_kind,
+    token_status: build_control_deck_token_status(
+      session.provider,
+      &session.token_usage,
+      session.token_usage_snapshot_kind,
+    ),
+  }
+}
+
+fn build_control_deck_token_status(
+  provider: Provider,
+  usage: &TokenUsage,
+  snapshot_kind: TokenUsageSnapshotKind,
+) -> ControlDeckTokenStatus {
+  if usage.context_window == 0 {
+    return ControlDeckTokenStatus {
+      label: "—".to_string(),
+      tone: ControlDeckTokenStatusTone::Muted,
+    };
+  }
+
+  let effective_input = effective_context_input_tokens(provider, usage, snapshot_kind);
+  let fill_percent = if usage.context_window == 0 {
+    0.0
+  } else {
+    (effective_input as f64 / usage.context_window as f64) * 100.0
+  };
+  let display_percent = if effective_input > 0 && fill_percent > 0.0 && fill_percent < 1.0 {
+    "<1".to_string()
+  } else {
+    format!("{}", fill_percent.floor() as u64)
+  };
+
+  ControlDeckTokenStatus {
+    label: format!(
+      "{}% · {}/{}",
+      display_percent,
+      format_token_count(effective_input),
+      format_token_count(usage.context_window)
+    ),
+    tone: if fill_percent > 90.0 {
+      ControlDeckTokenStatusTone::Critical
+    } else if fill_percent > 70.0 {
+      ControlDeckTokenStatusTone::Caution
+    } else {
+      ControlDeckTokenStatusTone::Normal
+    },
+  }
+}
+
+fn effective_context_input_tokens(
+  provider: Provider,
+  usage: &TokenUsage,
+  snapshot_kind: TokenUsageSnapshotKind,
+) -> u64 {
+  match snapshot_kind {
+    TokenUsageSnapshotKind::MixedLegacy => usage.input_tokens.saturating_add(usage.cached_tokens),
+    TokenUsageSnapshotKind::CompactionReset => 0,
+    TokenUsageSnapshotKind::ContextTurn => {
+      if provider == Provider::Claude {
+        usage.input_tokens.saturating_add(usage.cached_tokens)
+      } else {
+        usage.input_tokens
+      }
+    }
+    TokenUsageSnapshotKind::LifetimeTotals => usage.input_tokens,
+    TokenUsageSnapshotKind::Unknown => {
+      if provider == Provider::Codex {
+        usage.input_tokens
+      } else {
+        usage.input_tokens.saturating_add(usage.cached_tokens)
+      }
+    }
+  }
+}
+
+fn format_token_count(count: u64) -> String {
+  if count >= 1_000_000 {
+    format!("{:.1}M", count as f64 / 1_000_000.0)
+  } else if count >= 1_000 {
+    format!("{:.0}K", count as f64 / 1_000.0)
+  } else {
+    count.to_string()
+  }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct ControlDeckSubmitPlan {
+  pub text: String,
+  pub model: Option<String>,
+  pub effort: Option<String>,
+  pub skills: Vec<SkillInput>,
+  pub images: Vec<ImageInput>,
+  pub mentions: Vec<MentionInput>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum ControlDeckSubmitValidationError {
+  EmptyRequest,
+}
+
+impl ControlDeckSubmitValidationError {
+  pub(crate) fn message(&self) -> &'static str {
+    match self {
+      Self::EmptyRequest => "Provide text, attachments, or skills to submit a Control Deck turn",
+    }
+  }
+}
+
+pub(crate) fn validate_control_deck_submit_request(
+  request: ControlDeckSubmitTurnRequest,
+) -> Result<ControlDeckSubmitPlan, ControlDeckSubmitValidationError> {
+  let (images, mentions) = map_control_deck_attachments(request.attachments);
+  let skills = map_control_deck_skills(request.skills);
+  let ControlDeckTurnOverrides { model, effort } = request.overrides.unwrap_or_default();
+
+  if request.text.is_empty() && images.is_empty() && mentions.is_empty() && skills.is_empty() {
+    return Err(ControlDeckSubmitValidationError::EmptyRequest);
+  }
+
+  Ok(ControlDeckSubmitPlan {
+    text: request.text,
+    model,
+    effort,
+    skills,
+    images,
+    mentions,
+  })
+}
+
+fn map_control_deck_attachments(
+  attachments: Vec<ControlDeckAttachmentRef>,
+) -> (Vec<ImageInput>, Vec<MentionInput>) {
+  let mut images = Vec::new();
+  let mut mentions = Vec::new();
+
+  for attachment in attachments {
+    match attachment {
+      ControlDeckAttachmentRef::Image(ControlDeckImageAttachmentRef {
+        attachment_id,
+        display_name,
+      }) => {
+        images.push(ImageInput {
+          input_type: "attachment".to_string(),
+          value: attachment_id,
+          mime_type: None,
+          byte_count: None,
+          display_name,
+          pixel_width: None,
+          pixel_height: None,
+        });
+      }
+      ControlDeckAttachmentRef::Mention(ControlDeckMentionRef {
+        name,
+        path,
+        kind: _kind,
+        mention_id: _mention_id,
+        relative_path: _relative_path,
+      }) => {
+        mentions.push(MentionInput { name, path });
+      }
+    }
+  }
+
+  (images, mentions)
+}
+
+fn map_control_deck_skills(skills: Vec<ControlDeckSkillRef>) -> Vec<SkillInput> {
+  skills
+    .into_iter()
+    .map(|skill| SkillInput {
+      name: skill.name,
+      path: skill.path,
+    })
+    .collect()
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use orbitdock_protocol::{
+    ControlDeckMentionKind, SessionControlMode, SessionLifecycleState, SessionState, SessionStatus,
+    WorkStatus,
+  };
+
+  fn sample_session_state() -> SessionState {
+    SessionState {
+      id: "session-1".to_string(),
+      provider: Provider::Codex,
+      project_path: "/workspace/project".to_string(),
+      transcript_path: None,
+      project_name: Some("project".to_string()),
+      model: Some("gpt-5.4".to_string()),
+      custom_name: Some("Project".to_string()),
+      summary: None,
+      first_prompt: None,
+      last_message: None,
+      status: SessionStatus::Active,
+      work_status: WorkStatus::Working,
+      control_mode: SessionControlMode::Direct,
+      lifecycle_state: SessionLifecycleState::Open,
+      accepts_user_input: true,
+      steerable: true,
+      pending_approval: None,
+      permission_mode: Some("default".to_string()),
+      allow_bypass_permissions: true,
+      collaboration_mode: Some("default".to_string()),
+      multi_agent: Some(false),
+      personality: None,
+      service_tier: None,
+      developer_instructions: None,
+      codex_config_mode: Some(CodexConfigMode::Custom),
+      codex_config_profile: Some("default".to_string()),
+      codex_model_provider: Some("openai".to_string()),
+      codex_config_source: None,
+      codex_config_overrides: None,
+      pending_tool_name: None,
+      pending_tool_input: None,
+      pending_question: None,
+      pending_approval_id: None,
+      token_usage: Default::default(),
+      token_usage_snapshot_kind: Default::default(),
+      current_diff: None,
+      cumulative_diff: None,
+      current_plan: None,
+      codex_integration_mode: None,
+      claude_integration_mode: None,
+      approval_policy: None,
+      approval_policy_details: None,
+      sandbox_mode: None,
+      started_at: None,
+      last_activity_at: None,
+      last_progress_at: None,
+      forked_from_session_id: None,
+      revision: Some(42),
+      current_turn_id: None,
+      turn_count: 0,
+      turn_diffs: vec![],
+      git_branch: Some("main".to_string()),
+      git_sha: None,
+      current_cwd: Some("/workspace/project".to_string()),
+      subagents: vec![],
+      effort: Some("medium".to_string()),
+      terminal_session_id: None,
+      terminal_app: None,
+      approval_version: None,
+      repository_root: None,
+      is_worktree: false,
+      worktree_id: None,
+      unread_count: 0,
+      mission_id: None,
+      issue_identifier: None,
+      rows: vec![],
+      total_row_count: 0,
+      has_more_before: false,
+      oldest_sequence: None,
+      newest_sequence: None,
+    }
+  }
+
+  #[test]
+  fn uses_default_preferences_when_empty() {
+    let prefs = default_control_deck_preferences();
+    assert_eq!(prefs.density, ControlDeckDensity::Comfortable);
+    assert_eq!(prefs.show_when_empty, ControlDeckEmptyVisibility::Auto);
+    assert!(!prefs.modules.is_empty());
+  }
+
+  #[test]
+  fn builds_snapshot_from_session_state() {
+    let session = sample_session_state();
+    let snapshot = build_control_deck_snapshot(&session, default_control_deck_preferences());
+
+    assert_eq!(snapshot.session_id, "session-1");
+    assert_eq!(snapshot.revision, 42);
+    assert!(snapshot.capabilities.supports_skills);
+  }
+
+  #[test]
+  fn rejects_empty_submit_requests() {
+    let request = ControlDeckSubmitTurnRequest {
+      text: String::new(),
+      attachments: vec![],
+      skills: vec![],
+      overrides: None,
+    };
+
+    let result = validate_control_deck_submit_request(request);
+    assert!(matches!(
+      result,
+      Err(ControlDeckSubmitValidationError::EmptyRequest)
+    ));
+  }
+
+  #[test]
+  fn maps_control_deck_submit_payload_into_connector_plan() {
+    let request = ControlDeckSubmitTurnRequest {
+      text: "Refine the header".to_string(),
+      attachments: vec![
+        ControlDeckAttachmentRef::Image(ControlDeckImageAttachmentRef {
+          attachment_id: "img-123".to_string(),
+          display_name: Some("mock.png".to_string()),
+        }),
+        ControlDeckAttachmentRef::Mention(ControlDeckMentionRef {
+          mention_id: Some("mention-1".to_string()),
+          kind: ControlDeckMentionKind::File,
+          name: "design-system".to_string(),
+          path: "/workspace/design-system".to_string(),
+          relative_path: Some("design-system".to_string()),
+        }),
+      ],
+      skills: vec![ControlDeckSkillRef {
+        name: "design-system".to_string(),
+        path: "/workspace/.skills/design-system".to_string(),
+      }],
+      overrides: Some(ControlDeckTurnOverrides {
+        model: Some("gpt-5.4".to_string()),
+        effort: Some("high".to_string()),
+      }),
+    };
+
+    let plan = validate_control_deck_submit_request(request).expect("request should be valid");
+    assert_eq!(plan.text, "Refine the header");
+    assert_eq!(plan.images.len(), 1);
+    assert_eq!(plan.images[0].input_type, "attachment");
+    assert_eq!(plan.images[0].value, "img-123");
+    assert_eq!(plan.images[0].display_name.as_deref(), Some("mock.png"));
+    assert_eq!(plan.mentions.len(), 1);
+    assert_eq!(plan.mentions[0].name, "design-system");
+    assert_eq!(plan.mentions[0].path, "/workspace/design-system");
+    assert_eq!(plan.skills.len(), 1);
+    assert_eq!(plan.skills[0].name, "design-system");
+    assert_eq!(plan.model.as_deref(), Some("gpt-5.4"));
+    assert_eq!(plan.effort.as_deref(), Some("high"));
+  }
+}

--- a/orbitdock-server/crates/server/src/runtime/codex_config.rs
+++ b/orbitdock-server/crates/server/src/runtime/codex_config.rs
@@ -302,19 +302,28 @@ pub async fn resolve_codex_settings(
   })
 }
 
-pub async fn codex_config_catalog(cwd: &str) -> Result<CodexConfigCatalogResponse, String> {
-  let config_response = read_codex_config(cwd).await?;
-  let selection = CodexConfigSelection {
-    config_source: CodexConfigSource::User,
-    config_mode: CodexConfigMode::Inherit,
-    config_profile: None,
-    model_provider: None,
-    overrides: CodexSessionOverrides::default(),
+pub async fn codex_config_catalog(cwd: Option<&str>) -> Result<CodexConfigCatalogResponse, String> {
+  let explicit_cwd = cwd.and_then(normalized_optional_cwd);
+  let resolved_cwd = resolved_codex_context_cwd(explicit_cwd)?;
+  let config_response = read_codex_config(&resolved_cwd).await?;
+
+  let effective_settings = if let Some(explicit_cwd) = explicit_cwd {
+    let selection = CodexConfigSelection {
+      config_source: CodexConfigSource::User,
+      config_mode: CodexConfigMode::Inherit,
+      config_profile: None,
+      model_provider: None,
+      overrides: CodexSessionOverrides::default(),
+    };
+    let effective_config = build_effective_codex_config(explicit_cwd, &selection).await?;
+    Some(effective_settings(&effective_config, &selection))
+  } else {
+    None
   };
-  let effective_config = build_effective_codex_config(cwd, &selection).await?;
+
   Ok(CodexConfigCatalogResponse {
-    cwd: Some(cwd.to_string()),
-    effective_settings: Some(effective_settings(&effective_config, &selection)),
+    cwd: explicit_cwd.map(str::to_string),
+    effective_settings,
     profiles: config_profiles(&config_response.config),
     providers: config_providers(&config_response.config),
     warnings: Vec::new(),
@@ -671,6 +680,32 @@ async fn read_codex_config(cwd: &str) -> Result<ConfigReadResponse, String> {
   .await
 }
 
+fn normalized_optional_cwd(cwd: &str) -> Option<&str> {
+  let trimmed = cwd.trim();
+  if trimmed.is_empty() {
+    None
+  } else {
+    Some(trimmed)
+  }
+}
+
+fn resolved_codex_context_cwd(cwd: Option<&str>) -> Result<String, String> {
+  if let Some(cwd) = cwd {
+    return Ok(cwd.to_string());
+  }
+
+  if let Some(home) = std::env::var_os("HOME") {
+    let path = PathBuf::from(home);
+    if path.exists() {
+      return Ok(path.display().to_string());
+    }
+  }
+
+  std::env::current_dir()
+    .map(|path| path.display().to_string())
+    .map_err(|error| format!("Couldn't resolve a fallback Codex config directory: {error}"))
+}
+
 async fn call_codex_app_server<TParams, TResponse>(
   cwd: &str,
   request_id: i64,
@@ -928,6 +963,10 @@ async fn build_effective_codex_config(
     config_profile: selection.config_profile.clone(),
   };
   let control_plane = CodexControlPlane {
+    approvals_reviewer: selection
+      .overrides
+      .approvals_reviewer
+      .map(|value| value.as_str().to_string()),
     collaboration_mode: selection.overrides.collaboration_mode.clone(),
     multi_agent: selection.overrides.multi_agent,
     personality: selection.overrides.personality.clone(),

--- a/orbitdock-server/crates/server/src/runtime/control_deck.rs
+++ b/orbitdock-server/crates/server/src/runtime/control_deck.rs
@@ -1,0 +1,234 @@
+use std::sync::Arc;
+
+use orbitdock_protocol::{
+  ControlDeckConfigUpdate, ControlDeckPreferences, ControlDeckSnapshot,
+  ControlDeckSubmitTurnRequest, ImageInput, MentionInput, SkillInput,
+};
+
+use crate::domain::control_deck::{
+  build_control_deck_snapshot, default_control_deck_preferences,
+  validate_control_deck_submit_request, ControlDeckSubmitValidationError,
+  CONTROL_DECK_PREFERENCES_CONFIG_KEY,
+};
+use crate::infrastructure::images::store_uploaded_attachment;
+use crate::infrastructure::persistence::{load_config_value, PersistCommand};
+use crate::runtime::message_dispatch::{
+  dispatch_user_prompt, DispatchMessageError, DispatchUserPrompt,
+};
+use crate::runtime::session_mutations::{
+  update_session_config as update_runtime_session_config, SessionConfigUpdate, SessionMutationError,
+};
+use crate::runtime::session_queries::{load_full_session_state, SessionLoadError};
+use crate::runtime::session_registry::SessionRegistry;
+
+#[derive(Debug)]
+pub(crate) enum ControlDeckSnapshotLoadError {
+  NotFound,
+  Db(String),
+  Runtime(String),
+}
+
+#[derive(Debug)]
+pub(crate) enum ControlDeckPreferencesUpdateError {
+  Serialization(String),
+  Persistence(String),
+}
+
+#[derive(Debug)]
+pub(crate) enum ControlDeckConfigUpdateError {
+  NotFound,
+  InvalidConfig(String),
+  Db(String),
+  Runtime(String),
+}
+
+#[derive(Debug)]
+pub(crate) enum ControlDeckSubmitError {
+  InvalidRequest(String),
+  SessionNotFound,
+  ConnectorUnavailable,
+}
+
+#[derive(Debug)]
+pub(crate) enum ControlDeckAttachmentUploadError {
+  SessionNotFound,
+  Storage(String),
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct ControlDeckSubmitResult {
+  pub row: orbitdock_protocol::conversation_contracts::ConversationRowEntry,
+}
+
+#[derive(Debug, Clone)]
+struct ControlDeckDispatchRequest {
+  session_id: String,
+  content: String,
+  model: Option<String>,
+  effort: Option<String>,
+  skills: Vec<SkillInput>,
+  images: Vec<ImageInput>,
+  mentions: Vec<MentionInput>,
+  message_id: String,
+}
+
+pub(crate) fn load_control_deck_preferences() -> ControlDeckPreferences {
+  load_config_value(CONTROL_DECK_PREFERENCES_CONFIG_KEY)
+    .and_then(|raw| serde_json::from_str::<ControlDeckPreferences>(&raw).ok())
+    .unwrap_or_else(default_control_deck_preferences)
+}
+
+pub(crate) async fn load_control_deck_snapshot(
+  state: &Arc<SessionRegistry>,
+  session_id: &str,
+) -> Result<ControlDeckSnapshot, ControlDeckSnapshotLoadError> {
+  match load_full_session_state(state, session_id, false).await {
+    Ok(session) => Ok(build_control_deck_snapshot(
+      &session,
+      load_control_deck_preferences(),
+    )),
+    Err(SessionLoadError::NotFound) => Err(ControlDeckSnapshotLoadError::NotFound),
+    Err(SessionLoadError::Db(err)) => Err(ControlDeckSnapshotLoadError::Db(err)),
+    Err(SessionLoadError::Runtime(err)) => Err(ControlDeckSnapshotLoadError::Runtime(err)),
+  }
+}
+
+pub(crate) async fn update_control_deck_preferences(
+  state: &Arc<SessionRegistry>,
+  preferences: ControlDeckPreferences,
+) -> Result<ControlDeckPreferences, ControlDeckPreferencesUpdateError> {
+  let serialized = serde_json::to_string(&preferences)
+    .map_err(|error| ControlDeckPreferencesUpdateError::Serialization(error.to_string()))?;
+
+  state
+    .persist()
+    .send(PersistCommand::SetConfig {
+      key: CONTROL_DECK_PREFERENCES_CONFIG_KEY.to_string(),
+      value: serialized,
+    })
+    .await
+    .map_err(|error| ControlDeckPreferencesUpdateError::Persistence(error.to_string()))?;
+
+  Ok(preferences)
+}
+
+pub(crate) async fn update_control_deck_config(
+  state: &Arc<SessionRegistry>,
+  session_id: &str,
+  update: ControlDeckConfigUpdate,
+) -> Result<ControlDeckSnapshot, ControlDeckConfigUpdateError> {
+  update_runtime_session_config(
+    state,
+    session_id,
+    SessionConfigUpdate {
+      approval_policy: update.approval_policy.map(Some),
+      approval_policy_details: update.approval_policy_details.map(Some),
+      sandbox_mode: update.sandbox_mode.map(Some),
+      approvals_reviewer: update.approvals_reviewer.map(Some),
+      permission_mode: update.permission_mode.map(Some),
+      collaboration_mode: update.collaboration_mode.map(Some),
+      model: update.model.map(Some),
+      effort: update.effort.map(Some),
+      ..Default::default()
+    },
+  )
+  .await
+  .map_err(|error| match error {
+    SessionMutationError::NotFound(_) => ControlDeckConfigUpdateError::NotFound,
+    SessionMutationError::InvalidCodexConfig(message) => {
+      ControlDeckConfigUpdateError::InvalidConfig(message)
+    }
+  })?;
+
+  load_control_deck_snapshot(state, session_id)
+    .await
+    .map_err(|error| match error {
+      ControlDeckSnapshotLoadError::NotFound => ControlDeckConfigUpdateError::NotFound,
+      ControlDeckSnapshotLoadError::Db(message) => ControlDeckConfigUpdateError::Db(message),
+      ControlDeckSnapshotLoadError::Runtime(message) => {
+        ControlDeckConfigUpdateError::Runtime(message)
+      }
+    })
+}
+
+pub(crate) async fn submit_control_deck_turn(
+  state: &Arc<SessionRegistry>,
+  session_id: &str,
+  request: ControlDeckSubmitTurnRequest,
+) -> Result<ControlDeckSubmitResult, ControlDeckSubmitError> {
+  let plan = validate_control_deck_submit_request(request).map_err(
+    |error: ControlDeckSubmitValidationError| {
+      ControlDeckSubmitError::InvalidRequest(error.message().to_string())
+    },
+  )?;
+
+  let user_row = dispatch_control_deck_turn(
+    state,
+    ControlDeckDispatchRequest {
+      session_id: session_id.to_string(),
+      content: plan.text,
+      model: plan.model,
+      effort: plan.effort,
+      skills: plan.skills,
+      images: plan.images,
+      mentions: plan.mentions,
+      message_id: format!("control-deck-http-{}", orbitdock_protocol::new_id()),
+    },
+  )
+  .await
+  .map_err(map_dispatch_error)?;
+
+  Ok(ControlDeckSubmitResult { row: user_row })
+}
+
+async fn dispatch_control_deck_turn(
+  state: &Arc<SessionRegistry>,
+  request: ControlDeckDispatchRequest,
+) -> Result<orbitdock_protocol::conversation_contracts::ConversationRowEntry, DispatchMessageError>
+{
+  dispatch_user_prompt(
+    state,
+    DispatchUserPrompt {
+      session_id: request.session_id,
+      content: request.content,
+      model: request.model,
+      effort: request.effort,
+      skills: request.skills,
+      images: request.images,
+      mentions: request.mentions,
+      message_id: request.message_id,
+    },
+  )
+  .await
+}
+
+pub(crate) fn upload_control_deck_image_attachment(
+  state: &Arc<SessionRegistry>,
+  session_id: &str,
+  bytes: &[u8],
+  mime_type: &str,
+  display_name: Option<&str>,
+  pixel_width: Option<u32>,
+  pixel_height: Option<u32>,
+) -> Result<ImageInput, ControlDeckAttachmentUploadError> {
+  if state.get_session(session_id).is_none() {
+    return Err(ControlDeckAttachmentUploadError::SessionNotFound);
+  }
+
+  store_uploaded_attachment(
+    session_id,
+    bytes,
+    mime_type,
+    display_name,
+    pixel_width,
+    pixel_height,
+  )
+  .map_err(ControlDeckAttachmentUploadError::Storage)
+}
+
+fn map_dispatch_error(error: DispatchMessageError) -> ControlDeckSubmitError {
+  match error {
+    DispatchMessageError::SessionNotFound => ControlDeckSubmitError::SessionNotFound,
+    DispatchMessageError::ConnectorUnavailable => ControlDeckSubmitError::ConnectorUnavailable,
+  }
+}

--- a/orbitdock-server/crates/server/src/runtime/session_actor.rs
+++ b/orbitdock-server/crates/server/src/runtime/session_actor.rs
@@ -215,7 +215,7 @@ mod tests {
   use orbitdock_protocol::conversation_contracts::{
     ConversationRow, ConversationRowEntry, ConversationRowSummary, MessageRowContent,
   };
-  use orbitdock_protocol::{Provider, WorkStatus};
+  use orbitdock_protocol::{Provider, StateChanges, WorkStatus};
 
   fn test_handle() -> SessionHandle {
     SessionHandle::new(
@@ -251,8 +251,12 @@ mod tests {
     assert_eq!(snap.work_status, WorkStatus::Waiting);
 
     actor_handle
-      .send(SessionCommand::SetWorkStatus {
-        status: WorkStatus::Working,
+      .send(SessionCommand::ApplyDelta {
+        changes: Box::new(StateChanges {
+          work_status: Some(WorkStatus::Working),
+          ..Default::default()
+        }),
+        persist_op: None,
       })
       .await;
 

--- a/orbitdock-server/crates/server/src/runtime/session_command_handler.rs
+++ b/orbitdock-server/crates/server/src/runtime/session_command_handler.rs
@@ -56,6 +56,7 @@ async fn execute_persist_op(op: PersistOp, persist_tx: &mpsc::Sender<PersistComm
       session_id: cfg.session_id,
       approval_policy: cfg.approval_policy,
       sandbox_mode: cfg.sandbox_mode,
+      approvals_reviewer: cfg.approvals_reviewer,
       permission_mode: cfg.permission_mode,
       collaboration_mode: cfg.collaboration_mode,
       multi_agent: cfg.multi_agent,

--- a/orbitdock-server/crates/server/src/runtime/session_commands.rs
+++ b/orbitdock-server/crates/server/src/runtime/session_commands.rs
@@ -1,9 +1,9 @@
 //! Commands sent to a session actor from websocket/rollout_watcher callers.
 
 use orbitdock_protocol::{
-  conversation_contracts::ConversationRowEntry, ApprovalRequest, ApprovalType,
-  CodexIntegrationMode, ServerMessage, SessionLifecycleState, SessionState, SessionStatus,
-  SessionSummary, StateChanges, SubagentInfo, WorkStatus,
+  conversation_contracts::ConversationRowEntry, ApprovalRequest, ApprovalType, ServerMessage,
+  CodexApprovalsReviewer, SessionLifecycleState, SessionState, SessionStatus, SessionSummary,
+  StateChanges, SubagentInfo, WorkStatus,
 };
 use tokio::sync::{broadcast, oneshot};
 
@@ -32,6 +32,7 @@ pub struct SessionConfigPersist {
   pub session_id: String,
   pub approval_policy: Option<Option<String>>,
   pub sandbox_mode: Option<Option<String>>,
+  pub approvals_reviewer: Option<Option<CodexApprovalsReviewer>>,
   pub permission_mode: Option<Option<String>>,
   pub collaboration_mode: Option<Option<String>>,
   pub multi_agent: Option<Option<bool>>,
@@ -75,26 +76,11 @@ pub enum SessionCommand {
   },
 
   // -- Simple mutations (fire-and-forget) --
-  SetWorkStatus {
-    status: WorkStatus,
-  },
   SetModel {
     model: Option<String>,
   },
   SetTranscriptPath {
     path: Option<String>,
-  },
-  SetProjectName {
-    name: Option<String>,
-  },
-  SetStatus {
-    status: SessionStatus,
-  },
-  SetLastActivityAt {
-    ts: Option<String>,
-  },
-  SetCodexIntegrationMode {
-    mode: Option<CodexIntegrationMode>,
   },
   SetLastTool {
     tool: Option<String>,

--- a/orbitdock-server/crates/server/src/runtime/session_direct_start.rs
+++ b/orbitdock-server/crates/server/src/runtime/session_direct_start.rs
@@ -84,6 +84,7 @@ pub(crate) async fn start_direct_codex_session(
           config_profile,
         },
         control_plane: CodexControlPlane {
+          approvals_reviewer: None,
           collaboration_mode,
           multi_agent,
           personality,

--- a/orbitdock-server/crates/server/src/runtime/session_fork_policy.rs
+++ b/orbitdock-server/crates/server/src/runtime/session_fork_policy.rs
@@ -85,6 +85,9 @@ pub(crate) fn remap_rows_for_fork(
         ConversationRow::ShellCommand(row) => {
           row.id = new_id;
         }
+        ConversationRow::CommandExecution(row) => {
+          row.id = new_id;
+        }
         ConversationRow::Task(row) => {
           row.id = new_id;
         }

--- a/orbitdock-server/crates/server/src/runtime/session_mutations.rs
+++ b/orbitdock-server/crates/server/src/runtime/session_mutations.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use orbitdock_protocol::{CodexApprovalPolicy, CodexConfigMode, ServerMessage};
+use orbitdock_protocol::{CodexApprovalPolicy, CodexApprovalsReviewer, CodexConfigMode, ServerMessage};
 
 use orbitdock_protocol::StateChanges;
 
@@ -24,6 +24,7 @@ pub(crate) struct SessionConfigUpdate {
   pub approval_policy: Option<Option<String>>,
   pub approval_policy_details: Option<Option<CodexApprovalPolicy>>,
   pub sandbox_mode: Option<Option<String>>,
+  pub approvals_reviewer: Option<Option<CodexApprovalsReviewer>>,
   pub permission_mode: Option<Option<String>>,
   pub collaboration_mode: Option<Option<String>>,
   pub multi_agent: Option<Option<bool>>,
@@ -132,6 +133,7 @@ pub(crate) async fn update_session_config(
     approval_policy,
     approval_policy_details,
     sandbox_mode,
+    approvals_reviewer,
     permission_mode,
     collaboration_mode,
     multi_agent,
@@ -196,6 +198,9 @@ pub(crate) async fn update_session_config(
     }
     if let Some(value) = sandbox_mode {
       overrides.sandbox_mode = value;
+    }
+    if let Some(value) = approvals_reviewer {
+      overrides.approvals_reviewer = value;
     }
     if let Some(value) = collaboration_mode {
       overrides.collaboration_mode = value;
@@ -312,6 +317,7 @@ pub(crate) async fn update_session_config(
           session_id: session_id.to_string(),
           approval_policy: approval_policy.clone(),
           sandbox_mode: sandbox_mode.clone(),
+          approvals_reviewer: approvals_reviewer.clone(),
           permission_mode: permission_mode.clone(),
           collaboration_mode: collaboration_mode.clone(),
           multi_agent,
@@ -349,6 +355,7 @@ pub(crate) async fn update_session_config(
       .send(CodexAction::UpdateConfig {
         approval_policy: approval_policy.flatten(),
         sandbox_mode: sandbox_mode.flatten(),
+        approvals_reviewer: approvals_reviewer.flatten().map(|value| value.as_str().to_string()),
         permission_mode: permission_mode.flatten(),
         collaboration_mode: collaboration_mode.flatten(),
         multi_agent: multi_agent.flatten(),

--- a/orbitdock-server/crates/server/src/runtime/session_resume.rs
+++ b/orbitdock-server/crates/server/src/runtime/session_resume.rs
@@ -180,6 +180,7 @@ fn codex_resume_selection(request: &CodexResumeRequest) -> CodexConfigSelection 
         approval_policy: request.approval_policy.clone(),
         approval_policy_details: None,
         sandbox_mode: request.sandbox_mode.clone(),
+        approvals_reviewer: None,
         collaboration_mode: request.collaboration_mode.clone(),
         multi_agent: request.multi_agent,
         personality: request.personality.clone(),
@@ -377,6 +378,10 @@ async fn spawn_codex_resume(state: &Arc<SessionRegistry>, request: CodexResumeRe
     let task_session_id = session_id.clone();
     let mut connector_task = tokio::spawn(async move {
       let control_plane = orbitdock_connector_codex::CodexControlPlane {
+        approvals_reviewer: normalized_selection
+          .overrides
+          .approvals_reviewer
+          .map(|value| value.as_str().to_string()),
         collaboration_mode: effective_collaboration_mode.clone(),
         multi_agent: effective_multi_agent,
         personality: effective_personality.clone(),

--- a/orbitdock-server/crates/server/src/runtime/session_takeover.rs
+++ b/orbitdock-server/crates/server/src/runtime/session_takeover.rs
@@ -283,6 +283,7 @@ async fn complete_codex_takeover(
         approval.as_deref(),
         sandbox.as_deref(),
         orbitdock_connector_codex::CodexControlPlane {
+          approvals_reviewer: None,
           collaboration_mode: control_plane.collaboration_mode.clone(),
           multi_agent: control_plane.multi_agent,
           personality: control_plane.personality.clone(),
@@ -301,6 +302,7 @@ async fn complete_codex_takeover(
             approval.as_deref(),
             sandbox.as_deref(),
             orbitdock_connector_codex::CodexControlPlane {
+              approvals_reviewer: None,
               collaboration_mode: control_plane.collaboration_mode.clone(),
               multi_agent: control_plane.multi_agent,
               personality: control_plane.personality.clone(),
@@ -319,6 +321,7 @@ async fn complete_codex_takeover(
         approval.as_deref(),
         sandbox.as_deref(),
         orbitdock_connector_codex::CodexControlPlane {
+          approvals_reviewer: None,
           collaboration_mode: control_plane.collaboration_mode.clone(),
           multi_agent: control_plane.multi_agent,
           personality: control_plane.personality.clone(),
@@ -591,6 +594,7 @@ fn takeover_permission_persist_op(
       session_id: session_id.to_string(),
       approval_policy: None,
       sandbox_mode: None,
+      approvals_reviewer: None,
       permission_mode: Some(Some(permission_mode)),
       collaboration_mode: None,
       multi_agent: None,

--- a/orbitdock-server/crates/server/src/transport/http/capabilities.rs
+++ b/orbitdock-server/crates/server/src/transport/http/capabilities.rs
@@ -209,6 +209,9 @@ fn codex_plugin_context(
       config_profile: None,
     },
     CodexControlPlane {
+      approvals_reviewer: overrides
+        .approvals_reviewer
+        .map(|value| value.as_str().to_string()),
       collaboration_mode: session.collaboration_mode.clone(),
       multi_agent: session.multi_agent,
       personality: session.personality.clone(),

--- a/orbitdock-server/crates/server/src/transport/http/control_deck.rs
+++ b/orbitdock-server/crates/server/src/transport/http/control_deck.rs
@@ -1,0 +1,286 @@
+use std::sync::Arc;
+
+use axum::{
+  body::Bytes,
+  extract::{Path, Query, State},
+  http::{header::CONTENT_TYPE, HeaderMap, StatusCode},
+  Json,
+};
+use orbitdock_protocol::{
+  ControlDeckConfigUpdate, ControlDeckImageAttachmentRef, ControlDeckPreferences,
+  ControlDeckSnapshot, ControlDeckSubmitTurnRequest,
+};
+use serde::{Deserialize, Serialize};
+
+use super::{
+  errors::{bad_request, internal, not_found, service_unavailable},
+  ApiErrorResponse,
+};
+use crate::runtime::control_deck::{
+  load_control_deck_preferences, load_control_deck_snapshot as load_control_deck_snapshot_runtime,
+  submit_control_deck_turn as submit_control_deck_turn_runtime,
+  update_control_deck_config as update_control_deck_config_runtime,
+  update_control_deck_preferences as update_control_deck_preferences_runtime,
+  upload_control_deck_image_attachment as upload_control_deck_image_attachment_runtime,
+  ControlDeckAttachmentUploadError, ControlDeckConfigUpdateError,
+  ControlDeckPreferencesUpdateError, ControlDeckSnapshotLoadError, ControlDeckSubmitError,
+};
+use crate::runtime::session_registry::SessionRegistry;
+
+#[derive(Debug, Serialize)]
+pub struct ControlDeckSubmitResponse {
+  pub accepted: bool,
+  pub row: orbitdock_protocol::conversation_contracts::ConversationRowEntry,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ControlDeckImageAttachmentResponse {
+  pub attachment: ControlDeckImageAttachmentRef,
+}
+
+#[derive(Debug, Deserialize, Default)]
+pub struct UploadControlDeckImageAttachmentQuery {
+  #[serde(default)]
+  pub display_name: Option<String>,
+  #[serde(default)]
+  pub pixel_width: Option<u32>,
+  #[serde(default)]
+  pub pixel_height: Option<u32>,
+}
+
+pub async fn get_control_deck_snapshot(
+  Path(session_id): Path<String>,
+  State(state): State<Arc<SessionRegistry>>,
+) -> Result<Json<ControlDeckSnapshot>, (StatusCode, Json<ApiErrorResponse>)> {
+  load_control_deck_snapshot_runtime(&state, &session_id)
+    .await
+    .map(Json)
+    .map_err(|error| map_snapshot_load_error(error, &session_id))
+}
+
+pub async fn update_control_deck_config(
+  Path(session_id): Path<String>,
+  State(state): State<Arc<SessionRegistry>>,
+  Json(body): Json<ControlDeckConfigUpdate>,
+) -> Result<Json<ControlDeckSnapshot>, (StatusCode, Json<ApiErrorResponse>)> {
+  update_control_deck_config_runtime(&state, &session_id, body)
+    .await
+    .map(Json)
+    .map_err(|error| map_config_update_error(error, &session_id))
+}
+
+pub async fn get_control_deck_preferences() -> Json<ControlDeckPreferences> {
+  Json(load_control_deck_preferences())
+}
+
+pub async fn update_control_deck_preferences(
+  State(state): State<Arc<SessionRegistry>>,
+  Json(body): Json<ControlDeckPreferences>,
+) -> Result<Json<ControlDeckPreferences>, (StatusCode, Json<ApiErrorResponse>)> {
+  update_control_deck_preferences_runtime(&state, body)
+    .await
+    .map(Json)
+    .map_err(map_preferences_update_error)
+}
+
+pub async fn submit_control_deck_turn(
+  Path(session_id): Path<String>,
+  State(state): State<Arc<SessionRegistry>>,
+  Json(body): Json<ControlDeckSubmitTurnRequest>,
+) -> Result<(StatusCode, Json<ControlDeckSubmitResponse>), (StatusCode, Json<ApiErrorResponse>)> {
+  submit_control_deck_turn_runtime(&state, &session_id, body)
+    .await
+    .map(|result| {
+      (
+        StatusCode::ACCEPTED,
+        Json(ControlDeckSubmitResponse {
+          accepted: true,
+          row: result.row,
+        }),
+      )
+    })
+    .map_err(|error| map_submit_error(error, &session_id))
+}
+
+pub async fn upload_control_deck_image_attachment(
+  Path(session_id): Path<String>,
+  State(state): State<Arc<SessionRegistry>>,
+  Query(query): Query<UploadControlDeckImageAttachmentQuery>,
+  headers: HeaderMap,
+  body: Bytes,
+) -> Result<Json<ControlDeckImageAttachmentResponse>, (StatusCode, Json<ApiErrorResponse>)> {
+  if body.is_empty() {
+    return Err(bad_request(
+      "invalid_request",
+      "Provide image bytes in the request body".to_string(),
+    ));
+  }
+
+  let mime_type = headers
+    .get(CONTENT_TYPE)
+    .and_then(|value| value.to_str().ok())
+    .map(str::trim)
+    .filter(|value| !value.is_empty())
+    .ok_or_else(|| {
+      bad_request(
+        "invalid_request",
+        "Set the image MIME type in the Content-Type header".to_string(),
+      )
+    })?;
+
+  upload_control_deck_image_attachment_runtime(
+    &state,
+    &session_id,
+    body.as_ref(),
+    mime_type,
+    query.display_name.as_deref(),
+    query.pixel_width,
+    query.pixel_height,
+  )
+  .map(|image| {
+    Json(ControlDeckImageAttachmentResponse {
+      attachment: ControlDeckImageAttachmentRef {
+        attachment_id: image.value,
+        display_name: image.display_name,
+      },
+    })
+  })
+  .map_err(|error| map_attachment_upload_error(error, &session_id))
+}
+
+fn map_snapshot_load_error(
+  error: ControlDeckSnapshotLoadError,
+  session_id: &str,
+) -> (StatusCode, Json<ApiErrorResponse>) {
+  match error {
+    ControlDeckSnapshotLoadError::NotFound => {
+      not_found("not_found", format!("Session {} not found", session_id))
+    }
+    ControlDeckSnapshotLoadError::Db(err) => internal("db_error", err),
+    ControlDeckSnapshotLoadError::Runtime(err) => service_unavailable("runtime_error", err),
+  }
+}
+
+fn map_preferences_update_error(
+  error: ControlDeckPreferencesUpdateError,
+) -> (StatusCode, Json<ApiErrorResponse>) {
+  match error {
+    ControlDeckPreferencesUpdateError::Serialization(err) => internal("serialization_failed", err),
+    ControlDeckPreferencesUpdateError::Persistence(err) => internal("persistence_failed", err),
+  }
+}
+
+fn map_config_update_error(
+  error: ControlDeckConfigUpdateError,
+  session_id: &str,
+) -> (StatusCode, Json<ApiErrorResponse>) {
+  match error {
+    ControlDeckConfigUpdateError::NotFound => {
+      not_found("not_found", format!("Session {} not found", session_id))
+    }
+    ControlDeckConfigUpdateError::InvalidConfig(message) => bad_request("invalid_request", message),
+    ControlDeckConfigUpdateError::Db(message) => internal("db_error", message),
+    ControlDeckConfigUpdateError::Runtime(message) => service_unavailable("runtime_error", message),
+  }
+}
+
+fn map_submit_error(
+  error: ControlDeckSubmitError,
+  session_id: &str,
+) -> (StatusCode, Json<ApiErrorResponse>) {
+  match error {
+    ControlDeckSubmitError::InvalidRequest(message) => bad_request("invalid_request", message),
+    ControlDeckSubmitError::SessionNotFound => {
+      not_found("not_found", format!("Session {} not found", session_id))
+    }
+    ControlDeckSubmitError::ConnectorUnavailable => service_unavailable(
+      "connector_unavailable",
+      format!(
+        "Session {} is direct but has no active connector attached",
+        session_id
+      ),
+    ),
+  }
+}
+
+fn map_attachment_upload_error(
+  error: ControlDeckAttachmentUploadError,
+  session_id: &str,
+) -> (StatusCode, Json<ApiErrorResponse>) {
+  match error {
+    ControlDeckAttachmentUploadError::SessionNotFound => {
+      not_found("not_found", format!("Session {} not found", session_id))
+    }
+    ControlDeckAttachmentUploadError::Storage(err) => internal("attachment_store_failed", err),
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  use axum::body::Bytes;
+  use axum::extract::{Path, Query, State};
+  use axum::http::{header::CONTENT_TYPE, HeaderMap, HeaderValue, StatusCode};
+  use orbitdock_protocol::Provider;
+
+  use crate::domain::sessions::session::SessionHandle;
+  use crate::support::test_support::new_test_session_registry;
+
+  #[tokio::test]
+  async fn uploads_control_deck_image_attachments_into_deck_owned_refs() {
+    let _guard = crate::support::test_support::test_env_lock().lock().await;
+    let state = new_test_session_registry(true);
+    state.add_session(SessionHandle::new(
+      "session-1".to_string(),
+      Provider::Codex,
+      "/repo".to_string(),
+    ));
+
+    let mut headers = HeaderMap::new();
+    headers.insert(CONTENT_TYPE, HeaderValue::from_static("image/png"));
+
+    let Json(response) = upload_control_deck_image_attachment(
+      Path("session-1".to_string()),
+      State(state),
+      Query(UploadControlDeckImageAttachmentQuery {
+        display_name: Some("mock.png".to_string()),
+        pixel_width: Some(320),
+        pixel_height: Some(200),
+      }),
+      headers,
+      Bytes::from_static(b"fake-image-bytes"),
+    )
+    .await
+    .expect("deck attachment upload should succeed");
+
+    assert!(response
+      .attachment
+      .attachment_id
+      .starts_with("orbitdock-image-"));
+    assert_eq!(
+      response.attachment.display_name.as_deref(),
+      Some("mock.png")
+    );
+  }
+
+  #[tokio::test]
+  async fn rejects_missing_session_for_control_deck_attachment_upload() {
+    let _guard = crate::support::test_support::test_env_lock().lock().await;
+    let state = new_test_session_registry(true);
+    let mut headers = HeaderMap::new();
+    headers.insert(CONTENT_TYPE, HeaderValue::from_static("image/png"));
+
+    let err = upload_control_deck_image_attachment(
+      Path("missing-session".to_string()),
+      State(state),
+      Query(UploadControlDeckImageAttachmentQuery::default()),
+      headers,
+      Bytes::from_static(b"fake-image-bytes"),
+    )
+    .await
+    .expect_err("missing session should be rejected");
+
+    assert_eq!(err.0, StatusCode::NOT_FOUND);
+  }
+}

--- a/orbitdock-server/crates/server/src/transport/http/mod.rs
+++ b/orbitdock-server/crates/server/src/transport/http/mod.rs
@@ -54,6 +54,11 @@ pub use codex_auth::{codex_login_cancel, codex_login_start, codex_logout, read_c
 pub(crate) use connector_actions::{
   dispatch_error_response, messaging_dispatch_error_response, session_not_found_error,
 };
+pub use control_deck::{
+  get_control_deck_preferences, get_control_deck_snapshot, submit_control_deck_turn,
+  update_control_deck_config, update_control_deck_preferences,
+  upload_control_deck_image_attachment,
+};
 pub(crate) use errors::{revision_now, ApiErrorResponse, ApiResult};
 pub use files::{
   browse_directory, git_init_endpoint, list_recent_projects, list_subagent_messages_endpoint,

--- a/orbitdock-server/crates/server/src/transport/http/router.rs
+++ b/orbitdock-server/crates/server/src/transport/http/router.rs
@@ -43,6 +43,10 @@ fn session_read_routes() -> Router<Arc<SessionRegistry>> {
       get(super::get_session_composer),
     )
     .route(
+      "/api/sessions/{session_id}/control-deck",
+      get(super::get_control_deck_snapshot).patch(super::update_control_deck_config),
+    )
+    .route(
       "/api/sessions/{session_id}/conversation",
       get(super::get_conversation_snapshot),
     )

--- a/orbitdock-server/crates/server/src/transport/http/session_lifecycle.rs
+++ b/orbitdock-server/crates/server/src/transport/http/session_lifecycle.rs
@@ -167,6 +167,7 @@ pub async fn update_session_config(
       approval_policy: body.approval_policy,
       approval_policy_details: body.approval_policy_details,
       sandbox_mode: body.sandbox_mode,
+      approvals_reviewer: None,
       permission_mode: body.permission_mode,
       collaboration_mode: body.collaboration_mode,
       multi_agent: body.multi_agent,
@@ -285,6 +286,7 @@ fn create_codex_selection(
     }),
     approval_policy_details: body.approval_policy_details.clone(),
     sandbox_mode: body.sandbox_mode.clone(),
+    approvals_reviewer: None,
     collaboration_mode: body.collaboration_mode.clone(),
     multi_agent: body.multi_agent,
     personality: body.personality.clone(),
@@ -597,7 +599,7 @@ pub struct UpdateCodexPreferencesRequest {
 
 #[derive(Debug, Deserialize)]
 pub struct CodexConfigCatalogQuery {
-  pub cwd: String,
+  pub cwd: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -656,6 +658,7 @@ pub async fn inspect_codex_config(
         }),
         approval_policy_details: body.approval_policy_details,
         sandbox_mode: body.sandbox_mode,
+        approvals_reviewer: None,
         collaboration_mode: body.collaboration_mode,
         multi_agent: body.multi_agent,
         personality: body.personality,
@@ -673,7 +676,7 @@ pub async fn inspect_codex_config(
 pub async fn get_codex_config_catalog(
   Query(query): Query<CodexConfigCatalogQuery>,
 ) -> Result<Json<CodexConfigCatalogResponse>, (StatusCode, Json<ApiErrorResponse>)> {
-  let response = codex_config_catalog(&query.cwd)
+  let response = codex_config_catalog(query.cwd.as_deref())
     .await
     .map_err(|error| unprocessable("invalid_codex_config", error))?;
   Ok(Json(response))

--- a/orbitdock-server/crates/server/src/transport/websocket/handlers/session_crud.rs
+++ b/orbitdock-server/crates/server/src/transport/websocket/handlers/session_crud.rs
@@ -44,6 +44,7 @@ pub(crate) async fn handle(
           approval_policy: Some(approval_policy),
           approval_policy_details: Some(approval_policy_details),
           sandbox_mode: Some(sandbox_mode),
+          approvals_reviewer: None,
           permission_mode: Some(permission_mode),
           collaboration_mode: Some(collaboration_mode),
           multi_agent: Some(multi_agent),


### PR DESCRIPTION
## Summary
- redesign the native control deck UI and approval flows
- carry richer Codex session control and approval-reviewer config through the server
- wire the updated control deck endpoints and snapshot mapping across the stack

## Notes
- cherry-picked from the control-deck-api cleanup branch
