### PR TITLE
♻️ Clean up runtime housekeeping and approval plumbing

### DIFF
--- a/OrbitDockNative/OrbitDock/Services/DemoModeExperience.swift
+++ b/OrbitDockNative/OrbitDock/Services/DemoModeExperience.swift
@@ -1025,4 +1025,3 @@ struct DemoModeExperience {
     return formatter.string(from: date)
   }
 }
-

--- a/orbitdock-server/crates/cli/src/cli.rs
+++ b/orbitdock-server/crates/cli/src/cli.rs
@@ -1321,7 +1321,7 @@ mod tests {
     orbitdock_server::init_data_dir(Some(&tmp));
 
     let config = ClientConfig::from_sources(None, None, true, None);
-    let command = BinaryCommand::GenerateToken;
+    let command = BinaryCommand::Status;
 
     let result = dispatch_binary(&command, &config).await;
     assert!(result.is_none());

--- a/orbitdock-server/crates/connector-claude/src/lib.rs
+++ b/orbitdock-server/crates/connector-claude/src/lib.rs
@@ -5,9 +5,10 @@
 
 pub mod session;
 
-use std::collections::HashMap;
+use std::collections::{HashMap, VecDeque};
 use std::process::Stdio;
 use std::sync::Arc;
+use std::time::Instant;
 
 use base64::engine::general_purpose::STANDARD;
 use base64::Engine;
@@ -16,7 +17,7 @@ use serde_json::Value;
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::process::Child;
 use tokio::sync::{mpsc, oneshot, Mutex};
-use tracing::{debug, error, info, warn};
+use tracing::{error, info, warn};
 
 use orbitdock_connector_core::{ApprovalType, ConnectorError, ConnectorEvent};
 use orbitdock_protocol::conversation_contracts::render_hints::RenderHints;
@@ -585,8 +586,9 @@ struct ClaudeEventLoopState {
   // -- Mutable local state (owned by the event loop task) --
   streaming_content: String,
   streaming_msg_id: Option<String>,
+  streaming_last_broadcast: Option<Instant>,
   in_turn: bool,
-  turn_patch_diffs: Vec<String>,
+  turn_patch_diff: String,
   /// Per-call (input_tokens, cached_tokens) from the latest assistant message.
   last_turn_input: Option<(u64, u64)>,
   cumulative_output: u64,
@@ -615,8 +617,9 @@ impl ClaudeEventLoopState {
       stdin_tx,
       streaming_content: String::new(),
       streaming_msg_id: None,
+      streaming_last_broadcast: None,
       in_turn: false,
-      turn_patch_diffs: Vec::new(),
+      turn_patch_diff: String::new(),
       last_turn_input: None,
       cumulative_output: 0,
       last_context_window: 1_000_000,
@@ -637,6 +640,9 @@ pub struct ClaudeConnector {
   pending_controls: Arc<Mutex<HashMap<String, oneshot::Sender<Value>>>>,
   pending_approvals: Arc<Mutex<HashMap<String, PendingApproval>>>,
 }
+
+const CLAUDE_STREAM_THROTTLE_MS: u128 = 50;
+const CLAUDE_STDERR_TAIL_LINES: usize = 5;
 
 impl ClaudeConnector {
   /// Spawn a new `claude` CLI subprocess.
@@ -766,7 +772,7 @@ impl ClaudeConnector {
       tokio::spawn(async move {
         let reader = BufReader::new(stderr);
         let mut lines = reader.lines();
-        let mut stderr_lines = Vec::new();
+        let mut stderr_lines = VecDeque::with_capacity(CLAUDE_STDERR_TAIL_LINES);
         while let Ok(Some(line)) = lines.next_line().await {
           warn!(
               component = "claude_connector",
@@ -774,7 +780,10 @@ impl ClaudeConnector {
               line = %line,
               "Claude CLI stderr"
           );
-          stderr_lines.push(line);
+          if stderr_lines.len() == CLAUDE_STDERR_TAIL_LINES {
+            stderr_lines.pop_front();
+          }
+          stderr_lines.push_back(line);
         }
         // stderr closed — process is exiting, capture exit code
         let exit_status = child_for_exit.lock().await.wait().await;
@@ -786,9 +795,16 @@ impl ClaudeConnector {
                   component = "claude_connector",
                   event = "claude.exit",
                   exit_code = ?code,
-                  stderr_tail = %stderr_lines.iter().rev().take(5)
-                      .collect::<Vec<_>>().into_iter().rev()
-                      .cloned().collect::<Vec<_>>().join("\n"),
+                  stderr_tail = %stderr_lines
+                      .iter()
+                      .rev()
+                      .take(CLAUDE_STDERR_TAIL_LINES)
+                      .collect::<Vec<_>>()
+                      .into_iter()
+                      .rev()
+                      .map(|line| line.as_str())
+                      .collect::<Vec<_>>()
+                      .join("\n"),
                   "Claude CLI exited with non-zero status"
               );
             } else {
@@ -840,13 +856,7 @@ impl ClaudeConnector {
 
     // Send initialize control request — kill the child if it fails
     match connector.send_initialize().await {
-      Ok(_init_response) => {
-        debug!(
-          component = "claude_connector",
-          event = "claude.init.response",
-          "Initialize response received"
-        );
-      }
+      Ok(_init_response) => {}
       Err(e) => {
         error!(
             component = "claude_connector",
@@ -1252,13 +1262,6 @@ impl ClaudeConnector {
   async fn write_stdin_message(&self, msg: &StdinMessage) -> Result<(), ConnectorError> {
     let json = serde_json::to_string(msg).map_err(ConnectorError::JsonError)?;
 
-    debug!(
-      component = "claude_connector",
-      event = "claude.stdin.write",
-      payload_len = json.len(),
-      "Writing to CLI stdin"
-    );
-
     self
       .stdin_tx
       .send(json)
@@ -1289,11 +1292,6 @@ impl ClaudeConnector {
         break;
       }
     }
-    debug!(
-      component = "claude_connector",
-      event = "claude.stdin.closed",
-      "Stdin writer task ended"
-    );
   }
 
   /// Read stdout line-by-line, parse JSON, translate to ConnectorEvent.
@@ -1314,17 +1312,6 @@ impl ClaudeConnector {
             continue;
           }
 
-          // Log first few lines and any non-JSON for debugging startup issues
-          if state.line_count <= 3 {
-            info!(
-                component = "claude_connector",
-                event = "claude.stdout.raw",
-                line_num = state.line_count,
-                preview = %if line.len() > 300 { &line[..300] } else { &line },
-                "Raw stdout line"
-            );
-          }
-
           let raw: Value = match serde_json::from_str(&line) {
             Ok(v) => v,
             Err(e) => {
@@ -1343,11 +1330,6 @@ impl ClaudeConnector {
 
           for ev in events {
             if event_tx.send(ev).await.is_err() {
-              info!(
-                component = "claude_connector",
-                event = "claude.event_loop.channel_closed",
-                "Event channel closed, stopping reader"
-              );
               return;
             }
           }
@@ -1397,15 +1379,6 @@ impl ClaudeConnector {
       .and_then(|v| v.as_bool())
       .unwrap_or(false);
 
-    debug!(
-        component = "claude_connector",
-        event = "claude.stdout.dispatch",
-        msg_type = %msg_type,
-        session_id = %session_id,
-        is_replay = is_replay,
-        "Dispatching stdout message"
-    );
-
     // Skip replayed messages from --resume. Only allow `system` through
     // (contains init with session_id, hook_started for thread registration).
     if is_replay && msg_type != "system" {
@@ -1416,7 +1389,7 @@ impl ClaudeConnector {
     let mut turn_start_event = Vec::new();
     if !state.in_turn && matches!(msg_type, "assistant" | "stream_event") {
       state.in_turn = true;
-      state.turn_patch_diffs.clear();
+      state.turn_patch_diff.clear();
       turn_start_event.push(ConnectorEvent::TurnStarted);
     }
 
@@ -1433,7 +1406,7 @@ impl ClaudeConnector {
 
       "result" => {
         state.in_turn = false;
-        state.turn_patch_diffs.clear();
+        state.turn_patch_diff.clear();
         Self::handle_result_message(raw, &session_id, state)
       }
 
@@ -1446,12 +1419,6 @@ impl ClaudeConnector {
         // notify the server so the approval card is cleared.
         if let Some(req_id) = string_field(raw, "request_id", "requestId") {
           state.pending_approvals.lock().await.remove(req_id.as_str());
-          info!(
-              component = "claude_connector",
-              event = "claude.control.cancelled",
-              request_id = %req_id,
-              "CLI cancelled control request"
-          );
           vec![ConnectorEvent::ApprovalCancelled { request_id: req_id }]
         } else {
           vec![]
@@ -1472,12 +1439,6 @@ impl ClaudeConnector {
           .or_else(|| raw.get("permissionMode"))
           .and_then(Value::as_str)
         {
-          info!(
-              component = "claude_connector",
-              event = "claude.permission_mode.changed",
-              mode = %mode,
-              "Permission mode changed via status message"
-          );
           status_events.push(ConnectorEvent::PermissionModeChanged {
             mode: mode.to_string(),
           });
@@ -1536,15 +1497,6 @@ impl ClaudeConnector {
           .get("surpassed_threshold")
           .and_then(|v| v.as_f64());
 
-        info!(
-            component = "claude_connector",
-            event = "claude.rate_limit",
-            status = %status,
-            utilization = ?utilization,
-            rate_limit_type = ?rate_limit_type,
-            "Rate limit event received"
-        );
-
         vec![ConnectorEvent::RateLimitEvent {
           info: orbitdock_protocol::RateLimitInfo {
             status,
@@ -1566,19 +1518,8 @@ impl ClaudeConnector {
           .to_string();
 
         if suggestion.is_empty() {
-          debug!(
-            component = "claude_connector",
-            event = "claude.prompt_suggestion.empty",
-            "Prompt suggestion received with empty content"
-          );
           vec![]
         } else {
-          debug!(
-            component = "claude_connector",
-            event = "claude.prompt_suggestion",
-            suggestion_len = suggestion.len(),
-            "Prompt suggestion received"
-          );
           vec![ConnectorEvent::PromptSuggestion { suggestion }]
         }
       }
@@ -1586,7 +1527,7 @@ impl ClaudeConnector {
       "keep_alive" | "auth_status" => vec![],
 
       _ => {
-        debug!(
+        warn!(
             component = "claude_connector",
             event = "claude.stdout.unknown_type",
             msg_type = %msg_type,
@@ -1597,24 +1538,12 @@ impl ClaudeConnector {
     };
 
     // Prepend TurnStarted so it fires before any message events
-    let final_events = if !turn_start_event.is_empty() {
+    if !turn_start_event.is_empty() {
       turn_start_event.append(&mut events);
       turn_start_event
     } else {
       events
-    };
-
-    if !final_events.is_empty() && msg_type != "stream_event" {
-      debug!(
-          component = "claude_connector",
-          event = "claude.stdout.dispatch_result",
-          msg_type = %msg_type,
-          event_count = final_events.len(),
-          "Produced connector events"
-      );
     }
-
-    final_events
   }
 
   /// Handle `system` messages (init, compact_boundary, status).
@@ -1756,12 +1685,6 @@ impl ClaudeConnector {
         // the original. Without registering it, the hook handler creates a
         // duplicate passive session.
         if let Some(sid) = raw.get("session_id").and_then(|v| v.as_str()) {
-          info!(
-              component = "claude_connector",
-              event = "claude.hook_started",
-              hook_session_id = %sid,
-              "Hook started with session ID"
-          );
           vec![ConnectorEvent::HookSessionId(sid.to_string())]
         } else {
           vec![]
@@ -1783,15 +1706,6 @@ impl ClaudeConnector {
         if let Some(tool_use_id) = raw.get("tool_use_id").and_then(Value::as_str) {
           task_tool_use_map.insert(tool_use_id.to_string(), task_id.to_string());
         }
-
-        info!(
-            component = "claude_connector",
-            event = "claude.task_started",
-            task_id = %task_id,
-            task_type = %task_type,
-            tool_use_id = ?raw.get("tool_use_id").and_then(|v| v.as_str()),
-            "Background task started"
-        );
 
         let raw_input = Some(serde_json::json!({
             "subagent_type": task_type,
@@ -1866,14 +1780,6 @@ impl ClaudeConnector {
         let summary = raw.get("summary").and_then(Value::as_str).unwrap_or("");
         let duration_ms = raw.pointer("/usage/duration_ms").and_then(Value::as_u64);
 
-        info!(
-            component = "claude_connector",
-            event = "claude.task_notification",
-            task_id = %task_id,
-            status = %status_str,
-            "Background task completed"
-        );
-
         let session_id = session_id_slot.lock().await.clone().unwrap_or_default();
         if let Some(mut tr) = tool_rows.remove(task_id) {
           tr.status = if status_str == "failed" {
@@ -1907,12 +1813,6 @@ impl ClaudeConnector {
           .or_else(|| raw.get("permission_mode"))
           .and_then(Value::as_str)
         {
-          info!(
-              component = "claude_connector",
-              event = "claude.permission_mode.changed",
-              mode = %mode,
-              "Permission mode changed via system status message"
-          );
           events.push(ConnectorEvent::PermissionModeChanged {
             mode: mode.to_string(),
           });
@@ -1926,13 +1826,6 @@ impl ClaudeConnector {
             let session_id = session_id_slot.lock().await.clone().unwrap_or_default();
             let msg_id = format!("compacting-{}", uuid::Uuid::new_v4());
             *compacting_msg_id = Some(msg_id.clone());
-
-            info!(
-                component = "claude_connector",
-                event = "claude.status.compacting",
-                msg_id = %msg_id,
-                "Context compaction in progress — showing indicator"
-            );
 
             let tr = make_tool_row(
               msg_id.clone(),
@@ -1952,42 +1845,7 @@ impl ClaudeConnector {
 
         events
       }
-      "hook_progress" => {
-        let hook_name = raw
-          .get("hook_name")
-          .and_then(|v| v.as_str())
-          .unwrap_or("unknown");
-        let hook_event = raw
-          .get("hook_event")
-          .and_then(|v| v.as_str())
-          .unwrap_or("unknown");
-        debug!(
-            component = "claude_connector",
-            event = "claude.hook_progress",
-            hook_name = %hook_name,
-            hook_event = %hook_event,
-            "Hook progress event"
-        );
-        vec![]
-      }
-      "hook_response" => {
-        let hook_name = raw
-          .get("hook_name")
-          .and_then(|v| v.as_str())
-          .unwrap_or("unknown");
-        let outcome = raw
-          .get("outcome")
-          .and_then(|v| v.as_str())
-          .unwrap_or("unknown");
-        info!(
-            component = "claude_connector",
-            event = "claude.hook_response",
-            hook_name = %hook_name,
-            outcome = %outcome,
-            "Hook response event"
-        );
-        vec![]
-      }
+      "hook_progress" | "hook_response" => vec![],
       "files_persisted" => {
         let files: Vec<String> = raw
           .get("files")
@@ -1999,23 +1857,9 @@ impl ClaudeConnector {
               .collect()
           })
           .unwrap_or_default();
-        debug!(
-          component = "claude_connector",
-          event = "claude.files_persisted",
-          file_count = files.len(),
-          "Files persisted checkpoint"
-        );
         vec![ConnectorEvent::FilesPersisted { files }]
       }
-      _ => {
-        debug!(
-            component = "claude_connector",
-            event = "claude.system.unknown_subtype",
-            subtype = %subtype,
-            "Unknown system message subtype"
-        );
-        vec![]
-      }
+      _ => vec![],
     }
   }
 
@@ -2037,45 +1881,19 @@ impl ClaudeConnector {
       &mut events,
       &mut state.streaming_content,
       &mut state.streaming_msg_id,
+      &mut state.streaming_last_broadcast,
       session_id,
     );
 
     let message = match raw.get("message") {
       Some(m) => m,
-      None => {
-        debug!(
-          component = "claude_connector",
-          event = "claude.assistant.no_message_field",
-          "Assistant message missing 'message' field"
-        );
-        return events;
-      }
+      None => return events,
     };
 
     let content_blocks = match message.get("content").and_then(|v| v.as_array()) {
       Some(arr) => arr,
-      None => {
-        debug!(
-          component = "claude_connector",
-          event = "claude.assistant.no_content_blocks",
-          "Assistant message missing 'content' array"
-        );
-        return events;
-      }
+      None => return events,
     };
-
-    let block_types: Vec<&str> = content_blocks
-      .iter()
-      .map(|b| b.get("type").and_then(|v| v.as_str()).unwrap_or("?"))
-      .collect();
-    debug!(
-        component = "claude_connector",
-        event = "claude.assistant.content_blocks",
-        block_count = content_blocks.len(),
-        block_types = ?block_types,
-        had_streaming = had_streaming,
-        "Processing assistant content blocks"
-    );
 
     for block in content_blocks {
       let block_type = block.get("type").and_then(|v| v.as_str()).unwrap_or("");
@@ -2128,10 +1946,11 @@ impl ClaudeConnector {
           // Build an aggregated per-turn patch diff stream from direct edit/write tools.
           if let Some(payload) = input_value {
             if let Some(diff) = Self::patch_diff_for_tool_use(Some(tool_name), payload) {
-              state.turn_patch_diffs.push(diff);
-              events.push(ConnectorEvent::DiffUpdated(
-                state.turn_patch_diffs.join("\n\n"),
-              ));
+              if !state.turn_patch_diff.is_empty() {
+                state.turn_patch_diff.push_str("\n\n");
+              }
+              state.turn_patch_diff.push_str(&diff);
+              events.push(ConnectorEvent::DiffUpdated(state.turn_patch_diff.clone()));
             }
           }
         }
@@ -2242,15 +2061,6 @@ impl ClaudeConnector {
         .map(String::from)
         .unwrap_or_else(|| format!("claude-user-{}", uuid::Uuid::new_v4()));
 
-      info!(
-          component = "claude_connector",
-          event = "claude.user_message.row_created",
-          session_id = %session_id,
-          text_len = user_text.len(),
-          image_count = images.len(),
-          "Creating User conversation row"
-      );
-
       events.push(ConnectorEvent::ConversationRowCreated(make_entry(
         session_id,
         ConversationRow::User(MessageRowContent {
@@ -2274,14 +2084,6 @@ impl ClaudeConnector {
     if !has_tool_results {
       return events;
     }
-
-    info!(
-        component = "claude_connector",
-        event = "claude.user_message.has_tool_results",
-        session_id = %session_id,
-        block_count = content_blocks.len(),
-        "Processing user message with tool_result blocks"
-    );
 
     for block in content_blocks {
       let block_type = block.get("type").and_then(|v| v.as_str()).unwrap_or("");
@@ -2319,17 +2121,6 @@ impl ClaudeConnector {
 
       if let Some(tool_use_id) = block.get("tool_use_id").and_then(|v| v.as_str()) {
         let task_id = task_tool_use_map.remove(tool_use_id);
-
-        info!(
-            component = "claude_connector",
-            event = "claude.tool_result.extracted",
-            session_id = %session_id,
-            tool_use_id = %tool_use_id,
-            task_id = ?task_id,
-            output_chars = content.len(),
-            is_error = is_error,
-            "Extracted tool result → ConversationRowUpdated"
-        );
 
         // Determine the row_id: either the task_id (for background tasks)
         // or the tool_use_id (for regular tools).
@@ -2436,6 +2227,7 @@ impl ClaudeConnector {
   ) -> Vec<ConnectorEvent> {
     let streaming_content = &mut state.streaming_content;
     let streaming_msg_id = &mut state.streaming_msg_id;
+    let streaming_last_broadcast = &mut state.streaming_last_broadcast;
     let mut events = Vec::new();
 
     let event = match raw.get("event") {
@@ -2476,7 +2268,15 @@ impl ClaudeConnector {
               session_id, row,
             )));
             *streaming_msg_id = Some(msg_id);
+            *streaming_last_broadcast = Some(Instant::now());
           } else {
+            let now = Instant::now();
+            if streaming_last_broadcast
+              .is_some_and(|last| now.duration_since(last).as_millis() < CLAUDE_STREAM_THROTTLE_MS)
+            {
+              return events;
+            }
+            *streaming_last_broadcast = Some(now);
             let msg_id = streaming_msg_id.clone().unwrap();
             let row = ConversationRow::Assistant(MessageRowContent {
               id: msg_id.clone(),
@@ -2545,6 +2345,7 @@ impl ClaudeConnector {
       &mut events,
       &mut state.streaming_content,
       &mut state.streaming_msg_id,
+      &mut state.streaming_last_broadcast,
       session_id,
     );
 
@@ -2625,14 +2426,6 @@ impl ClaudeConnector {
       "hook_callback" => {
         // CLI is invoking a registered hook callback.
         // We don't currently register any hooks, so respond with an empty result.
-        let callback_id = string_field(request, "callback_id", "callbackId").unwrap_or_default();
-        info!(
-            component = "claude_connector",
-            event = "claude.control_request.hook_callback",
-            request_id = %request_id,
-            callback_id = %callback_id,
-            "Received hook_callback control request"
-        );
         let response = StdinMessage::ControlResponse {
           response: ControlResponsePayload::Success {
             request_id,
@@ -2650,13 +2443,6 @@ impl ClaudeConnector {
         // CLI is sending a JSON-RPC message for an SDK-hosted MCP server.
         // We don't currently host any MCP servers, so respond with an error.
         let server_name = string_field(request, "server_name", "serverName").unwrap_or_default();
-        info!(
-            component = "claude_connector",
-            event = "claude.control_request.mcp_message",
-            request_id = %request_id,
-            server_name = %server_name,
-            "Received mcp_message control request"
-        );
         let response = StdinMessage::ControlResponse {
           response: ControlResponsePayload::Error {
             request_id,
@@ -2671,14 +2457,7 @@ impl ClaudeConnector {
       "can_use_tool" => {
         // Permission prompt — handled below
       }
-      other => {
-        debug!(
-            component = "claude_connector",
-            event = "claude.control_request.unhandled",
-            subtype = %other,
-            request_id = %request_id,
-            "Unhandled CLI control request subtype"
-        );
+      _other => {
         return vec![];
       }
     }
@@ -2692,7 +2471,7 @@ impl ClaudeConnector {
       value_field(request, "permission_suggestions", "permissionSuggestions")
         .cloned()
         .or_else(|| value_field(raw, "permission_suggestions", "permissionSuggestions").cloned());
-    let has_permission_suggestions = permission_suggestions.is_some();
+    let _has_permission_suggestions = permission_suggestions.is_some();
 
     if request_id.is_empty() {
       warn!(
@@ -2764,17 +2543,6 @@ impl ClaudeConnector {
     } else {
       None
     };
-
-    debug!(
-        component = "claude_connector",
-        event = "claude.approval_requested",
-        request_id = %request_id,
-        tool_name = ?tool_name,
-        tool_use_id = ?tool_use_id,
-        approval_type = ?approval_type,
-        has_permission_suggestions,
-        "CLI requesting tool approval"
-    );
 
     let tool_input_json = input.as_ref().and_then(|i| serde_json::to_string(i).ok());
     let mut events = Vec::new();
@@ -2957,9 +2725,11 @@ fn flush_streaming(
   events: &mut Vec<ConnectorEvent>,
   streaming_content: &mut String,
   streaming_msg_id: &mut Option<String>,
+  streaming_last_broadcast: &mut Option<Instant>,
   session_id: &str,
 ) {
   if let Some(mid) = streaming_msg_id.take() {
+    *streaming_last_broadcast = None;
     if !streaming_content.is_empty() {
       let row = ConversationRow::Assistant(MessageRowContent {
         id: mid.clone(),

--- a/orbitdock-server/crates/server/src/app/mod.rs
+++ b/orbitdock-server/crates/server/src/app/mod.rs
@@ -72,6 +72,7 @@ pub async fn run_server(options: ServerRunOptions) -> anyhow::Result<()> {
   crate::infrastructure::paths::ensure_dirs()?;
   crate::infrastructure::crypto::ensure_key();
   cleanup_stale_pid_file();
+  crate::infrastructure::housekeeping::run_housekeeping();
 
   let logging = init_logging(&options.logging)?;
   let run_id = logging.run_id.clone();

--- a/orbitdock-server/crates/server/src/domain/sessions/session.rs
+++ b/orbitdock-server/crates/server/src/domain/sessions/session.rs
@@ -22,7 +22,6 @@ pub use super::facets::{
 };
 use serde::Serialize;
 use tokio::sync::broadcast;
-use tracing::info;
 
 use orbitdock_protocol::ServerMessage;
 
@@ -1481,11 +1480,6 @@ impl SessionHandle {
     }
   }
 
-  /// Set started_at timestamp
-  pub fn set_started_at(&mut self, started_at: Option<String>) {
-    self.timestamps.started_at = started_at;
-  }
-
   /// Set last_activity_at timestamp
   pub fn set_last_activity_at(&mut self, last_activity_at: Option<String>) {
     self.timestamps.last_activity_at = last_activity_at;
@@ -1800,31 +1794,11 @@ impl SessionHandle {
         *existing = next_entry;
       }
       self.approval_version += 1;
-      info!(
-          component = "approval",
-          event = "approval.updated",
-          session_id = %self.identity.id,
-          request_id = %normalized_request_id,
-          approval_version = self.approval_version,
-          approval_type = ?self.pending_approvals[index].approval_type,
-          queue_depth = self.pending_approvals.len(),
-          "Approval request updated in place"
-      );
       return PendingApprovalMutation::Updated;
     }
 
     self.pending_approvals.push_back(next_entry);
     self.approval_version += 1;
-    info!(
-        component = "approval",
-        event = "approval.enqueued",
-        session_id = %self.identity.id,
-        request_id = %normalized_request_id,
-        approval_version = self.approval_version,
-        approval_type = ?self.pending_approvals.back().map(|entry| entry.approval_type).unwrap_or(approval_type),
-        queue_depth = self.pending_approvals.len(),
-        "Approval request enqueued"
-    );
     PendingApprovalMutation::Enqueued
   }
 
@@ -1839,16 +1813,6 @@ impl SessionHandle {
       self.pending_question = entry.request.question.clone();
       self.pending_approval_id = Some(entry.request.id.clone());
       self.work_status = Self::work_status_for_approval_type(entry.approval_type);
-      info!(
-          component = "approval",
-          event = "approval.promoted",
-          session_id = %self.identity.id,
-          request_id = %entry.request.id,
-          approval_version = self.approval_version,
-          approval_type = ?entry.approval_type,
-          queue_depth = self.pending_approvals.len(),
-          "Promoted next approval to active"
-      );
       return;
     }
 
@@ -1869,7 +1833,6 @@ impl SessionHandle {
 
   fn clear_pending_approvals(&mut self) {
     let had_approvals = !self.pending_approvals.is_empty() || self.pending_approval.is_some();
-    let cleared_count = self.pending_approvals.len();
     self.pending_approvals.clear();
     self.pending_approval = None;
     self.pending_tool_name = None;
@@ -1878,14 +1841,6 @@ impl SessionHandle {
     self.pending_approval_id = None;
     if had_approvals {
       self.approval_version += 1;
-      info!(
-          component = "approval",
-          event = "approval.cleared",
-          session_id = %self.identity.id,
-          approval_version = self.approval_version,
-          cleared_count,
-          "Cleared all pending approvals"
-      );
     }
   }
 
@@ -2016,16 +1971,6 @@ impl SessionHandle {
       let _ = self.pending_approvals.pop_front();
     }
     self.approval_version += 1;
-    info!(
-        component = "approval",
-        event = "approval.decided",
-        session_id = %self.identity.id,
-        request_id = %removed.request.id,
-        approval_version = self.approval_version,
-        approval_type = ?removed.approval_type,
-        queue_depth = self.pending_approvals.len(),
-        "Approval decided and removed from queue"
-    );
     self.promote_queue_front();
     if self.pending_approvals.is_empty() {
       self.work_status = fallback_work_status;

--- a/orbitdock-server/crates/server/src/infrastructure/housekeeping.rs
+++ b/orbitdock-server/crates/server/src/infrastructure/housekeeping.rs
@@ -1,0 +1,296 @@
+//! Housekeeping — prunes stale logs, temporary files, and unbounded DB tables.
+
+use std::path::Path;
+use std::time::{Duration, SystemTime};
+
+use rusqlite::{params, Connection};
+use tracing::{info, warn};
+
+/// Maximum age for rotated log files before they get deleted.
+const LOG_MAX_AGE: Duration = Duration::from_secs(7 * 24 * 60 * 60); // 7 days
+
+/// Maximum age for root-level `.log` files (cli.log, hooks.log, etc.)
+/// These are written by external processes and never rotated, so we truncate
+/// them when they exceed this age since last modification.
+const ROOT_LOG_MAX_AGE: Duration = Duration::from_secs(3 * 24 * 60 * 60); // 3 days
+
+/// Maximum size for root-level `.log` files before truncation (10 MB).
+const ROOT_LOG_MAX_BYTES: u64 = 10 * 1024 * 1024;
+
+/// Usage events older than this are pruned. The rolled-up `usage_session_state`
+/// table retains the summary — granular events are only useful short-term.
+const USAGE_EVENTS_MAX_AGE_DAYS: u32 = 30;
+
+/// Messages from ended sessions older than this are deleted. The session row
+/// itself is kept (for dashboard history) but the conversation payload is freed.
+const ENDED_SESSION_MESSAGE_MAX_AGE_DAYS: u32 = 60;
+
+/// Run all housekeeping tasks. Safe to call on every startup.
+pub fn run_housekeeping() {
+  let data_dir = crate::infrastructure::paths::data_dir();
+  let log_dir = crate::infrastructure::paths::log_dir();
+
+  prune_old_logs(&log_dir);
+  truncate_root_logs(&data_dir);
+  prune_usage_events();
+  prune_old_session_messages();
+  prune_orphaned_images();
+}
+
+/// Delete rotated log files in `logs/` older than `LOG_MAX_AGE`.
+fn prune_old_logs(log_dir: &Path) {
+  let entries = match std::fs::read_dir(log_dir) {
+    Ok(entries) => entries,
+    Err(_) => return,
+  };
+
+  let cutoff = SystemTime::now() - LOG_MAX_AGE;
+
+  for entry in entries.filter_map(Result::ok) {
+    let path = entry.path();
+    if !path.is_file() {
+      continue;
+    }
+
+    // Only prune rotated files (e.g. server.log.2026-03-21) — skip the
+    // active log which has no date suffix.
+    let file_name = path.file_name().and_then(|n| n.to_str()).unwrap_or("");
+    if file_name == "server.log" {
+      continue;
+    }
+
+    let modified = match entry.metadata().and_then(|m| m.modified()) {
+      Ok(t) => t,
+      Err(_) => continue,
+    };
+
+    if modified < cutoff {
+      let _ = std::fs::remove_file(&path);
+    }
+  }
+}
+
+/// Truncate root-level `.log` files that are too old or too large.
+/// These files (cli.log, hooks.log, codex-server.log, etc.) are written by
+/// external processes that don't rotate, so we cap them here.
+fn truncate_root_logs(data_dir: &Path) {
+  let entries = match std::fs::read_dir(data_dir) {
+    Ok(entries) => entries,
+    Err(_) => return,
+  };
+
+  let age_cutoff = SystemTime::now() - ROOT_LOG_MAX_AGE;
+
+  for entry in entries.filter_map(Result::ok) {
+    let path = entry.path();
+    if !path.is_file() {
+      continue;
+    }
+
+    let file_name = path.file_name().and_then(|n| n.to_str()).unwrap_or("");
+    if !file_name.ends_with(".log") {
+      continue;
+    }
+
+    let metadata = match entry.metadata() {
+      Ok(m) => m,
+      Err(_) => continue,
+    };
+
+    let modified = metadata.modified().unwrap_or(SystemTime::UNIX_EPOCH);
+    let too_old = modified < age_cutoff;
+    let too_large = metadata.len() > ROOT_LOG_MAX_BYTES;
+
+    if too_old || too_large {
+      if let Err(error) = std::fs::OpenOptions::new()
+        .write(true)
+        .truncate(true)
+        .open(&path)
+      {
+        warn!(
+          component = "housekeeping",
+          event = "housekeeping.root_log_truncate_error",
+          path = %path.display(),
+          error = %error,
+          "Failed to truncate root log file"
+        );
+      }
+    }
+  }
+}
+
+/// Delete usage_events older than `USAGE_EVENTS_MAX_AGE_DAYS`.
+fn prune_usage_events() {
+  let db_path = crate::infrastructure::paths::db_path();
+  if !db_path.exists() {
+    return;
+  }
+
+  let conn = match Connection::open(&db_path) {
+    Ok(c) => c,
+    Err(_) => return,
+  };
+  let _ = conn.execute_batch(
+    "PRAGMA journal_mode = WAL;
+     PRAGMA busy_timeout = 5000;",
+  );
+
+  let cutoff = format!("-{USAGE_EVENTS_MAX_AGE_DAYS} days");
+  match conn.execute(
+    "DELETE FROM usage_events WHERE observed_at < strftime('%Y-%m-%dT%H:%M:%fZ', 'now', ?1)",
+    params![cutoff],
+  ) {
+    Ok(deleted) if deleted > 0 => {
+      info!(
+        component = "housekeeping",
+        event = "housekeeping.usage_events_pruned",
+        deleted,
+        "Pruned old usage events"
+      );
+    }
+    _ => {}
+  }
+}
+
+/// Delete messages from ended sessions older than `ENDED_SESSION_MESSAGE_MAX_AGE_DAYS`.
+/// Keeps the session row for history/dashboard but frees the heavy conversation payload.
+fn prune_old_session_messages() {
+  let db_path = crate::infrastructure::paths::db_path();
+  if !db_path.exists() {
+    return;
+  }
+
+  let conn = match Connection::open(&db_path) {
+    Ok(c) => c,
+    Err(_) => return,
+  };
+  let _ = conn.execute_batch(
+    "PRAGMA journal_mode = WAL;
+     PRAGMA busy_timeout = 5000;",
+  );
+
+  let cutoff = format!("-{ENDED_SESSION_MESSAGE_MAX_AGE_DAYS} days");
+  match conn.execute(
+    "DELETE FROM messages WHERE session_id IN (
+       SELECT id FROM sessions
+       WHERE lifecycle_state = 'ended'
+         AND ended_at < strftime('%Y-%m-%dT%H:%M:%fZ', 'now', ?1)
+     )",
+    params![cutoff],
+  ) {
+    Ok(deleted) if deleted > 0 => {
+      info!(
+        component = "housekeeping",
+        event = "housekeeping.old_session_messages_pruned",
+        deleted,
+        "Pruned messages from ended sessions older than {ENDED_SESSION_MESSAGE_MAX_AGE_DAYS} days"
+      );
+    }
+    _ => {}
+  }
+}
+
+/// Remove image attachment directories for sessions whose messages have been pruned.
+fn prune_orphaned_images() {
+  let images_dir = crate::infrastructure::paths::images_dir();
+  let db_path = crate::infrastructure::paths::db_path();
+
+  if !images_dir.exists() || !db_path.exists() {
+    return;
+  }
+
+  let conn = match Connection::open(&db_path) {
+    Ok(c) => c,
+    Err(_) => return,
+  };
+  let _ = conn.execute_batch(
+    "PRAGMA journal_mode = WAL;
+     PRAGMA busy_timeout = 5000;",
+  );
+
+  let entries = match std::fs::read_dir(&images_dir) {
+    Ok(entries) => entries,
+    Err(_) => return,
+  };
+
+  let mut removed = 0u64;
+  for entry in entries.filter_map(Result::ok) {
+    let path = entry.path();
+    if !path.is_dir() {
+      continue;
+    }
+
+    let session_id = match path.file_name().and_then(|n| n.to_str()) {
+      Some(name) => name.to_string(),
+      None => continue,
+    };
+
+    // If no messages remain for this session, the images are orphaned.
+    let has_messages: bool = conn
+      .query_row(
+        "SELECT EXISTS(SELECT 1 FROM messages WHERE session_id = ?1 LIMIT 1)",
+        params![session_id],
+        |row| row.get(0),
+      )
+      .unwrap_or(true); // default to keeping on error
+
+    if !has_messages && std::fs::remove_dir_all(&path).is_ok() {
+      removed += 1;
+    }
+  }
+
+  if removed > 0 {
+    info!(
+      component = "housekeeping",
+      event = "housekeeping.orphaned_images_pruned",
+      removed,
+      "Removed orphaned image directories"
+    );
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use std::fs;
+
+  #[test]
+  fn prune_old_logs_preserves_active_log() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    let log_dir = tmp.path();
+
+    fs::write(log_dir.join("server.log"), "active").unwrap();
+    fs::write(log_dir.join("server.log.2026-03-27"), "recent").unwrap();
+
+    prune_old_logs(log_dir);
+
+    assert!(log_dir.join("server.log").exists());
+    assert!(log_dir.join("server.log.2026-03-27").exists());
+  }
+
+  #[test]
+  fn truncate_root_logs_caps_large_files() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    let data_dir = tmp.path();
+
+    // Small log — should survive
+    fs::write(data_dir.join("small.log"), "tiny").unwrap();
+
+    // Large log — should be truncated
+    let big_content = vec![b'x'; (ROOT_LOG_MAX_BYTES + 1) as usize];
+    fs::write(data_dir.join("big.log"), &big_content).unwrap();
+
+    // Non-log file — should be ignored
+    let big_non_log = vec![b'y'; (ROOT_LOG_MAX_BYTES + 1) as usize];
+    fs::write(data_dir.join("big.json"), &big_non_log).unwrap();
+
+    truncate_root_logs(data_dir);
+
+    assert_eq!(
+      fs::read_to_string(data_dir.join("small.log")).unwrap(),
+      "tiny"
+    );
+    assert_eq!(fs::metadata(data_dir.join("big.log")).unwrap().len(), 0);
+    assert!(fs::metadata(data_dir.join("big.json")).unwrap().len() > ROOT_LOG_MAX_BYTES);
+  }
+}

--- a/orbitdock-server/crates/server/src/infrastructure/logging.rs
+++ b/orbitdock-server/crates/server/src/infrastructure/logging.rs
@@ -1,3 +1,5 @@
+use std::io::Write;
+use std::sync::atomic::{AtomicU32, Ordering};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use chrono::{SecondsFormat, Utc};
@@ -7,6 +9,7 @@ use tokio::sync::mpsc;
 use tracing::field::{Field, Visit};
 use tracing::{Event, Subscriber};
 use tracing_appender::non_blocking::WorkerGuard;
+use tracing_appender::rolling::RollingFileAppender;
 use tracing_subscriber::fmt;
 use tracing_subscriber::layer::{Context, SubscriberExt};
 use tracing_subscriber::registry::LookupSpan;
@@ -23,6 +26,7 @@ const QUIET_TARGET_DIRECTIVES: &[(&str, &str)] = &[
   ("feedback_tags", "warn"),
   ("rmcp::transport::worker", "off"),
 ];
+const SECONDS_PER_DAY: u64 = 24 * 60 * 60;
 
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
 pub enum StderrLogMode {
@@ -59,18 +63,62 @@ pub struct LoggingHandle {
   pub _stderr_guard: Option<WorkerGuard>,
 }
 
+struct HousekeepingWriter {
+  inner: RollingFileAppender,
+  last_housekeeping_day: AtomicU32,
+}
+
+impl HousekeepingWriter {
+  fn new(inner: RollingFileAppender) -> Self {
+    Self {
+      inner,
+      last_housekeeping_day: AtomicU32::new(current_utc_day()),
+    }
+  }
+
+  fn trigger_housekeeping_if_rotated(&self) {
+    let current_day = current_utc_day();
+    if self.mark_rotation_if_needed(current_day) {
+      let _ = std::thread::Builder::new()
+        .name("orbitdock-housekeeping".into())
+        .spawn(crate::infrastructure::housekeeping::run_housekeeping);
+    }
+  }
+
+  fn mark_rotation_if_needed(&self, current_day: u32) -> bool {
+    loop {
+      let last_day = self.last_housekeeping_day.load(Ordering::Acquire);
+      if current_day <= last_day {
+        return false;
+      }
+
+      if self
+        .last_housekeeping_day
+        .compare_exchange(last_day, current_day, Ordering::AcqRel, Ordering::Acquire)
+        .is_ok()
+      {
+        return true;
+      }
+    }
+  }
+}
+
+impl Write for HousekeepingWriter {
+  fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+    let result = self.inner.write(buf);
+    self.trigger_housekeeping_if_rotated();
+    result
+  }
+
+  fn flush(&mut self) -> std::io::Result<()> {
+    self.inner.flush()
+  }
+}
+
 pub fn init_logging(options: &ServerLoggingOptions) -> anyhow::Result<LoggingHandle> {
   let log_dir = crate::infrastructure::paths::log_dir();
   std::fs::create_dir_all(&log_dir)?;
   let log_path = log_dir.join("server.log");
-
-  if std::env::var("ORBITDOCK_TRUNCATE_SERVER_LOG_ON_START").as_deref() == Ok("1") {
-    let _ = std::fs::OpenOptions::new()
-      .create(true)
-      .write(true)
-      .truncate(true)
-      .open(&log_path)?;
-  }
 
   let resolved_filter = resolve_filter_directives(
     std::env::var("ORBITDOCK_SERVER_LOG_FILTER")
@@ -80,8 +128,9 @@ pub fn init_logging(options: &ServerLoggingOptions) -> anyhow::Result<LoggingHan
   let filter = EnvFilter::try_new(&resolved_filter)
     .unwrap_or_else(|_| EnvFilter::new(apply_quiet_target_directives(DEFAULT_FILTER)));
 
-  let file_appender = tracing_appender::rolling::never(&log_dir, "server.log");
-  let (file_writer, guard) = tracing_appender::non_blocking(file_appender);
+  let file_appender = tracing_appender::rolling::daily(&log_dir, "server.log");
+  let housekeeping_writer = HousekeepingWriter::new(file_appender);
+  let (file_writer, guard) = tracing_appender::non_blocking(housekeeping_writer);
   let format = std::env::var("ORBITDOCK_SERVER_LOG_FORMAT").unwrap_or_else(|_| "json".into());
 
   let (stderr_layer, stderr_guard) = match options.stderr_mode {
@@ -158,6 +207,13 @@ pub fn init_logging(options: &ServerLoggingOptions) -> anyhow::Result<LoggingHan
 fn resolve_filter_directives(raw_filter: Option<String>) -> String {
   let base_filter = raw_filter.unwrap_or_else(|| DEFAULT_FILTER.to_string());
   apply_quiet_target_directives(&base_filter)
+}
+
+fn current_utc_day() -> u32 {
+  SystemTime::now()
+    .duration_since(UNIX_EPOCH)
+    .map(|duration| (duration.as_secs() / SECONDS_PER_DAY) as u32)
+    .unwrap_or(0)
 }
 
 fn apply_quiet_target_directives(base_filter: &str) -> String {
@@ -410,5 +466,20 @@ mod tests {
     assert!(resolved.contains("codex_otel.log_only=warn"));
     assert!(resolved.contains("feedback_tags=warn"));
     assert!(resolved.contains("rmcp::transport::worker=off"));
+  }
+
+  #[test]
+  fn housekeeping_writer_marks_rotation_once_per_day() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    let appender = tracing_appender::rolling::daily(tmp.path(), "server.log");
+    let writer = HousekeepingWriter {
+      inner: appender,
+      last_housekeeping_day: AtomicU32::new(10),
+    };
+
+    assert!(writer.mark_rotation_if_needed(11));
+    assert!(!writer.mark_rotation_if_needed(11));
+    assert!(!writer.mark_rotation_if_needed(10));
+    assert_eq!(writer.last_housekeeping_day.load(Ordering::Acquire), 11);
   }
 }

--- a/orbitdock-server/crates/server/src/infrastructure/migration_runner.rs
+++ b/orbitdock-server/crates/server/src/infrastructure/migration_runner.rs
@@ -39,10 +39,42 @@ pub fn run_migrations(conn: &mut Connection) -> anyhow::Result<()> {
 
   ensure_session_control_plane_columns(conn)?;
 
+  let applied = report.applied_migrations();
+
+  // V042 drops dead columns. Some columns (images_json, thinking) were added
+  // ad-hoc on existing installs but never by a migration, so we drop them
+  // conditionally here rather than in the SQL file.
+  let v042_applied = applied.iter().any(|m| m.version() == 42);
+  if v042_applied {
+    for col in &["images_json", "thinking"] {
+      if column_exists(conn, "messages", col)? {
+        conn
+          .execute(&format!("ALTER TABLE messages DROP COLUMN {col}"), [])
+          .with_context(|| format!("drop messages.{col}"))?;
+      }
+    }
+
+    // VACUUM must run outside a transaction to actually reclaim disk space.
+    // Critical for Pi deployments where 2+ GB of dead data is untenable.
+    info!(
+      component = "migrations",
+      event = "migrations.vacuum_start",
+      "Running VACUUM to reclaim disk space after column drops"
+    );
+    conn
+      .execute_batch("VACUUM;")
+      .context("VACUUM after V042 column drops")?;
+    info!(
+      component = "migrations",
+      event = "migrations.vacuum_complete",
+      "VACUUM complete"
+    );
+  }
+
   info!(
     component = "migrations",
     event = "migrations.complete",
-    applied = report.applied_migrations().len(),
+    applied = applied.len(),
     "Migration check complete"
   );
 

--- a/orbitdock-server/crates/server/src/infrastructure/mod.rs
+++ b/orbitdock-server/crates/server/src/infrastructure/mod.rs
@@ -4,6 +4,7 @@ pub(crate) mod crypto;
 pub(crate) mod daytona;
 pub(crate) mod github;
 pub(crate) mod github_releases;
+pub(crate) mod housekeeping;
 pub(crate) mod images;
 pub(crate) mod linear;
 pub(crate) mod logging;

--- a/orbitdock-server/crates/server/src/infrastructure/persistence/commands.rs
+++ b/orbitdock-server/crates/server/src/infrastructure/persistence/commands.rs
@@ -112,6 +112,7 @@ pub enum PersistCommand {
     session_id: String,
     approval_policy: Option<Option<String>>,
     sandbox_mode: Option<Option<String>>,
+    approvals_reviewer: Option<Option<orbitdock_protocol::CodexApprovalsReviewer>>,
     permission_mode: Option<Option<String>>,
     collaboration_mode: Option<Option<String>>,
     multi_agent: Option<Option<bool>>,

--- a/orbitdock-server/crates/server/src/infrastructure/persistence/sync_writer.rs
+++ b/orbitdock-server/crates/server/src/infrastructure/persistence/sync_writer.rs
@@ -9,7 +9,7 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use anyhow::Context;
 use serde::{Deserialize, Serialize};
 use tokio::sync::{mpsc, watch};
-use tracing::{debug, error, info, warn};
+use tracing::{error, warn};
 
 use crate::infrastructure::paths;
 use crate::support::session_time::chrono_now;
@@ -119,17 +119,6 @@ impl SyncWriter {
   }
 
   pub async fn run(mut self) {
-    info!(
-        component = "sync",
-        event = "sync.writer.started",
-        workspace_id = %self.config.workspace_id,
-        server_url = %self.config.server_url,
-        batch_size = self.config.batch_size,
-        flush_interval_ms = self.config.flush_interval.as_millis() as u64,
-        heartbeat_interval_secs = self.config.heartbeat_interval.as_secs(),
-        "Sync writer started"
-    );
-
     let mut flush_interval = tokio::time::interval(self.config.flush_interval);
     let mut heartbeat_interval = tokio::time::interval(self.config.heartbeat_interval);
 
@@ -178,13 +167,7 @@ impl SyncWriter {
     };
 
     match tokio::time::timeout(DEFAULT_SHUTDOWN_TIMEOUT, shutdown_future).await {
-      Ok(()) => {
-        info!(
-          component = "sync",
-          event = "sync.writer.stopped",
-          "Sync writer drained pending commands before shutdown"
-        );
-      }
+      Ok(()) => {}
       Err(_) => {
         warn!(
           component = "sync",
@@ -263,15 +246,7 @@ impl SyncWriter {
     };
 
     match self.post_batch(request).await {
-      Ok(()) => {
-        debug!(
-            component = "sync",
-            event = "sync.flush.succeeded",
-            workspace_id = %self.config.workspace_id,
-            command_count = envelopes.len(),
-            "Sync batch delivered"
-        );
-      }
+      Ok(()) => {}
       Err(error) => {
         warn!(
             component = "sync",
@@ -486,7 +461,7 @@ async fn post_batch(
   let response = response
     .error_for_status()
     .context("sync batch returned error status")?;
-  let status = response.status().as_u16();
+  let _status = response.status().as_u16();
 
   if request.commands.is_empty() {
     return Ok(());
@@ -519,13 +494,6 @@ async fn post_batch(
       );
     }
   }
-
-  debug!(
-    component = "sync",
-    event = "sync.post.completed",
-    status = status,
-    "Sync POST completed"
-  );
 
   Ok(())
 }

--- a/orbitdock-server/crates/server/src/transport/websocket/handlers/approvals.rs
+++ b/orbitdock-server/crates/server/src/transport/websocket/handlers/approvals.rs
@@ -1,7 +1,6 @@
 use std::sync::Arc;
 
 use tokio::sync::mpsc;
-use tracing::info;
 
 use crate::runtime::approval_dispatch::{dispatch_approve_tool, ApprovalDispatchResult};
 use crate::runtime::session_registry::SessionRegistry;
@@ -32,7 +31,7 @@ pub(crate) async fn handle(
   msg: ClientMessage,
   client_tx: &mpsc::Sender<OutboundMessage>,
   state: &Arc<SessionRegistry>,
-  conn_id: u64,
+  _conn_id: u64,
 ) {
   match msg {
     ClientMessage::ApproveTool {
@@ -43,16 +42,6 @@ pub(crate) async fn handle(
       interrupt,
       updated_input,
     } => {
-      info!(
-          component = "approval",
-          event = "approval.decision.received",
-          connection_id = conn_id,
-          session_id = %session_id,
-          request_id = %request_id,
-          decision = %decision,
-          "Approval decision received"
-      );
-
       let request_id_for_result = request_id.clone();
       let result = match dispatch_approve_tool(
         state,
@@ -83,19 +72,8 @@ pub(crate) async fn handle(
         }
       };
 
-      let promoted_request_id = result.active_request_id.clone();
       send_approval_decision_result(client_tx, session_id.clone(), request_id_for_result, result)
         .await;
-
-      if let Some(next_pending_request_id) = promoted_request_id {
-        info!(
-            component = "approval",
-            event = "approval.queue.promoted",
-            session_id = %session_id,
-            next_request_id = %next_pending_request_id,
-            "Promoted next queued approval"
-        );
-      }
     }
 
     ClientMessage::ListApprovals { session_id, .. } => {

--- a/orbitdock-server/migrations/V042__drop_legacy_message_columns.sql
+++ b/orbitdock-server/migrations/V042__drop_legacy_message_columns.sql
@@ -1,0 +1,22 @@
+-- Drop dead/redundant columns from messages table.
+--
+-- These columns were superseded by `row_data` (V022) and are no longer
+-- read or written by any code path:
+--
+--   tool_output  (V001) — legacy tool results
+--   tool_input   (V001) — legacy tool payloads
+--   tool_name    (V001) — legacy tool name strings
+--   tool_duration(V001) — legacy duration floats
+--   content      (V001) — redundant extract of row_data content
+--
+-- Some columns (images_json, thinking) were added ad-hoc on existing installs
+-- but never by a migration, so they may not exist on fresh databases.
+-- We handle those conditionally in the migration runner.
+--
+-- Requires SQLite >= 3.35.0 (macOS ships 3.39+).
+
+ALTER TABLE messages DROP COLUMN tool_output;
+ALTER TABLE messages DROP COLUMN tool_input;
+ALTER TABLE messages DROP COLUMN tool_name;
+ALTER TABLE messages DROP COLUMN tool_duration;
+ALTER TABLE messages DROP COLUMN content;


### PR DESCRIPTION
## Summary
- add startup housekeeping and the migration cleanup that supports it
- trim noisy approval and connector logging paths
- tighten the remaining runtime persistence and CLI cleanup work

## Notes
- cherry-picked from the control-deck-api cleanup branch
