### PR TITLE
📝 Add Codex architecture working notes

### DIFF
--- a/docs/codex-core-app-server-matrix.md
+++ b/docs/codex-core-app-server-matrix.md
@@ -1,0 +1,159 @@
+# Codex Core vs App Server Matrix
+
+This doc answers a very specific question:
+
+- what OrbitDock uses today that is not really "app-server"
+- what `codex-core` still gives us that OrbitDock might actually want
+- which Codex crates still make sense if app-server becomes the canonical runtime
+
+The short version is simple.
+
+OrbitDock currently depends on `codex-core` in meaningful ways. But most of that value is coming from our **embedded runtime architecture**, not from a large set of user-facing features that app-server cannot support.
+
+That distinction matters.
+
+If we move to app-server as the one real session runtime, a lot of current `codex-core` usage stops being strategic. What remains is mostly lower-level leverage: in-process embedding, direct manager access, rollout-path helpers, and internal escape hatches.
+
+## Current Dependency Surface
+
+OrbitDock currently pins these direct Codex dependencies in `orbitdock-server/Cargo.toml`:
+
+- `codex-core`
+- `codex-protocol`
+- `codex-app-server-protocol`
+- `codex-utils-absolute-path`
+- `codex-arg0`
+- `codex-login`
+
+See:
+
+- `orbitdock-server/Cargo.toml:18-25`
+
+## What OrbitDock Uses Today
+
+These are the major places where OrbitDock is coupled to Codex internals today:
+
+- Embedded live runtime through `CodexThread` and `ThreadManager`
+  - `orbitdock-server/crates/connector-codex/src/lib.rs`
+  - `orbitdock-server/crates/connector-codex/src/config.rs`
+- Direct session control via `Op::*`, `UserInput`, approvals, interrupt, skills, MCP refresh, and plugin manager access
+  - `orbitdock-server/crates/connector-codex/src/session_ops.rs`
+  - `orbitdock-server/crates/connector-codex/src/session.rs`
+- Direct auth manager and browser login server integration
+  - `orbitdock-server/crates/connector-codex/src/auth.rs`
+- Raw rollout file lookup and transcript-path resolution
+  - `orbitdock-server/crates/connector-codex/src/config.rs`
+  - `orbitdock-server/crates/connector-codex/src/lib.rs`
+  - `orbitdock-server/crates/server/src/transport/http/files.rs`
+- App-server utility RPCs for config/account/rate-limit reads
+  - `orbitdock-server/crates/server/src/runtime/codex_config.rs`
+  - `orbitdock-server/crates/server/src/infrastructure/usage_probe.rs`
+
+## Capability Matrix
+
+This is the important split.
+
+Some things are on `codex-core` today because we chose an embedded integration. Other things are genuinely lower-level and still only make sense if we want direct internal access.
+
+| Area | OrbitDock uses today | Current dependency shape | App-server equivalent? | Keep core after app-server migration? | Recommendation |
+| --- | --- | --- | --- | --- | --- |
+| Live session runtime | Start/resume/fork threads, send messages, steer active turns, interrupt, stream events | `CodexThread`, `ThreadManager`, `Op::*`, `UserInput`, event mapping in `connector-codex` | Yes. `thread/start`, `thread/resume`, `thread/fork`, `turn/start`, `turn/interrupt`, streamed notifications | No for the product path | Move this to app-server. This is the biggest source of complexity today. |
+| Approvals and ask-user flows | Exec approval, patch approval, permission answers, question answers | Direct `Op::*` submission plus concrete `CodexAction` plumbing | Yes. App-server exposes approval requests and client responses/server requests | No for the product path | Move to app-server and normalize responses into OrbitDock events. |
+| Skills and MCP discovery | `ListSkills`, `ListMcpTools`, `RefreshMcpServers` | Direct thread ops and manager cache clearing | Yes. `skills/list` exists, app-server also owns app/tool surfaces | Probably not | Treat this as runtime capability on the app-server path. |
+| Plugins | List/install/uninstall plus marketplace shaping | Mixed. Protocol types come from `codex-app-server-protocol`, but execution uses `thread_manager.plugins_manager()` | Yes. `plugin/list`, `plugin/read`, `plugin/install`, `plugin/uninstall` | No | This is a strong migration candidate. OrbitDock already thinks in app-server-shaped plugin payloads. |
+| Auth and account state | Read account, login, cancel login, logout | `AuthManager`, `codex-login`, direct token refresh | Yes. `account/read`, `account/login/start`, `account/logout`, `account/updated` | No for canonical runtime | Prefer app-server auth flows. Direct auth manager access is not a strong reason to keep a whole embedded runtime. |
+| Config and model discovery | Effective config, model/provider discovery, config writes | Split today. Utility APIs already use app-server; live runtime bootstrap still builds `codex_core::config::Config` directly | Yes. `config/read`, `config/value/write`, `model/list` | Probably not for product runtime | Finish the migration. This area is already partially app-server-backed. |
+| Native new features | `thread/shellCommand`, `fs/watch`, remote websocket auth, newer app-server-first workflows | Not available on OrbitDock's current direct session path | Yes. These are app-server surfaces | No | This is the clearest sign that app-server should be the canonical runtime. |
+| Raw rollout file lookup | Find transcript path by thread id, inspect files directly | `find_thread_path_by_id_str`, `find_codex_home` | Not really as a raw file helper. App-server gives thread APIs, not direct rollout paths | Maybe | Keep only if OrbitDock still wants file-level passive tooling. Otherwise redesign away from raw path dependence. |
+| Direct plugin/auth/config managers | Call internal managers in-process | `thread_manager.plugins_manager()`, `AuthManager`, config assembly internals | Not as direct manager access | Maybe, but only for special tooling | This is lower-level leverage, not a product requirement. Keep only if we have a concrete use case. |
+| Git/environment helper internals | Collect git state for event enrichment | `codex_core::git_info::collect_git_info` in event mapping | OrbitDock already has its own git resolver | No | Replace with OrbitDock-native helpers and drop this dependency reason. |
+| Passive rollout parsing | Parse JSONL transcripts and recover subagent/file/tool state | `codex-protocol` types plus local rollout parser | Not a one-to-one app-server surface | Maybe | This is the best remaining argument for some lower-level Codex dependency, but it should be justified separately from the live runtime. |
+
+## What Is Actually Core-Only Value?
+
+If we strip away "we built the runtime around it," the remaining `codex-core` value is mostly this:
+
+- in-process embedding without OrbitDock speaking JSON-RPC directly
+- direct access to internal managers and helpers
+- raw rollout/transcript file access
+- a possible fallback or experimentation layer when app-server lags
+
+That is real value. But it is **architectural value**, not a broad product-surface advantage.
+
+If we do not plan to exploit that on purpose, it is hard to justify carrying the whole embedded runtime as a permanent first-class path.
+
+## Crate Matrix
+
+This is the more practical dependency decision.
+
+| Crate | What OrbitDock uses it for today | If app-server becomes canonical | Likely recommendation |
+| --- | --- | --- | --- |
+| `codex-app-server-protocol` | Typed request/response payloads, especially config and plugin surfaces | Still needed | Keep |
+| `codex-core` | Embedded live runtime, auth/config/plugin managers, rollout helpers, some git helpers | Most product-runtime usage should disappear | Keep during migration. Reevaluate afterward. Likely remove from the main live-session path, maybe retain only if passive/experimental tooling still needs it. |
+| `codex-protocol` | Embedded event and op types, rollout parsing, model/config types | Embedded runtime usage should shrink sharply; passive tooling may still need it | Reevaluate after runtime migration. Possibly keep only for rollout/passive support, or remove if that path is redesigned. |
+| `codex-login` | Direct ChatGPT login server in OrbitDock auth service | App-server auth should replace this | Candidate to remove |
+| `codex-arg0` | Current direct integration bootstrapping | May still appear indirectly if OrbitDock adopts in-process app-server client | Likely remove as a direct design dependency, but verify upstream client/runtime needs first |
+| `codex-utils-absolute-path` | Plugin path normalization | Replaceable locally if needed | Candidate to remove |
+
+## Important Nuance About Binary Size
+
+Moving to app-server does **not automatically** mean `codex-core` disappears from the binary.
+
+Upstream now has `codex-app-server-client`, which is an in-process app-server facade. But that crate currently depends on:
+
+- `codex-app-server`
+- `codex-core`
+- `codex-protocol`
+- `codex-arg0`
+
+So there are really two separate decisions:
+
+1. Should OrbitDock make app-server the canonical runtime surface?
+2. Should OrbitDock also remove most direct lower-level Codex crates from its own dependency graph?
+
+The first answer looks like yes.
+
+The second answer is "probably later, after the migration works and we confirm what passive tooling still needs."
+
+## Recommendation
+
+Use app-server as the one canonical Codex runtime for OrbitDock sessions.
+
+Keep a narrow internal runtime boundary so OrbitDock's server stays in control of persistence, HTTP, and WebSocket behavior. But stop treating embedded `codex-core` as a co-equal long-term backend unless we can name a concrete reason it must survive.
+
+### What to migrate first
+
+- live session lifecycle
+- turn start / interrupt / steer behavior
+- approvals
+- auth/account flows
+- plugins
+- skills / MCP listing
+
+### What to reevaluate after that works
+
+- passive rollout support
+- raw transcript-path lookups
+- direct auth manager access
+- direct plugin manager access
+- direct config/model assembly
+
+### What likely becomes deleteable
+
+- most direct `codex-core` runtime plumbing in `connector-codex`
+- `codex-login`
+- direct `codex-core` auth integration
+- direct plugin-manager wiring
+- direct `Op::*`-driven session command handling
+
+## Bottom Line
+
+Right now, OrbitDock is carrying a lot of `codex-core` complexity because the whole session stack is built around embedded core.
+
+That does not mean OrbitDock needs all of that complexity in the future.
+
+The matrix points to a pretty clear conclusion:
+
+- app-server covers most of the product surface OrbitDock actually wants
+- most remaining `codex-core` value is lower-level leverage, not must-have runtime surface
+- we should keep only the lower-level pieces we can defend with a specific use case

--- a/docs/codex-runtime-architecture.md
+++ b/docs/codex-runtime-architecture.md
@@ -1,0 +1,585 @@
+# Codex Runtime Architecture
+
+This doc scopes a new Codex runtime architecture for OrbitDock.
+
+The goal is simple:
+
+- keep OrbitDock's server-authoritative model
+- support app-server-first Codex features cleanly
+- preserve the flexibility of direct crate integration
+- stop baking one specific Codex runtime choice into every server seam
+
+This is the design follow-up to [codex-rust-v0.117.0-scope.md](/Users/robertdeluca/Developer/OrbitDock/docs/codex-rust-v0.117.0-scope.md).
+
+## Why Change This
+
+OrbitDock's current direct Codex integration was a sensible choice.
+
+It gave us:
+
+- tight control over event normalization
+- no subprocess in the main live-session path
+- a natural fit for OrbitDock's server-owned transport contract
+
+But upstream is clearly building product velocity around app-server. That is where major new client-facing workflows are landing first.
+
+Today we already have a split world:
+
+- live Codex sessions run through embedded `codex-core`
+- some utility reads already shell out to `codex app-server`
+- plugin response types come from `codex-app-server-protocol`
+- app-server-only features like `thread/shellCommand` and `fs/watch` do not fit the current runtime shape
+
+That drift is the real problem.
+
+## Invariant To Protect
+
+OrbitDock server remains the source of truth.
+
+The native app should still talk only to OrbitDock's HTTP and WebSocket APIs. It should not become a direct Codex app-server client.
+
+That means:
+
+- HTTP still owns bootstrap, heavy reads, and mutations
+- WebSocket still owns replay, deltas, and refetch hints
+- SQLite and the session actor remain the durable business authority
+- Codex runtime changes stay behind the server boundary
+
+This is non-negotiable. It keeps us aligned with [data-flow.md](/Users/robertdeluca/Developer/OrbitDock/docs/data-flow.md) instead of replacing one clean architecture problem with three new ones.
+
+## Current Shape
+
+The current Codex runtime seam is too low-level.
+
+We already have good normalization at the event layer:
+
+- connectors emit `ConnectorEvent`
+- the session actor consumes those through `SessionCommand::ProcessEvent`
+- durable state changes still flow through `SessionHandle`, persistence commands, and server-authored deltas
+
+That part is strong.
+
+The part that leaks is control and lifecycle.
+
+Codex-specific action channels, start paths, resume paths, takeover paths, approval dispatch, and HTTP connector query helpers all know about the concrete `CodexAction` type today.
+
+You can see that in:
+
+- `orbitdock-server/crates/connector-codex/src/session.rs`
+- `orbitdock-server/crates/server/src/runtime/session_direct_start.rs`
+- `orbitdock-server/crates/server/src/runtime/session_resume.rs`
+- `orbitdock-server/crates/server/src/runtime/session_takeover.rs`
+- `orbitdock-server/crates/server/src/runtime/message_dispatch.rs`
+- `orbitdock-server/crates/server/src/runtime/approval_dispatch.rs`
+- `orbitdock-server/crates/server/src/transport/http/connector_actions.rs`
+- `orbitdock-server/crates/server/src/runtime/session_registry/connector_registry.rs`
+
+That makes the current runtime choice contagious.
+
+## Target Architecture
+
+Move the seam up one level.
+
+OrbitDock should own a provider-neutral Codex runtime contract, and then plug different implementations into it.
+
+The two initial implementations are:
+
+1. `EmbeddedCoreCodexRuntime`
+2. `AppServerCodexRuntime`
+
+Passive rollout watching stays separate. It is not a direct-session runtime.
+
+## What Stays The Same
+
+These layers should not fundamentally change:
+
+- the native app contract
+- session actor semantics
+- `ConnectorEvent` as the normalized event language
+- `SessionCommand` as the session mutation/query language
+- persistence ownership in the Rust server
+
+That is the point of this design. We are changing the Codex runtime substrate, not rewriting OrbitDock's whole session system.
+
+## The New Codex Runtime Boundary
+
+The server should stop depending on a concrete `CodexAction` channel and instead depend on a generic Codex runtime handle.
+
+At a high level, the new model looks like this:
+
+```text
+OrbitDock HTTP / WS
+        |
+        v
+ Session actor + domain transitions
+        |
+        v
+   CodexRuntimeHandle  <----- provider-neutral control surface
+        |
+        +---- EmbeddedCoreCodexRuntime
+        |
+        +---- AppServerCodexRuntime
+```
+
+The runtime handle should expose:
+
+- a stream of normalized `ConnectorEvent`s
+- a typed control channel for session actions
+- runtime identity and capability metadata
+
+## Proposed Types
+
+The exact Rust names can change, but the shape should be close to this.
+
+### Runtime kind
+
+```rust
+enum CodexRuntimeKind {
+    EmbeddedCore,
+    AppServer,
+}
+```
+
+This should be distinct from `CodexIntegrationMode`.
+
+`CodexIntegrationMode` is still useful for user-facing session semantics like:
+
+- `direct`
+- `passive`
+
+But it is the wrong type for the backend implementation choice.
+
+We should add a new persisted concept for runtime backend selection, something like:
+
+```rust
+enum CodexRuntimeBackend {
+    EmbeddedCore,
+    AppServer,
+}
+```
+
+## Runtime actions
+
+Replace the concrete `CodexAction` surface with a provider-neutral action enum.
+
+Something like:
+
+```rust
+enum CodexRuntimeAction {
+    SendMessage { ... },
+    SteerTurn { ... },
+    Interrupt,
+    ApproveExec { ... },
+    ApprovePatch { ... },
+    AnswerQuestion { ... },
+    RequestPermissionsResponse { ... },
+    UpdateConfig { ... },
+    SetThreadName { ... },
+    ListSkills { ... },
+    ListPlugins { ... },
+    ReadPlugin { ... },
+    InstallPlugin { ... },
+    UninstallPlugin { ... },
+    ListMcpTools,
+    RefreshMcpServers,
+    Compact,
+    Undo,
+    ThreadRollback { ... },
+    ForkSession { ... },
+    EndSession,
+}
+```
+
+This should describe OrbitDock intent, not upstream transport mechanics.
+
+That distinction matters.
+
+For example:
+
+- `AppServerCodexRuntime` may implement `SendMessage` through `turn/start`
+- `EmbeddedCoreCodexRuntime` may implement it through the current direct connector
+
+The session runtime should not care.
+
+## Runtime handle
+
+Each runtime implementation should return a common handle:
+
+```rust
+struct CodexRuntimeHandle {
+    kind: CodexRuntimeKind,
+    capabilities: CodexRuntimeCapabilities,
+    action_tx: mpsc::Sender<CodexRuntimeAction>,
+    event_rx: mpsc::Receiver<ConnectorEvent>,
+    binding: CodexRuntimeBinding,
+}
+```
+
+Where:
+
+```rust
+struct CodexRuntimeBinding {
+    external_thread_id: Option<String>,
+    session_source: Option<String>,
+}
+```
+
+And:
+
+```rust
+struct CodexRuntimeCapabilities {
+    supports_plugins: bool,
+    supports_plugin_read: bool,
+    supports_thread_shell_command: bool,
+    supports_fs_watch: bool,
+    supports_remote_transport: bool,
+    supports_multi_agent_v2: bool,
+}
+```
+
+This gives us a future-proof way to gate behavior by capability rather than by hard-coded version checks.
+
+## Why Capabilities Matter
+
+We should expect Codex to keep evolving quickly.
+
+Future-proof here does not mean "predict every future API."
+It means:
+
+- do not spread version-specific conditionals across the app
+- do not assume embedded-core and app-server always reach parity
+- do not make the native app infer what a runtime can do
+
+The runtime adapter should decide what is supported and expose that as typed capability metadata. The server can then surface only the stable product truth the client needs.
+
+## Implementation Model
+
+Each Codex runtime should own its own task and translate upstream behavior into OrbitDock concepts.
+
+### Embedded core runtime
+
+This wraps the current direct connector.
+
+It should:
+
+- keep using `codex-core`
+- keep translating upstream events into `ConnectorEvent`
+- adapt current direct commands into `CodexRuntimeAction`
+
+This lets us keep all the flexibility we already earned from direct crate integration.
+
+### App-server runtime
+
+This wraps the app-server product surface.
+
+It should:
+
+- use the official app-server client path, not a handwritten JSON-RPC layer
+- translate app-server notifications and request/response flows into `ConnectorEvent`
+- translate `CodexRuntimeAction` into app-server requests like `thread/*`, `turn/*`, `plugin/*`, and later `fs/*`
+
+This gives us access to the upstream-native runtime without leaking that transport into the rest of OrbitDock.
+
+## Recommended Process Model For App-Server
+
+Do not spawn one app-server process per session.
+
+That fights the upstream model.
+
+App-server is thread-oriented and already designed to multiplex many conversations.
+
+The better starting point is:
+
+- one supervised local app-server process per OrbitDock server instance
+- one shared app-server client connection manager
+- many OrbitDock sessions mapped to many app-server threads
+
+Benefits:
+
+- closer to upstream's intended model
+- simpler auth and config handling
+- easier support for future remote websocket mode
+- less process overhead
+
+We can keep the transport abstraction flexible enough to swap the local supervised app-server for a remote websocket app-server later.
+
+## Recommended App-Server Client Strategy
+
+Prefer the official app-server client crate or equivalent official transport helper over custom JSON-RPC glue.
+
+OrbitDock already has a few narrow manual app-server calls today. That was fine for utility reads.
+
+For a real long-lived runtime, a custom client would become maintenance debt almost immediately.
+
+Use the official client path where possible.
+
+## Normalization Strategy
+
+The event normalization boundary should stay at `ConnectorEvent`.
+
+That means:
+
+- app-server item notifications are not sent directly to the native app
+- app-server request payloads are not treated as durable business truth
+- the runtime adapter turns them into OrbitDock events, rows, approvals, subagent updates, and capability broadcasts
+
+When app-server introduces a genuinely new concept, the fix should be:
+
+1. add a typed OrbitDock event or typed state field
+2. update persistence and broadcast layers if it is durable
+3. let the client render that typed concept
+
+Not:
+
+- "just pipe the JSON through"
+
+## Session Lifecycle Changes
+
+The direct Codex start, resume, and takeover flows should stop constructing concrete `CodexSession` objects directly.
+
+Instead, they should ask a runtime factory for a `CodexRuntimeHandle`.
+
+Something like:
+
+```rust
+trait CodexRuntimeFactory {
+    async fn start_direct(... ) -> Result<CodexRuntimeHandle, CodexRuntimeError>;
+    async fn resume_direct(... ) -> Result<CodexRuntimeHandle, CodexRuntimeError>;
+    async fn takeover_passive(... ) -> Result<CodexRuntimeHandle, CodexRuntimeError>;
+}
+```
+
+That moves runtime choice out of:
+
+- `session_direct_start.rs`
+- `session_resume.rs`
+- `session_takeover.rs`
+
+And into one deliberate place.
+
+## Registry Changes
+
+The current connector registry is also too concrete.
+
+Today it stores:
+
+- `mpsc::Sender<CodexAction>`
+- `mpsc::Sender<ClaudeAction>`
+- provider-specific external thread maps
+
+That should become more generic for Codex.
+
+Recommended direction:
+
+- replace `codex_actions` with `codex_runtime_actions`
+- store runtime kind and thread binding alongside the sender
+- keep provider-specific identities where they matter, but stop making the control channel itself runtime-specific
+
+This makes future app-server-backed Codex sessions look the same to the rest of the server.
+
+## Approval And Message Dispatch Changes
+
+`message_dispatch.rs`, `approval_dispatch.rs`, and HTTP connector query helpers should dispatch through the generic Codex runtime action surface, not through `CodexAction`.
+
+That is one of the biggest cleanup wins in this design.
+
+Right now those layers know too much about the concrete runtime choice.
+
+After this change, they should only know:
+
+- is this a Codex session
+- what OrbitDock is asking the runtime to do
+- whether the runtime reported success, failure, or unavailability
+
+## Persistence Changes
+
+We should persist runtime backend selection for direct Codex sessions.
+
+Why:
+
+- resume behavior depends on it
+- takeover behavior depends on it
+- debugging depends on it
+- migration between backends should be explicit
+
+Suggested new persisted field:
+
+- `codex_runtime_backend`
+
+Suggested values:
+
+- `embedded_core`
+- `app_server`
+
+Do not overload `codex_integration_mode` for this.
+
+That field means something different today.
+
+## Capability Surface
+
+The server should expose Codex runtime capability truth as part of session state or a closely related surface.
+
+That might include:
+
+- plugin support
+- plugin read/install auth follow-up support
+- app-server shell command support
+- filesystem watch support
+- remote runtime support
+
+The client should not guess from runtime backend names alone. Backend and capability are related, but not identical.
+
+This is especially important for future releases where embedded-core may catch up on some features or app-server may gate features behind capability flags.
+
+## What We Should Not Do
+
+Do not:
+
+- make the native app a direct app-server client
+- expose raw app-server JSON-RPC over OrbitDock WebSocket
+- add version checks all over the codebase
+- replace `ConnectorEvent` with untyped protocol payloads
+- keep two entirely separate Codex product models in the client
+
+That would make upgrades harder, not easier.
+
+## Migration Plan
+
+## Phase 0: Name the concepts
+
+- add `CodexRuntimeBackend`
+- add `CodexRuntimeKind`
+- add `CodexRuntimeCapabilities`
+- add a provider-neutral `CodexRuntimeAction` surface
+
+No behavior change yet.
+
+## Phase 1: Put the current embedded runtime behind the new interface
+
+- adapt the current direct connector to the new runtime contract
+- change registry storage from `CodexAction` to `CodexRuntimeAction`
+- update message dispatch, approvals, and HTTP query helpers to use the new contract
+
+This is the make-it-boring phase.
+
+The goal is to prove the abstraction against the runtime we already trust.
+
+## Phase 2: Add app-server supervisor and runtime adapter
+
+- add a supervised local app-server process manager
+- add a shared app-server client manager
+- implement `AppServerCodexRuntime`
+- translate app-server thread/item/approval/plugin flows into `ConnectorEvent`
+
+Still do not change the native client contract.
+
+## Phase 3: Add runtime selection
+
+- choose backend for new direct Codex sessions
+- persist backend choice
+- route resume/takeover through the correct runtime factory
+- expose runtime capabilities to OrbitDock session state
+
+At first, make this opt-in.
+
+## Phase 4: Reach parity on the workflows that matter
+
+Use app-server runtime to unlock:
+
+- first-class plugins
+- app-server-native subagent behavior
+- `thread/shellCommand`, if we choose to support it
+- filesystem watch, if we choose to surface it
+
+Do not flip defaults until session creation, resume, approval handling, and core transcript rendering are trustworthy.
+
+## Phase 5: Make app-server the default direct runtime
+
+Once parity is good enough:
+
+- new direct Codex sessions default to app-server backend
+- embedded-core remains supported as fallback and escape hatch
+
+That last part matters.
+
+Keeping embedded-core as a supported backend is the hedge that preserves flexibility for future upstream shifts.
+
+## Why Keep Embedded Core At All
+
+Because it still has real strategic value.
+
+Direct crate integration gives us:
+
+- freedom to experiment
+- lower-level access when upstream app-server abstractions lag
+- a path for niche or performance-sensitive features later
+- resilience if app-server semantics change in ways that do not fit OrbitDock
+
+So the right move is not "replace direct integration."
+
+It is:
+
+- stop making direct integration the only shape OrbitDock understands
+
+## Risks
+
+### Risk: Adapter leaks
+
+If `CodexRuntimeAction` just becomes a thin rename of app-server methods, the abstraction failed.
+
+The action surface must describe OrbitDock intent.
+
+### Risk: Event mismatch
+
+App-server may expose richer or differently grouped item streams than direct core.
+
+We need to normalize carefully and only promote new durable concepts when they matter.
+
+### Risk: Resume complexity
+
+App-server thread identity, embedded-core thread identity, and passive rollout identity all need clean ownership and persistence rules.
+
+Do not patch this with string heuristics.
+
+### Risk: Dual-runtime test matrix
+
+Once we support both backends, parity drift becomes possible.
+
+We should expect a targeted test matrix around:
+
+- send
+- steer
+- interrupt
+- approvals
+- plugin flows
+- fork
+- resume
+- subagent updates
+
+## Recommended First Build Slice
+
+If we decide to move on this architecture, the first implementation slice should be:
+
+1. add the new Codex runtime types and registry seam
+2. adapt embedded-core to that seam
+3. keep behavior unchanged
+4. only then add app-server runtime
+
+That keeps the migration honest.
+
+It also lets the compiler tell us every place where the current concrete Codex runtime leaks into the server.
+
+That is exactly the kind of pressure we want.
+
+## Bottom Line
+
+OrbitDock should become runtime-agnostic for direct Codex sessions.
+
+The server-owned truth, actor model, and client transport contract are worth keeping.
+
+The piece that should change is the Codex runtime boundary.
+
+That gives us the best of both worlds:
+
+- app-server alignment for where Codex is going
+- direct crate flexibility for where Codex might go next

--- a/docs/codex-rust-v0.117.0-scope.md
+++ b/docs/codex-rust-v0.117.0-scope.md
@@ -1,0 +1,368 @@
+# Codex `rust-v0.117.0` Support Scope
+
+This is the scope pass for bringing OrbitDock up to Codex `rust-v0.117.0`, released on March 26, 2026.
+
+The short version:
+
+- OrbitDock is currently pinned to `rust-v0.116.0`.
+- We already have real Codex support, not a thin wrapper.
+- The biggest release-note items split into two buckets:
+  - direct-embedding features we mostly already understand
+  - app-server-only features that OrbitDock cannot support just by bumping crates
+
+That distinction matters. It changes the size of the work quite a bit.
+
+## What Changed In `0.117.0`
+
+Using `gh`, the release and compare data point to four relevant themes:
+
+1. Plugins became a first-class workflow.
+2. Sub-agents moved further into multi-agent v2 with path-based agent addresses like `/root/agent_a`.
+3. App-server clients gained `thread/shellCommand`, filesystem watch RPCs, and remote websocket auth.
+4. The app-server-backed TUI became the default path upstream.
+
+The direct release-note language is useful here:
+
+- plugins are now first-class
+- sub-agents use path-based addresses
+- app-server clients can send `!` shell commands
+- app-server clients can watch filesystem changes
+- remote websocket app-server connections support bearer-token auth
+
+## What OrbitDock Already Has
+
+OrbitDock is not starting from zero.
+
+### Direct Codex integration already exists
+
+The Rust workspace is pinned to `rust-v0.116.0` in `orbitdock-server/Cargo.toml`, and the main live session path embeds `codex-core` directly through the connector in `orbitdock-server/crates/connector-codex/src/lib.rs`.
+
+That connector already handles:
+
+- streamed agent/tool events
+- approvals
+- dynamic tool calls
+- collab agent lifecycle events
+- subagent persistence
+- plugin list/install/uninstall flows
+
+### Plugin backend is already partially built
+
+OrbitDock already exposes HTTP endpoints for:
+
+- `GET /api/sessions/{id}/plugins`
+- `POST /api/sessions/{id}/plugins/install`
+- `POST /api/sessions/{id}/plugins/uninstall`
+
+Those are wired through `orbitdock-server/crates/server/src/transport/http/capabilities.rs` into `orbitdock-server/crates/connector-codex/src/session_ops.rs`.
+
+That means the server side is ahead of the product surface.
+
+### Subagent UI already exists
+
+The native app already has a worker roster and worker detail sidecar in:
+
+- `OrbitDockNative/OrbitDock/Views/SessionDetail/SessionWorkerRoster.swift`
+- `OrbitDockNative/OrbitDock/Views/SessionDetail/SessionDetailViewModel.swift`
+
+The session model also already carries:
+
+- `subagents`
+- `subagentTools`
+- `subagentMessages`
+
+So OrbitDock already thinks in terms of first-class workers.
+
+### OrbitDock already talks to Codex app-server in a narrow way
+
+We already spawn `codex app-server` for:
+
+- config inspection in `orbitdock-server/crates/server/src/runtime/codex_config.rs`
+- account/rate-limit reads in `orbitdock-server/crates/server/src/infrastructure/usage_probe.rs`
+
+But that is not a persistent app-server session runtime. It is one-shot request/response usage.
+
+## The Big Boundary: Direct vs App-Server
+
+This is the most important scoping conclusion.
+
+Some of the flashy `0.117.0` features are not general Codex-core capabilities. They are app-server protocol features.
+
+That includes:
+
+- `thread/shellCommand`
+- `fs/watch`
+- `fs/unwatch`
+- `fs/changed`
+- remote websocket auth for app-server clients
+
+OrbitDock does not currently run Codex sessions through app-server. Our real session path is still direct embedding through `codex-core`.
+
+So if we want true first-class support for those features, we need a new OrbitDock app-server session mode. A crate bump alone will not get us there.
+
+## Feature-By-Feature Scope
+
+## 1. Plugins
+
+This is the best first target.
+
+Why:
+
+- the backend is already mostly there
+- the release made plugins a stable, user-facing workflow
+- OrbitDock currently has a gap between server capability and actual product UX
+
+### Current OrbitDock state
+
+Server support exists for:
+
+- listing plugin marketplaces
+- installing plugins
+- uninstalling plugins
+- filtering by session source and product restriction
+- optional remote sync
+
+### Current gaps
+
+- the native client does not expose plugin APIs through `SessionsClient`
+- there is no first-class plugin UI in the app
+- install results currently throw away part of the upstream response
+
+That last point is important. In `orbitdock-server/crates/connector-codex/src/session_ops.rs`, `install_plugin()` currently returns:
+
+- `auth_policy`
+- `apps_needing_auth: Vec::new()`
+
+Upstream `0.117.0` expects plugin install to surface apps that still need auth. So even where we have server support, we are not yet exposing the full workflow.
+
+### Scope to make plugins first-class in OrbitDock
+
+- bump Codex crates to `rust-v0.117.0`
+- verify `PluginListResponse`, `PluginReadResponse`, `PluginInstallResponse`, and related types still compile cleanly
+- add native client API methods for plugin list/read/install/uninstall
+- add a session-level plugin browser UI
+- show install state, auth state, and marketplace metadata
+- surface `apps_needing_auth` after install
+- refresh MCP/app/tool inventory after install or uninstall
+
+### Effort
+
+Medium. Mostly additive. Good candidate for the first implementation slice.
+
+## 2. Sub-agents and multi-agent v2
+
+OrbitDock is closer here than the release notes might suggest.
+
+### Current OrbitDock state
+
+The direct connector already maps collab agent events in `orbitdock-server/crates/connector-codex/src/event_mapping/collab.rs`.
+
+The server already persists subagents.
+
+The native app already renders a worker roster.
+
+### Why this is still not “done”
+
+Multi-agent v2 changed the upstream model in a few meaningful ways:
+
+- path-based agent IDs like `/root/agent_a`
+- structured inter-agent communication
+- agent listing improvements
+- watcher-driven updates around v2 communication
+
+OrbitDock’s high-level worker ID handling is probably fine because IDs are plain strings everywhere.
+
+The risk is lower-level compatibility:
+
+- drill-down views rely on transcript parsing and rollout interpretation
+- subagent transcript parsing in `orbitdock-server/crates/server/src/connectors/subagent_parser.rs` is tuned to older message shapes
+- the old rollout parser path was removed when OrbitDock dropped passive rollout watching in favor of a hook-first Codex design
+
+### Scope to harden subagent support
+
+- bump Codex crates to `rust-v0.117.0`
+- validate collab event enum changes compile cleanly
+- verify worker roster behavior with path-based IDs
+- update rollout parsing for new multi-agent v2 communication events
+- update transcript parsing for worker drill-down, if upstream transcript shape changed
+- test parent/child worker relationships with path-based parents
+- test mixed states like running, interrupted, completed, failed, not found
+
+### Effort
+
+Medium. Lower risk than app-server work, but more subtle than it first looks.
+
+## 3. `!` shell commands from app-server clients
+
+This is not a small feature for OrbitDock.
+
+### What upstream added
+
+Upstream added `thread/shellCommand` so app-server clients can implement `!` shell commands.
+
+The generated schema for `ThreadShellCommandParams` is especially important:
+
+- it sends a raw shell command string
+- it preserves shell syntax like pipes and redirects
+- it runs unsandboxed with full access rather than inheriting the thread sandbox policy
+
+That last point makes this a product and security decision, not just a transport detail.
+
+### Current OrbitDock state
+
+OrbitDock does not run Codex conversations over app-server today.
+
+We only use app-server for narrow utility calls like config reads and rate-limit reads.
+
+### Scope required for real support
+
+- add a persistent app-server-backed Codex session mode in OrbitDock
+- map OrbitDock sessions to app-server `thread/*` lifecycle
+- render app-server item streams as OrbitDock conversation rows
+- support app-server approvals and interruptions
+- explicitly decide how OrbitDock exposes an unsandboxed `!` shell path
+- decide whether this is opt-in, hidden behind a capability, or intentionally not supported
+
+### Effort
+
+Large. This is a new integration mode, not a patch.
+
+## 4. Filesystem watch and remote websocket auth
+
+These land in the same bucket as `!` shell commands.
+
+### What upstream added
+
+App-server now supports:
+
+- `fs/watch`
+- `fs/unwatch`
+- `fs/changed`
+- remote websocket auth with bearer tokens during websocket upgrade
+
+### Current OrbitDock state
+
+OrbitDock has its own server-authoritative transport model already:
+
+- HTTP for bootstrap and heavy reads
+- WebSocket for light realtime deltas and refetch hints
+
+For OrbitDock itself, filesystem watch is only useful if we decide to become an app-server client for live Codex sessions.
+
+Remote websocket auth matters if we want OrbitDock to connect to a remote Codex app-server instead of spawning local Codex or embedding `codex-core`.
+
+### Effort
+
+Large when taken seriously. This belongs in the same project as app-server session mode.
+
+## Recommended Plan
+
+If the goal is to add real first-class support without disappearing into a giant rewrite, the best order is:
+
+### Phase 1: Safe upgrade plus plugin productization
+
+- bump all Codex crates from `rust-v0.116.0` to `rust-v0.117.0`
+- fix compile fallout
+- verify direct-session behavior in a real session
+- expose plugin APIs to the native app
+- build a first-class plugin browser/install flow
+- carry through auth follow-up state after install
+
+Why this first:
+
+- users get visible value quickly
+- most of the server plumbing already exists
+- it exercises the release in a low-risk way
+
+### Phase 2: Multi-agent v2 hardening
+
+- validate path-based worker IDs
+- harden rollout parsing and worker drill-down
+- improve worker messaging surfaces for structured inter-agent communication
+
+Why second:
+
+- OrbitDock already has worker UI
+- we can make the existing experience more trustworthy without changing the whole architecture
+
+### Phase 3: Decide whether OrbitDock should support app-server session mode
+
+This is the fork-in-the-road decision.
+
+If yes, scope a dedicated project for:
+
+- persistent app-server thread runtime
+- session mapping
+- item/event translation
+- approval handling
+- shell command policy
+- optional remote Codex connections
+
+If no, then we should explicitly say OrbitDock supports:
+
+- direct embedded Codex sessions
+- passive rollout watching
+- plugin workflows
+- multi-agent support through the direct connector
+
+And we should leave app-server-only features out of scope on purpose.
+
+## My Recommendation
+
+Start with Phase 1.
+
+That means:
+
+1. bump to `rust-v0.117.0`
+2. finish the plugin product surface
+3. validate multi-agent v2 compatibility while doing the bump
+4. defer app-server session mode to a separate design pass
+
+This gives OrbitDock meaningful `0.117.0` value without forcing us to pretend that app-server and direct embedding are the same thing.
+
+They are not.
+
+## Concrete Touchpoints
+
+If we take the recommended Phase 1 path, these are the main files I would expect to touch first:
+
+- `orbitdock-server/Cargo.toml`
+- `orbitdock-server/Cargo.lock`
+- `orbitdock-server/crates/connector-codex/src/session_ops.rs`
+- `orbitdock-server/crates/server/src/transport/http/capabilities.rs`
+- `OrbitDockNative/OrbitDock/Services/Server/API/SessionsClient.swift`
+- `OrbitDockNative/OrbitDock/Services/Server/Protocol/` types for plugin payloads
+- a new native plugins UI surface under `OrbitDockNative/OrbitDock/Views/`
+
+For Phase 2, add:
+
+- `orbitdock-server/crates/server/src/connectors/subagent_parser.rs`
+- `OrbitDockNative/OrbitDock/Views/SessionDetail/SessionWorkerRoster.swift`
+
+## GH CLI Notes
+
+This scope pass used `gh` against the upstream release and PRs, especially:
+
+- `gh release view rust-v0.117.0 --repo openai/codex`
+- `gh api repos/openai/codex/compare/rust-v0.116.0...rust-v0.117.0`
+- `gh pr view 14988 --repo openai/codex`
+- `gh pr view 14533 --repo openai/codex`
+- `gh pr view 14847 --repo openai/codex`
+- `gh pr view 14853 --repo openai/codex`
+- `gh pr view 15041 --repo openai/codex`
+- `gh pr view 15195 --repo openai/codex`
+- `gh pr view 15215 --repo openai/codex`
+- `gh pr view 15217 --repo openai/codex`
+- `gh pr view 15264 --repo openai/codex`
+- `gh pr view 15313 --repo openai/codex`
+- `gh pr view 15342 --repo openai/codex`
+- `gh pr view 15515 --repo openai/codex`
+- `gh pr view 15556 --repo openai/codex`
+- `gh pr view 15570 --repo openai/codex`
+- `gh pr view 15606 --repo openai/codex`
+- `gh pr view 15621 --repo openai/codex`
+- `gh pr view 15713 --repo openai/codex`
+- `gh pr view 15722 --repo openai/codex`
+- `gh pr view 15820 --repo openai/codex`
+
+That should make the next implementation pass straightforward.


### PR DESCRIPTION
## Summary
- add the current Codex core app/server matrix notes
- document the runtime architecture and Rust scope notes captured during this branch

## Notes
- cherry-picked from the control-deck-api cleanup branch
