### PR TITLE
✨ Stream shell output previews safely

### DIFF
--- a/orbitdock-server/crates/server/src/transport/http/shell.rs
+++ b/orbitdock-server/crates/server/src/transport/http/shell.rs
@@ -16,9 +16,9 @@ use crate::domain::sessions::transition::Input;
 use crate::infrastructure::shell::{ShellCancelStatus, ShellOutcome, ShellResult};
 use crate::runtime::session_commands::SessionCommand;
 use crate::runtime::session_registry::SessionRegistry;
+use crate::transport::shell_streaming::{ShellStreamPreviewState, SHELL_STREAM_THROTTLE_MS};
 
 const DEFAULT_SHELL_TIMEOUT_SECS: u64 = 120;
-const SHELL_STREAM_THROTTLE_MS: u128 = 120;
 
 #[derive(Debug, Deserialize)]
 pub struct ExecuteShellRequest {
@@ -115,7 +115,7 @@ fn build_shell_row_entry(
 
 fn finalize_shell_result(
   result: ShellResult,
-  streamed_output: String,
+  streamed_output: Option<String>,
 ) -> (String, bool, ShellExecutionOutcome, ShellResult) {
   let is_error = match result.outcome {
     ShellOutcome::Completed => result.exit_code != Some(0),
@@ -130,7 +130,7 @@ fn finalize_shell_result(
     format!("{}\n{}", result.stdout, result.stderr)
   };
   let final_output = if combined_output.is_empty() {
-    streamed_output
+    streamed_output.unwrap_or_default()
   } else {
     combined_output
   };
@@ -218,15 +218,15 @@ pub async fn execute_shell_endpoint(
   tokio::spawn(async move {
     let mut chunk_rx = shell_execution.chunk_rx;
     let completion_rx = shell_execution.completion_rx;
-    let mut streamed_output = String::new();
+    let mut preview_state = ShellStreamPreviewState::default();
     let mut last_stream_emit = std::time::Instant::now();
 
     while let Some(chunk) = chunk_rx.recv().await {
       if !chunk.stdout.is_empty() {
-        streamed_output.push_str(&chunk.stdout);
+        preview_state.append_stdout(&chunk.stdout);
       }
       if !chunk.stderr.is_empty() {
-        streamed_output.push_str(&chunk.stderr);
+        preview_state.append_stderr(&chunk.stderr);
       }
       let now = std::time::Instant::now();
       if now.duration_since(last_stream_emit).as_millis() < SHELL_STREAM_THROTTLE_MS {
@@ -239,8 +239,8 @@ pub async fn execute_shell_endpoint(
           &sid,
           ShellRowState {
             command: Some(command_for_task.clone()),
-            stdout: (!streamed_output.is_empty()).then(|| streamed_output.clone()),
-            stderr: None,
+            stdout: preview_state.stdout_preview(),
+            stderr: preview_state.stderr_preview(),
             exit_code: None,
             duration_ms: 0,
             cwd: Some(resolved_cwd_for_task.clone()),
@@ -267,7 +267,8 @@ pub async fn execute_shell_endpoint(
         outcome: ShellOutcome::Failed,
       },
     };
-    let (final_output, _is_error, outcome, result) = finalize_shell_result(result, streamed_output);
+    let (final_output, _is_error, outcome, result) =
+      finalize_shell_result(result, preview_state.combined_preview());
 
     if let Some(actor) = state_ref.get_session(&sid) {
       let stdout = if result.stdout.is_empty() {

--- a/orbitdock-server/crates/server/src/transport/mod.rs
+++ b/orbitdock-server/crates/server/src/transport/mod.rs
@@ -1,3 +1,4 @@
 pub(crate) mod http;
+pub(crate) mod shell_streaming;
 pub mod web_assets;
 pub(crate) mod websocket;

--- a/orbitdock-server/crates/server/src/transport/shell_streaming.rs
+++ b/orbitdock-server/crates/server/src/transport/shell_streaming.rs
@@ -1,0 +1,68 @@
+const SHELL_STREAM_PREVIEW_CHAR_LIMIT: usize = 8 * 1024;
+pub(crate) const SHELL_STREAM_THROTTLE_MS: u128 = 120;
+
+#[derive(Debug, Default)]
+pub(crate) struct ShellStreamPreviewState {
+  stdout: String,
+  stderr: String,
+}
+
+impl ShellStreamPreviewState {
+  pub(crate) fn append_stdout(&mut self, chunk: &str) {
+    self.stdout.push_str(chunk);
+    trim_front_to_char_limit(&mut self.stdout, SHELL_STREAM_PREVIEW_CHAR_LIMIT);
+  }
+
+  pub(crate) fn append_stderr(&mut self, chunk: &str) {
+    self.stderr.push_str(chunk);
+    trim_front_to_char_limit(&mut self.stderr, SHELL_STREAM_PREVIEW_CHAR_LIMIT);
+  }
+
+  pub(crate) fn stdout_preview(&self) -> Option<String> {
+    (!self.stdout.is_empty()).then(|| self.stdout.clone())
+  }
+
+  pub(crate) fn stderr_preview(&self) -> Option<String> {
+    (!self.stderr.is_empty()).then(|| self.stderr.clone())
+  }
+
+  pub(crate) fn combined_preview(&self) -> Option<String> {
+    match (self.stdout.is_empty(), self.stderr.is_empty()) {
+      (true, true) => None,
+      (false, true) => Some(self.stdout.clone()),
+      (true, false) => Some(self.stderr.clone()),
+      (false, false) => Some(format!("{}\n{}", self.stdout, self.stderr)),
+    }
+  }
+}
+
+fn trim_front_to_char_limit(value: &mut String, limit: usize) {
+  if value.len() <= limit {
+    return;
+  }
+
+  let mut split_at = value.len().saturating_sub(limit);
+  while split_at < value.len() && !value.is_char_boundary(split_at) {
+    split_at += 1;
+  }
+  value.drain(..split_at);
+}
+
+#[cfg(test)]
+mod tests {
+  use super::ShellStreamPreviewState;
+
+  #[test]
+  fn combined_preview_retains_recent_tail() {
+    let mut state = ShellStreamPreviewState::default();
+    state.append_stdout(&"a".repeat(9000));
+    state.append_stderr("stderr");
+
+    let stdout = state.stdout_preview().expect("stdout preview");
+    assert!(stdout.len() <= 8 * 1024);
+    assert!(stdout.ends_with(&"a".repeat(128)));
+
+    let combined = state.combined_preview().expect("combined preview");
+    assert!(combined.contains("stderr"));
+  }
+}

--- a/orbitdock-server/crates/server/src/transport/websocket/handlers/shell.rs
+++ b/orbitdock-server/crates/server/src/transport/websocket/handlers/shell.rs
@@ -1,6 +1,5 @@
 use std::sync::Arc;
 use tokio::sync::mpsc;
-use tracing::info;
 
 use orbitdock_protocol::conversation_contracts::{
   ConversationRow, ConversationRowEntry, RenderHints, ShellCommandRow, ShellCommandRowKind,
@@ -9,6 +8,7 @@ use orbitdock_protocol::{new_id, ClientMessage, ServerMessage, ShellExecutionOut
 
 use crate::runtime::session_commands::SessionCommand;
 use crate::runtime::session_registry::SessionRegistry;
+use crate::transport::shell_streaming::{ShellStreamPreviewState, SHELL_STREAM_THROTTLE_MS};
 use crate::transport::websocket::{send_json, OutboundMessage};
 
 fn shell_render_hints() -> RenderHints {
@@ -77,7 +77,7 @@ pub(crate) async fn handle(
   msg: ClientMessage,
   client_tx: &mpsc::Sender<OutboundMessage>,
   state: &Arc<SessionRegistry>,
-  conn_id: u64,
+  _conn_id: u64,
 ) {
   match msg {
     ClientMessage::ExecuteShell {
@@ -86,14 +86,6 @@ pub(crate) async fn handle(
       cwd,
       timeout_secs,
     } => {
-      info!(
-          component = "shell",
-          event = "shell.execute.requested",
-          connection_id = conn_id,
-          session_id = %session_id,
-          "Shell execution requested"
-      );
-
       let resolved_cwd = if let Some(ref explicit) = cwd {
         explicit.clone()
       } else if let Some(actor) = state.get_session(&session_id) {
@@ -181,16 +173,15 @@ pub(crate) async fn handle(
         let mut chunk_rx = shell_execution.chunk_rx;
         let completion_rx = shell_execution.completion_rx;
 
-        let mut streamed_output = String::new();
+        let mut preview_state = ShellStreamPreviewState::default();
         let mut last_stream_emit = std::time::Instant::now();
-        const SHELL_STREAM_THROTTLE_MS: u128 = 120;
 
         while let Some(chunk) = chunk_rx.recv().await {
           if !chunk.stdout.is_empty() {
-            streamed_output.push_str(&chunk.stdout);
+            preview_state.append_stdout(&chunk.stdout);
           }
           if !chunk.stderr.is_empty() {
-            streamed_output.push_str(&chunk.stderr);
+            preview_state.append_stderr(&chunk.stderr);
           }
 
           let now = std::time::Instant::now();
@@ -205,8 +196,8 @@ pub(crate) async fn handle(
               &sid,
               ShellRowState {
                 command: Some(cmd_clone.clone()),
-                stdout: (!streamed_output.is_empty()).then(|| streamed_output.clone()),
-                stderr: None,
+                stdout: preview_state.stdout_preview(),
+                stderr: preview_state.stderr_preview(),
                 exit_code: None,
                 duration_ms: 0,
                 cwd: Some(resolved_cwd.clone()),
@@ -249,7 +240,7 @@ pub(crate) async fn handle(
           format!("{}\n{}", result.stdout, result.stderr)
         };
         let final_output = if combined_output.is_empty() {
-          streamed_output
+          preview_state.combined_preview().unwrap_or_default()
         } else {
           combined_output
         };
@@ -309,15 +300,6 @@ pub(crate) async fn handle(
       session_id,
       request_id,
     } => {
-      info!(
-          component = "shell",
-          event = "shell.cancel.requested",
-          connection_id = conn_id,
-          session_id = %session_id,
-          request_id = %request_id,
-          "Shell cancel requested"
-      );
-
       if state.get_session(&session_id).is_none() {
         send_json(
           client_tx,
@@ -332,16 +314,7 @@ pub(crate) async fn handle(
       }
 
       match state.shell_service().cancel(&session_id, &request_id) {
-        crate::infrastructure::shell::ShellCancelStatus::Canceled => {
-          info!(
-              component = "shell",
-              event = "shell.cancel.accepted",
-              connection_id = conn_id,
-              session_id = %session_id,
-              request_id = %request_id,
-              "Shell cancel accepted"
-          );
-        }
+        crate::infrastructure::shell::ShellCancelStatus::Canceled => {}
         crate::infrastructure::shell::ShellCancelStatus::NotFound => {
           send_json(
             client_tx,


### PR DESCRIPTION
## Summary
- Keep bounded live shell previews for both the HTTP and WebSocket execution paths.
- Reuse shared preview-state handling so streamed shell output stays lightweight.
- Preserve the final shell row without letting live previews grow unbounded.

## Verification
- `cargo check -p orbitdock-server`
- `cargo test -p orbitdock-server shell_streaming`
- `cargo test -p orbitdock-server shell`