### PR TITLE
⬆️ bump codex-rs from 0.116.0 to 0.117.0

### DIFF
--- a/orbitdock-server/Cargo.lock
+++ b/orbitdock-server/Cargo.lock
@@ -225,9 +225,9 @@ dependencies = [
 
 [[package]]
 name = "arc-swap"
-version = "1.8.2"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9f3647c145568cec02c42054e07bdf9a5a698e15b466fb2341bfc393cd24aa5"
+checksum = "a07d1f37ff60921c83bdfc7407723bdefe89b44b98a9b772f225c8f9d67141a6"
 dependencies = [
  "rustversion",
 ]
@@ -245,58 +245,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8824ecca2e851cec16968d54a01dd372ef8f95b244fb84b84e70128be347c3c6"
 dependencies = [
  "term",
-]
-
-[[package]]
-name = "askama"
-version = "0.15.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08e1676b346cadfec169374f949d7490fd80a24193d37d2afce0c047cf695e57"
-dependencies = [
- "askama_macros",
- "itoa",
- "percent-encoding",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "askama_derive"
-version = "0.15.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7661ff56517787343f376f75db037426facd7c8d3049cef8911f1e75016f3a37"
-dependencies = [
- "askama_parser",
- "basic-toml",
- "memchr",
- "proc-macro2",
- "quote",
- "rustc-hash 2.1.1",
- "serde",
- "serde_derive",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "askama_macros"
-version = "0.15.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "713ee4dbfd1eb719c2dab859465b01fa1d21cb566684614a713a6b7a99a4e47b"
-dependencies = [
- "askama_derive",
-]
-
-[[package]]
-name = "askama_parser"
-version = "0.15.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d62d674238a526418b30c0def480d5beadb9d8964e7f38d635b03bf639c704c"
-dependencies = [
- "rustc-hash 2.1.1",
- "serde",
- "serde_derive",
- "unicode-ident",
- "winnow",
 ]
 
 [[package]]
@@ -651,6 +599,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a8241f3ebb85c056b509d4327ad0358fbbba6ffb340bf388f26350aeda225b1"
 
 [[package]]
+name = "bindgen"
+version = "0.72.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
+dependencies = [
+ "bitflags 2.11.0",
+ "cexpr",
+ "clang-sys",
+ "itertools 0.13.0",
+ "log",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash 2.1.1",
+ "shlex",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "bit-set"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -836,6 +804,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ade8366b8bd5ba243f0a58f036cc0ca8a2f069cff1a2351ef1cac6b083e16fc0"
 
 [[package]]
+name = "calendrical_calculations"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a0b39595c6ee54a8d0900204ba4c401d0ab4eb45adaf07178e8d017541529e7"
+dependencies = [
+ "core_maths",
+ "displaydoc",
+]
+
+[[package]]
 name = "cassowary"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -876,6 +854,15 @@ name = "cesu8"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
+
+[[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom 7.1.3",
+]
 
 [[package]]
 name = "cfg-if"
@@ -962,6 +949,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "clang-sys"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
+]
+
+[[package]]
 name = "clap"
 version = "4.5.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1035,9 +1033,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9b18233253483ce2f65329a24072ec414db782531bdbb7d0bbc4bd2ce6b7e21"
 
 [[package]]
+name = "codex-analytics"
+version = "0.117.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.117.0#4c70bff480af37b1bf1a9b352b8341060fe55755"
+dependencies = [
+ "codex-git-utils",
+ "codex-login",
+ "codex-plugin",
+ "codex-protocol",
+ "serde",
+ "sha1",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "codex-api"
-version = "0.116.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.116.0#38771c9082535aa16b4c4d0395d3532f32f656ff"
+version = "0.117.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.117.0#4c70bff480af37b1bf1a9b352b8341060fe55755"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1061,12 +1074,13 @@ dependencies = [
 
 [[package]]
 name = "codex-app-server-protocol"
-version = "0.116.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.116.0#38771c9082535aa16b4c4d0395d3532f32f656ff"
+version = "0.117.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.117.0#4c70bff480af37b1bf1a9b352b8341060fe55755"
 dependencies = [
  "anyhow",
  "clap",
  "codex-experimental-api-macros",
+ "codex-git-utils",
  "codex-protocol",
  "codex-utils-absolute-path",
  "inventory",
@@ -1085,8 +1099,8 @@ dependencies = [
 
 [[package]]
 name = "codex-apply-patch"
-version = "0.116.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.116.0#38771c9082535aa16b4c4d0395d3532f32f656ff"
+version = "0.117.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.117.0#4c70bff480af37b1bf1a9b352b8341060fe55755"
 dependencies = [
  "anyhow",
  "similar",
@@ -1097,12 +1111,13 @@ dependencies = [
 
 [[package]]
 name = "codex-arg0"
-version = "0.116.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.116.0#38771c9082535aa16b4c4d0395d3532f32f656ff"
+version = "0.117.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.117.0#4c70bff480af37b1bf1a9b352b8341060fe55755"
 dependencies = [
  "anyhow",
  "codex-apply-patch",
  "codex-linux-sandbox",
+ "codex-sandboxing",
  "codex-shell-escalation",
  "codex-utils-home-dir",
  "dotenvy",
@@ -1111,25 +1126,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "codex-artifacts"
-version = "0.116.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.116.0#38771c9082535aa16b4c4d0395d3532f32f656ff"
-dependencies = [
- "codex-package-manager",
- "reqwest",
- "serde",
- "serde_json",
- "tempfile",
- "thiserror 2.0.18",
- "tokio",
- "url",
- "which",
-]
-
-[[package]]
 name = "codex-async-utils"
-version = "0.116.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.116.0#38771c9082535aa16b4c4d0395d3532f32f656ff"
+version = "0.117.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.117.0#4c70bff480af37b1bf1a9b352b8341060fe55755"
 dependencies = [
  "async-trait",
  "tokio",
@@ -1138,8 +1137,8 @@ dependencies = [
 
 [[package]]
 name = "codex-client"
-version = "0.116.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.116.0#38771c9082535aa16b4c4d0395d3532f32f656ff"
+version = "0.117.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.117.0#4c70bff480af37b1bf1a9b352b8341060fe55755"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1163,9 +1162,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "codex-code-mode"
+version = "0.117.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.117.0#4c70bff480af37b1bf1a9b352b8341060fe55755"
+dependencies = [
+ "async-trait",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "v8",
+]
+
+[[package]]
 name = "codex-config"
-version = "0.116.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.116.0#38771c9082535aa16b4c4d0395d3532f32f656ff"
+version = "0.117.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.117.0#4c70bff480af37b1bf1a9b352b8341060fe55755"
 dependencies = [
  "codex-app-server-protocol",
  "codex-execpolicy",
@@ -1173,6 +1186,7 @@ dependencies = [
  "codex-utils-absolute-path",
  "futures",
  "multimap",
+ "schemars 0.8.22",
  "serde",
  "serde_json",
  "serde_path_to_error",
@@ -1186,8 +1200,8 @@ dependencies = [
 
 [[package]]
 name = "codex-connectors"
-version = "0.116.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.116.0#38771c9082535aa16b4c4d0395d3532f32f656ff"
+version = "0.117.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.117.0#4c70bff480af37b1bf1a9b352b8341060fe55755"
 dependencies = [
  "anyhow",
  "codex-app-server-protocol",
@@ -1197,12 +1211,11 @@ dependencies = [
 
 [[package]]
 name = "codex-core"
-version = "0.116.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.116.0#38771c9082535aa16b4c4d0395d3532f32f656ff"
+version = "0.117.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.117.0#4c70bff480af37b1bf1a9b352b8341060fe55755"
 dependencies = [
  "anyhow",
  "arc-swap",
- "askama",
  "async-channel",
  "async-trait",
  "base64 0.22.1",
@@ -1210,37 +1223,46 @@ dependencies = [
  "chardetng",
  "chrono",
  "clap",
+ "codex-analytics",
  "codex-api",
  "codex-app-server-protocol",
  "codex-apply-patch",
- "codex-artifacts",
  "codex-async-utils",
- "codex-client",
+ "codex-code-mode",
  "codex-config",
  "codex-connectors",
- "codex-environment",
+ "codex-core-skills",
+ "codex-exec-server",
  "codex-execpolicy",
- "codex-file-search",
- "codex-git",
+ "codex-features",
+ "codex-git-utils",
  "codex-hooks",
- "codex-keyring-store",
+ "codex-instructions",
+ "codex-login",
  "codex-network-proxy",
  "codex-otel",
+ "codex-plugin",
  "codex-protocol",
  "codex-rmcp-client",
+ "codex-rollout",
+ "codex-sandboxing",
  "codex-secrets",
  "codex-shell-command",
  "codex-shell-escalation",
- "codex-skills",
  "codex-state",
+ "codex-terminal-detection",
  "codex-utils-absolute-path",
  "codex-utils-cache",
  "codex-utils-home-dir",
  "codex-utils-image",
+ "codex-utils-output-truncation",
+ "codex-utils-path",
+ "codex-utils-plugins",
  "codex-utils-pty",
  "codex-utils-readiness",
  "codex-utils-stream-parser",
  "codex-utils-string",
+ "codex-utils-template",
  "codex-windows-sandbox",
  "core-foundation 0.9.4",
  "csv",
@@ -1254,13 +1276,11 @@ dependencies = [
  "iana-time-zone",
  "image",
  "indexmap 2.13.0",
- "keyring",
  "landlock",
  "libc",
  "notify 8.2.0",
  "once_cell",
  "openssl-sys",
- "os_info",
  "rand 0.9.2",
  "regex-lite",
  "reqwest",
@@ -1269,15 +1289,12 @@ dependencies = [
  "seccompiler",
  "serde",
  "serde_json",
- "serde_yaml",
  "sha1",
- "sha2",
  "shlex",
  "similar",
  "tempfile",
  "test-log",
  "thiserror 2.0.18",
- "time",
  "tokio",
  "tokio-tungstenite 0.28.0",
  "tokio-util",
@@ -1286,26 +1303,65 @@ dependencies = [
  "tracing",
  "url",
  "uuid",
- "which",
+ "which 8.0.0",
  "wildmatch",
  "windows-sys 0.52.0",
  "zip",
 ]
 
 [[package]]
-name = "codex-environment"
-version = "0.116.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.116.0#38771c9082535aa16b4c4d0395d3532f32f656ff"
+name = "codex-core-skills"
+version = "0.117.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.117.0#4c70bff480af37b1bf1a9b352b8341060fe55755"
 dependencies = [
- "async-trait",
+ "anyhow",
+ "codex-analytics",
+ "codex-app-server-protocol",
+ "codex-config",
+ "codex-instructions",
+ "codex-login",
+ "codex-otel",
+ "codex-protocol",
+ "codex-skills",
  "codex-utils-absolute-path",
+ "codex-utils-plugins",
+ "dirs",
+ "dunce",
+ "serde",
+ "serde_json",
+ "serde_yaml",
+ "shlex",
  "tokio",
+ "toml 0.9.12+spec-1.1.0",
+ "tracing",
+ "zip",
+]
+
+[[package]]
+name = "codex-exec-server"
+version = "0.117.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.117.0#4c70bff480af37b1bf1a9b352b8341060fe55755"
+dependencies = [
+ "arc-swap",
+ "async-trait",
+ "base64 0.22.1",
+ "clap",
+ "codex-app-server-protocol",
+ "codex-utils-absolute-path",
+ "codex-utils-pty",
+ "futures",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-tungstenite 0.28.0",
+ "tracing",
 ]
 
 [[package]]
 name = "codex-execpolicy"
-version = "0.116.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.116.0#38771c9082535aa16b4c4d0395d3532f32f656ff"
+version = "0.117.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.117.0#4c70bff480af37b1bf1a9b352b8341060fe55755"
 dependencies = [
  "anyhow",
  "clap",
@@ -1320,8 +1376,8 @@ dependencies = [
 
 [[package]]
 name = "codex-experimental-api-macros"
-version = "0.116.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.116.0#38771c9082535aa16b4c4d0395d3532f32f656ff"
+version = "0.117.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.117.0#4c70bff480af37b1bf1a9b352b8341060fe55755"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1329,9 +1385,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "codex-features"
+version = "0.117.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.117.0#4c70bff480af37b1bf1a9b352b8341060fe55755"
+dependencies = [
+ "codex-login",
+ "codex-otel",
+ "codex-protocol",
+ "schemars 0.8.22",
+ "serde",
+ "toml 0.9.12+spec-1.1.0",
+ "tracing",
+]
+
+[[package]]
 name = "codex-file-search"
-version = "0.116.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.116.0#38771c9082535aa16b4c4d0395d3532f32f656ff"
+version = "0.117.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.117.0#4c70bff480af37b1bf1a9b352b8341060fe55755"
 dependencies = [
  "anyhow",
  "clap",
@@ -1344,24 +1414,27 @@ dependencies = [
 ]
 
 [[package]]
-name = "codex-git"
-version = "0.116.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.116.0#38771c9082535aa16b4c4d0395d3532f32f656ff"
+name = "codex-git-utils"
+version = "0.117.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.117.0#4c70bff480af37b1bf1a9b352b8341060fe55755"
 dependencies = [
+ "codex-utils-absolute-path",
+ "futures",
  "once_cell",
  "regex",
  "schemars 0.8.22",
  "serde",
  "tempfile",
  "thiserror 2.0.18",
+ "tokio",
  "ts-rs",
  "walkdir",
 ]
 
 [[package]]
 name = "codex-hooks"
-version = "0.116.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.116.0#38771c9082535aa16b4c4d0395d3532f32f656ff"
+version = "0.117.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.117.0#4c70bff480af37b1bf1a9b352b8341060fe55755"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1376,9 +1449,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "codex-instructions"
+version = "0.117.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.117.0#4c70bff480af37b1bf1a9b352b8341060fe55755"
+dependencies = [
+ "codex-protocol",
+ "serde",
+]
+
+[[package]]
 name = "codex-keyring-store"
-version = "0.116.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.116.0#38771c9082535aa16b4c4d0395d3532f32f656ff"
+version = "0.117.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.117.0#4c70bff480af37b1bf1a9b352b8341060fe55755"
 dependencies = [
  "keyring",
  "tracing",
@@ -1386,13 +1468,14 @@ dependencies = [
 
 [[package]]
 name = "codex-linux-sandbox"
-version = "0.116.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.116.0#38771c9082535aa16b4c4d0395d3532f32f656ff"
+version = "0.117.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.117.0#4c70bff480af37b1bf1a9b352b8341060fe55755"
 dependencies = [
  "cc",
  "clap",
  "codex-core",
  "codex-protocol",
+ "codex-sandboxing",
  "codex-utils-absolute-path",
  "landlock",
  "libc",
@@ -1405,19 +1488,27 @@ dependencies = [
 
 [[package]]
 name = "codex-login"
-version = "0.116.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.116.0#38771c9082535aa16b4c4d0395d3532f32f656ff"
+version = "0.117.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.117.0#4c70bff480af37b1bf1a9b352b8341060fe55755"
 dependencies = [
+ "async-trait",
  "base64 0.22.1",
  "chrono",
  "codex-app-server-protocol",
  "codex-client",
- "codex-core",
+ "codex-config",
+ "codex-keyring-store",
+ "codex-protocol",
+ "codex-terminal-detection",
+ "once_cell",
+ "os_info",
  "rand 0.9.2",
  "reqwest",
+ "schemars 0.8.22",
  "serde",
  "serde_json",
  "sha2",
+ "thiserror 2.0.18",
  "tiny_http",
  "tokio",
  "tracing",
@@ -1428,8 +1519,8 @@ dependencies = [
 
 [[package]]
 name = "codex-network-proxy"
-version = "0.116.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.116.0#38771c9082535aa16b4c4d0395d3532f32f656ff"
+version = "0.117.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.117.0#4c70bff480af37b1bf1a9b352b8341060fe55755"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1458,11 +1549,12 @@ dependencies = [
 
 [[package]]
 name = "codex-otel"
-version = "0.116.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.116.0#38771c9082535aa16b4c4d0395d3532f32f656ff"
+version = "0.117.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.117.0#4c70bff480af37b1bf1a9b352b8341060fe55755"
 dependencies = [
  "chrono",
  "codex-api",
+ "codex-app-server-protocol",
  "codex-protocol",
  "codex-utils-absolute-path",
  "codex-utils-string",
@@ -1488,36 +1580,29 @@ dependencies = [
 ]
 
 [[package]]
-name = "codex-package-manager"
-version = "0.116.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.116.0#38771c9082535aa16b4c4d0395d3532f32f656ff"
+name = "codex-plugin"
+version = "0.117.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.117.0#4c70bff480af37b1bf1a9b352b8341060fe55755"
 dependencies = [
- "fd-lock",
- "flate2",
- "reqwest",
- "serde",
- "sha2",
- "tar",
- "tempfile",
+ "codex-utils-absolute-path",
+ "codex-utils-plugins",
  "thiserror 2.0.18",
- "tokio",
- "url",
- "zip",
 ]
 
 [[package]]
 name = "codex-protocol"
-version = "0.116.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.116.0#38771c9082535aa16b4c4d0395d3532f32f656ff"
+version = "0.117.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.117.0#4c70bff480af37b1bf1a9b352b8341060fe55755"
 dependencies = [
  "codex-execpolicy",
- "codex-git",
+ "codex-git-utils",
  "codex-utils-absolute-path",
  "codex-utils-image",
+ "codex-utils-string",
  "icu_decimal",
  "icu_locale_core",
  "icu_provider",
- "mime_guess",
+ "quick-xml",
  "schemars 0.8.22",
  "serde",
  "serde_json",
@@ -1532,8 +1617,8 @@ dependencies = [
 
 [[package]]
 name = "codex-rmcp-client"
-version = "0.116.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.116.0#38771c9082535aa16b4c4d0395d3532f32f656ff"
+version = "0.117.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.117.0#4c70bff480af37b1bf1a9b352b8341060fe55755"
 dependencies = [
  "anyhow",
  "axum",
@@ -1558,17 +1643,58 @@ dependencies = [
  "tracing",
  "urlencoding",
  "webbrowser",
- "which",
+ "which 8.0.0",
+]
+
+[[package]]
+name = "codex-rollout"
+version = "0.117.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.117.0#4c70bff480af37b1bf1a9b352b8341060fe55755"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "chrono",
+ "codex-file-search",
+ "codex-git-utils",
+ "codex-login",
+ "codex-otel",
+ "codex-protocol",
+ "codex-state",
+ "codex-utils-path",
+ "codex-utils-string",
+ "serde",
+ "serde_json",
+ "time",
+ "tokio",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "codex-sandboxing"
+version = "0.117.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.117.0#4c70bff480af37b1bf1a9b352b8341060fe55755"
+dependencies = [
+ "codex-network-proxy",
+ "codex-protocol",
+ "codex-utils-absolute-path",
+ "dirs",
+ "dunce",
+ "libc",
+ "serde_json",
+ "tracing",
+ "url",
 ]
 
 [[package]]
 name = "codex-secrets"
-version = "0.116.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.116.0#38771c9082535aa16b4c4d0395d3532f32f656ff"
+version = "0.117.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.117.0#4c70bff480af37b1bf1a9b352b8341060fe55755"
 dependencies = [
  "age",
  "anyhow",
  "base64 0.22.1",
+ "codex-git-utils",
  "codex-keyring-store",
  "rand 0.9.2",
  "regex",
@@ -1581,8 +1707,8 @@ dependencies = [
 
 [[package]]
 name = "codex-shell-command"
-version = "0.116.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.116.0#38771c9082535aa16b4c4d0395d3532f32f656ff"
+version = "0.117.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.117.0#4c70bff480af37b1bf1a9b352b8341060fe55755"
 dependencies = [
  "base64 0.22.1",
  "codex-protocol",
@@ -1595,13 +1721,13 @@ dependencies = [
  "tree-sitter",
  "tree-sitter-bash",
  "url",
- "which",
+ "which 8.0.0",
 ]
 
 [[package]]
 name = "codex-shell-escalation"
-version = "0.116.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.116.0#38771c9082535aa16b4c4d0395d3532f32f656ff"
+version = "0.117.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.117.0#4c70bff480af37b1bf1a9b352b8341060fe55755"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1620,8 +1746,8 @@ dependencies = [
 
 [[package]]
 name = "codex-skills"
-version = "0.116.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.116.0#38771c9082535aa16b4c4d0395d3532f32f656ff"
+version = "0.117.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.117.0#4c70bff480af37b1bf1a9b352b8341060fe55755"
 dependencies = [
  "codex-utils-absolute-path",
  "include_dir",
@@ -1630,8 +1756,8 @@ dependencies = [
 
 [[package]]
 name = "codex-state"
-version = "0.116.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.116.0#38771c9082535aa16b4c4d0395d3532f32f656ff"
+version = "0.117.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.117.0#4c70bff480af37b1bf1a9b352b8341060fe55755"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1643,6 +1769,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sqlx",
+ "strum 0.27.2",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -1650,9 +1777,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "codex-terminal-detection"
+version = "0.117.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.117.0#4c70bff480af37b1bf1a9b352b8341060fe55755"
+dependencies = [
+ "tracing",
+]
+
+[[package]]
 name = "codex-utils-absolute-path"
-version = "0.116.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.116.0#38771c9082535aa16b4c4d0395d3532f32f656ff"
+version = "0.117.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.117.0#4c70bff480af37b1bf1a9b352b8341060fe55755"
 dependencies = [
  "dirs",
  "path-absolutize",
@@ -1663,8 +1798,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-cache"
-version = "0.116.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.116.0#38771c9082535aa16b4c4d0395d3532f32f656ff"
+version = "0.117.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.117.0#4c70bff480af37b1bf1a9b352b8341060fe55755"
 dependencies = [
  "lru 0.16.3",
  "sha1",
@@ -1673,28 +1808,57 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-home-dir"
-version = "0.116.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.116.0#38771c9082535aa16b4c4d0395d3532f32f656ff"
+version = "0.117.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.117.0#4c70bff480af37b1bf1a9b352b8341060fe55755"
 dependencies = [
  "dirs",
 ]
 
 [[package]]
 name = "codex-utils-image"
-version = "0.116.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.116.0#38771c9082535aa16b4c4d0395d3532f32f656ff"
+version = "0.117.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.117.0#4c70bff480af37b1bf1a9b352b8341060fe55755"
 dependencies = [
  "base64 0.22.1",
  "codex-utils-cache",
  "image",
+ "mime_guess",
  "thiserror 2.0.18",
  "tokio",
 ]
 
 [[package]]
+name = "codex-utils-output-truncation"
+version = "0.117.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.117.0#4c70bff480af37b1bf1a9b352b8341060fe55755"
+dependencies = [
+ "codex-protocol",
+ "codex-utils-string",
+]
+
+[[package]]
+name = "codex-utils-path"
+version = "0.117.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.117.0#4c70bff480af37b1bf1a9b352b8341060fe55755"
+dependencies = [
+ "codex-utils-absolute-path",
+ "dunce",
+ "tempfile",
+]
+
+[[package]]
+name = "codex-utils-plugins"
+version = "0.117.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.117.0#4c70bff480af37b1bf1a9b352b8341060fe55755"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "codex-utils-pty"
-version = "0.116.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.116.0#38771c9082535aa16b4c4d0395d3532f32f656ff"
+version = "0.117.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.117.0#4c70bff480af37b1bf1a9b352b8341060fe55755"
 dependencies = [
  "anyhow",
  "filedescriptor",
@@ -1709,8 +1873,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-readiness"
-version = "0.116.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.116.0#38771c9082535aa16b4c4d0395d3532f32f656ff"
+version = "0.117.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.117.0#4c70bff480af37b1bf1a9b352b8341060fe55755"
 dependencies = [
  "async-trait",
  "thiserror 2.0.18",
@@ -1720,29 +1884,34 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-rustls-provider"
-version = "0.116.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.116.0#38771c9082535aa16b4c4d0395d3532f32f656ff"
+version = "0.117.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.117.0#4c70bff480af37b1bf1a9b352b8341060fe55755"
 dependencies = [
  "rustls",
 ]
 
 [[package]]
 name = "codex-utils-stream-parser"
-version = "0.116.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.116.0#38771c9082535aa16b4c4d0395d3532f32f656ff"
+version = "0.117.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.117.0#4c70bff480af37b1bf1a9b352b8341060fe55755"
 
 [[package]]
 name = "codex-utils-string"
-version = "0.116.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.116.0#38771c9082535aa16b4c4d0395d3532f32f656ff"
+version = "0.117.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.117.0#4c70bff480af37b1bf1a9b352b8341060fe55755"
 dependencies = [
  "regex-lite",
 ]
 
 [[package]]
+name = "codex-utils-template"
+version = "0.117.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.117.0#4c70bff480af37b1bf1a9b352b8341060fe55755"
+
+[[package]]
 name = "codex-windows-sandbox"
-version = "0.116.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.116.0#38771c9082535aa16b4c4d0395d3532f32f656ff"
+version = "0.117.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.117.0#4c70bff480af37b1bf1a9b352b8341060fe55755"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -1919,6 +2088,15 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "core_maths"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77745e017f5edba1a9c1d854f6f3a52dac8a12dd5af5d2f54aecf61e43d80d30"
+dependencies = [
+ "libm",
+]
 
 [[package]]
 name = "cpufeatures"
@@ -2386,6 +2564,38 @@ dependencies = [
  "const-oid",
  "crypto-common",
  "subtle",
+]
+
+[[package]]
+name = "diplomat"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9adb46b05e2f53dcf6a7dfc242e4ce9eb60c369b6b6eb10826a01e93167f59c6"
+dependencies = [
+ "diplomat_core",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "diplomat-runtime"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0569bd3caaf13829da7ee4e83dbf9197a0e1ecd72772da6d08f0b4c9285c8d29"
+
+[[package]]
+name = "diplomat_core"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51731530ed7f2d4495019abc7df3744f53338e69e2863a6a64ae91821c763df1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde",
+ "smallvec",
+ "strck",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2952,6 +3162,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "fslock"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04412b8935272e3a9bae6f48c7bfff74c2911f60525404edfdd28e49884c3bfb"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "futures"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3158,6 +3378,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
 name = "globset"
 version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3168,6 +3394,15 @@ dependencies = [
  "log",
  "regex-automata",
  "regex-syntax 0.8.10",
+]
+
+[[package]]
+name = "gzip-header"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95cc527b92e6029a62960ad99aa8a6660faa4555fe5f731aab13aa6a921795a2"
+dependencies = [
+ "crc32fast",
 ]
 
 [[package]]
@@ -3595,6 +3830,28 @@ checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
 dependencies = [
  "cc",
 ]
+
+[[package]]
+name = "icu_calendar"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6f0e52e009b6b16ba9c0693578796f2dd4aaa59a7f8f920423706714a89ac4e"
+dependencies = [
+ "calendrical_calculations",
+ "displaydoc",
+ "icu_calendar_data",
+ "icu_locale",
+ "icu_locale_core",
+ "icu_provider",
+ "tinystr",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_calendar_data"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "527f04223b17edfe0bd43baf14a0cb1b017830db65f3950dc00224860a9a446d"
 
 [[package]]
 name = "icu_collections"
@@ -4032,6 +4289,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
+name = "ixdtf"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84de9d95a6d2547d9b77ee3f25fa0ee32e3c3a6484d47a55adebc0439c077992"
+
+[[package]]
 name = "jni"
 version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4191,6 +4454,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "328c4789d42200f1eeec05bd86c9c13c7f091d2ba9a6ea35acdf51f31bc0f043"
 dependencies = [
  "pkg-config",
+]
+
+[[package]]
+name = "libloading"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
+dependencies = [
+ "cfg-if",
+ "windows-link",
 ]
 
 [[package]]
@@ -5278,10 +5551,13 @@ dependencies = [
  "codex-app-server-protocol",
  "codex-arg0",
  "codex-core",
+ "codex-exec-server",
+ "codex-git-utils",
  "codex-login",
  "codex-protocol",
  "codex-utils-absolute-path",
  "notify 7.0.0",
+ "openssl",
  "orbitdock-connector-core",
  "orbitdock-protocol",
  "serde",
@@ -5857,6 +6133,16 @@ name = "quick-error"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
+
+[[package]]
+name = "quick-xml"
+version = "0.38.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
+dependencies = [
+ "memchr",
+ "serde",
+]
 
 [[package]]
 name = "quinn"
@@ -6572,6 +6858,16 @@ dependencies = [
  "wasm-streams",
  "web-sys",
  "webpki-roots 1.0.6",
+]
+
+[[package]]
+name = "resb"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a067ab3b5ca3b4dc307d0de9cf75f9f5e6ca9717b192b2f28a36c83e5de9e76"
+dependencies = [
+ "potential_utf",
+ "serde_core",
 ]
 
 [[package]]
@@ -7802,6 +8098,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "strck"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42316e70da376f3d113a68d138a60d8a9883c604fe97942721ec2068dab13a9f"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
 name = "streaming-iterator"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7856,6 +8161,9 @@ name = "strum"
 version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
+dependencies = [
+ "strum_macros 0.27.2",
+]
 
 [[package]]
 name = "strum_macros"
@@ -7867,6 +8175,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
  "syn 2.0.117",
 ]
 
@@ -7967,17 +8287,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
 
 [[package]]
-name = "tar"
-version = "0.4.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d863878d212c87a19c1a610eb53bb01fe12951c0501cf5a0d65f724914a667a"
-dependencies = [
- "filetime",
- "libc",
- "xattr",
-]
-
-[[package]]
 name = "tempfile"
 version = "3.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7988,6 +8297,39 @@ dependencies = [
  "once_cell",
  "rustix 1.1.4",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "temporal_capi"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a151e402c2bdb6a3a2a2f3f225eddaead2e7ce7dd5d3fa2090deb11b17aa4ed8"
+dependencies = [
+ "diplomat",
+ "diplomat-runtime",
+ "icu_calendar",
+ "icu_locale",
+ "num-traits",
+ "temporal_rs",
+ "timezone_provider",
+ "writeable",
+ "zoneinfo64",
+]
+
+[[package]]
+name = "temporal_rs"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88afde3bd75d2fc68d77a914bece426aa08aa7649ffd0cdd4a11c3d4d33474d1"
+dependencies = [
+ "core_maths",
+ "icu_calendar",
+ "icu_locale",
+ "ixdtf",
+ "num-traits",
+ "timezone_provider",
+ "tinystr",
+ "writeable",
 ]
 
 [[package]]
@@ -8121,6 +8463,18 @@ checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
 dependencies = [
  "num-conv",
  "time-core",
+]
+
+[[package]]
+name = "timezone_provider"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9ba0000e9e73862f3e7ca1ff159e2ddf915c9d8bb11e38a7874760f445d993"
+dependencies = [
+ "tinystr",
+ "zerotrie",
+ "zerovec",
+ "zoneinfo64",
 ]
 
 [[package]]
@@ -8901,6 +9255,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "v8"
+version = "146.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d97bcac5cdc5a195a4813f1855a6bc658f240452aac36caa12fd6c6f16026ab1"
+dependencies = [
+ "bindgen",
+ "bitflags 2.11.0",
+ "fslock",
+ "gzip-header",
+ "home",
+ "miniz_oxide",
+ "paste",
+ "temporal_capi",
+ "which 6.0.3",
+]
+
+[[package]]
 name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9132,6 +9503,18 @@ name = "weezl"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
+
+[[package]]
+name = "which"
+version = "6.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ee928febd44d98f2f459a4a79bd4d928591333a494a10a868418ac1b39cf1f"
+dependencies = [
+ "either",
+ "home",
+ "rustix 0.38.44",
+ "winsafe",
+]
 
 [[package]]
 name = "which"
@@ -9857,16 +10240,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "xattr"
-version = "1.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
-dependencies = [
- "libc",
- "rustix 1.1.4",
-]
-
-[[package]]
 name = "xdg-home"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10109,6 +10482,19 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zoneinfo64"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb2e5597efbe7c421da8a7fd396b20b571704e787c21a272eecf35dfe9d386f0"
+dependencies = [
+ "calendrical_calculations",
+ "icu_locale_core",
+ "potential_utf",
+ "resb",
+ "serde",
+]
 
 [[package]]
 name = "zopfli"

--- a/orbitdock-server/Cargo.toml
+++ b/orbitdock-server/Cargo.toml
@@ -17,12 +17,14 @@ authors = ["Robert DeLuca"]
 
 [workspace.dependencies]
 # Codex direct integration (OSS: https://github.com/openai/codex)
-codex-core = { git = "https://github.com/openai/codex", tag = "rust-v0.116.0" }
-codex-protocol = { git = "https://github.com/openai/codex", tag = "rust-v0.116.0" }
-codex-app-server-protocol = { git = "https://github.com/openai/codex", tag = "rust-v0.116.0" }
-codex-utils-absolute-path = { git = "https://github.com/openai/codex", tag = "rust-v0.116.0" }
-codex-arg0 = { git = "https://github.com/openai/codex", tag = "rust-v0.116.0" }
-codex-login = { git = "https://github.com/openai/codex", tag = "rust-v0.116.0" }
+codex-core = { git = "https://github.com/openai/codex", tag = "rust-v0.117.0" }
+codex-protocol = { git = "https://github.com/openai/codex", tag = "rust-v0.117.0" }
+codex-app-server-protocol = { git = "https://github.com/openai/codex", tag = "rust-v0.117.0" }
+codex-utils-absolute-path = { git = "https://github.com/openai/codex", tag = "rust-v0.117.0" }
+codex-arg0 = { git = "https://github.com/openai/codex", tag = "rust-v0.117.0" }
+codex-login = { git = "https://github.com/openai/codex", tag = "rust-v0.117.0" }
+codex-git-utils = { git = "https://github.com/openai/codex", tag = "rust-v0.117.0" }
+codex-exec-server = { git = "https://github.com/openai/codex", tag = "rust-v0.117.0" }
 
 # Async runtime
 tokio = { version = "1", features = ["full"] }
@@ -58,7 +60,7 @@ anyhow = "1"
 futures = "0.3"
 bytes = "1"
 notify = "7"
-arc-swap = "1"
+arc-swap = "1.9"
 dashmap = "6"
 reqwest = { version = "0.12", features = ["json"] }
 clap = { version = "4", features = ["derive", "env"] }
@@ -77,6 +79,9 @@ orbitdock-connector-core = { path = "crates/connector-core" }
 orbitdock-connector-claude = { path = "crates/connector-claude" }
 orbitdock-connector-codex = { path = "crates/connector-codex" }
 orbitdock-server = { path = "crates/server" }
+
+# Vendor OpenSSL for codex-core transitive dependencies (no libssl-dev needed)
+openssl = { version = "0.10", features = ["vendored"] }
 
 # Patches required by codex-core transitive dependencies
 [patch.crates-io]

--- a/orbitdock-server/crates/connector-codex/Cargo.toml
+++ b/orbitdock-server/crates/connector-codex/Cargo.toml
@@ -15,6 +15,8 @@ codex-login = { workspace = true }
 codex-protocol = { workspace = true }
 codex-app-server-protocol = { workspace = true }
 codex-utils-absolute-path = { workspace = true }
+codex-git-utils = { workspace = true }
+codex-exec-server = { workspace = true }
 tokio = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
@@ -24,3 +26,4 @@ tracing = { workspace = true }
 uuid = { workspace = true }
 base64 = { workspace = true }
 toml = "0.9"
+openssl = { workspace = true }

--- a/orbitdock-server/crates/connector-codex/src/auth.rs
+++ b/orbitdock-server/crates/connector-codex/src/auth.rs
@@ -301,14 +301,14 @@ impl CodexAuthService {
     fn auth_mode_from_auth(auth: &CodexAuth) -> CodexAuthMode {
         match auth.auth_mode() {
             AuthMode::ApiKey => CodexAuthMode::ApiKey,
-            AuthMode::Chatgpt => CodexAuthMode::Chatgpt,
+            AuthMode::Chatgpt | AuthMode::ChatgptAuthTokens => CodexAuthMode::Chatgpt,
         }
     }
 
     fn account_from_auth(auth: &CodexAuth) -> CodexAccount {
         match auth.auth_mode() {
             AuthMode::ApiKey => CodexAccount::ApiKey,
-            AuthMode::Chatgpt => CodexAccount::Chatgpt {
+            AuthMode::Chatgpt | AuthMode::ChatgptAuthTokens => CodexAccount::Chatgpt {
                 email: auth.get_account_email(),
                 plan_type: auth
                     .account_plan_type()

--- a/orbitdock-server/crates/connector-codex/src/config.rs
+++ b/orbitdock-server/crates/connector-codex/src/config.rs
@@ -5,6 +5,7 @@ use codex_core::config::{find_codex_home, Config, ConfigOverrides};
 use codex_core::models_manager::collaboration_mode_presets::CollaborationModesConfig;
 use codex_core::models_manager::manager::RefreshStrategy;
 use codex_core::{AuthManager, ThreadManager};
+use codex_exec_server::EnvironmentManager;
 use codex_protocol::config_types::{
     CollaborationMode, CollaborationModeMask, ModeKind, Personality, ReasoningSummary, ServiceTier,
     Settings,
@@ -155,6 +156,7 @@ impl CodexConnector {
             auth_manager.clone(),
             SessionSource::Mcp,
             CollaborationModesConfig::default(),
+            Arc::new(EnvironmentManager::new(None)),
         ));
         Self::finalize_reasoning_summary(&mut config, thread_manager.as_ref()).await;
 
@@ -283,6 +285,7 @@ impl CodexConnector {
             auth_manager.clone(),
             SessionSource::Mcp,
             CollaborationModesConfig::default(),
+            Arc::new(EnvironmentManager::new(None)),
         ));
         Self::finalize_reasoning_summary(&mut config, thread_manager.as_ref()).await;
 
@@ -493,6 +496,7 @@ pub async fn discover_models() -> Result<Vec<orbitdock_protocol::CodexModelOptio
         auth_manager,
         SessionSource::Mcp,
         CollaborationModesConfig::default(),
+        Arc::new(EnvironmentManager::new(None)),
     ));
 
     let mut models: Vec<orbitdock_protocol::CodexModelOption> = Vec::new();

--- a/orbitdock-server/crates/connector-codex/src/event_mapping/lifecycle.rs
+++ b/orbitdock-server/crates/connector-codex/src/event_mapping/lifecycle.rs
@@ -89,9 +89,9 @@ pub(crate) async fn handle_session_configured(
         *effort = event.reasoning_effort;
     }
 
-    let git_info = codex_core::git_info::collect_git_info(&event.cwd).await;
+    let git_info = codex_git_utils::collect_git_info(&event.cwd).await;
     let (branch, sha) = match git_info {
-        Some(info) => (info.branch, info.commit_hash),
+        Some(info) => (info.branch, info.commit_hash.map(|s| s.0)),
         None => (None, None),
     };
 

--- a/orbitdock-server/crates/connector-codex/src/event_mapping/tools.rs
+++ b/orbitdock-server/crates/connector-codex/src/event_mapping/tools.rs
@@ -60,9 +60,9 @@ pub(crate) async fn handle_exec_command_begin(
     }
 
     let new_cwd = event.cwd.to_string_lossy().to_string();
-    let git_info = codex_core::git_info::collect_git_info(&event.cwd).await;
+    let git_info = codex_git_utils::collect_git_info(&event.cwd).await;
     let (new_branch, new_sha) = match git_info {
-        Some(info) => (info.branch, info.commit_hash),
+        Some(info) => (info.branch, info.commit_hash.map(|s| s.0)),
         None => (None, None),
     };
 

--- a/orbitdock-server/crates/connector-codex/src/session_ops.rs
+++ b/orbitdock-server/crates/connector-codex/src/session_ops.rs
@@ -3,9 +3,10 @@ use std::path::Path;
 use std::path::PathBuf;
 
 use codex_app_server_protocol::{
-    MarketplaceInterface, PluginAuthPolicy, PluginInstallParams, PluginInstallPolicy,
-    PluginInstallResponse, PluginInterface, PluginListResponse, PluginMarketplaceEntry,
-    PluginSource, PluginSummary, PluginUninstallParams, PluginUninstallResponse,
+    MarketplaceInterface, MarketplaceLoadErrorInfo, PluginAuthPolicy, PluginInstallParams,
+    PluginInstallPolicy, PluginInstallResponse, PluginInterface, PluginListResponse,
+    PluginMarketplaceEntry, PluginSource, PluginSummary, PluginUninstallParams,
+    PluginUninstallResponse,
 };
 use codex_core::auth::{AuthCredentialsStoreMode, AuthManager};
 use codex_core::SteerInputError;
@@ -291,6 +292,11 @@ impl CodexConnector {
                     "Turn mismatch: expected {expected}, got {actual}"
                 )))
             }
+            Err(SteerInputError::ActiveTurnNotSteerable { turn_kind }) => {
+                Err(ConnectorError::ProviderError(format!(
+                    "Active turn is not steerable: {turn_kind:?}"
+                )))
+            }
         }
     }
 
@@ -327,7 +333,7 @@ impl CodexConnector {
         if force_remote_sync {
             let auth = self.plugin_auth().await;
             if let Err(err) = plugins_manager
-                .sync_plugins_from_remote(&config, auth.as_ref())
+                .sync_plugins_from_remote(&config, auth.as_ref(), false)
                 .await
             {
                 remote_sync_error = Some(err.to_string());
@@ -343,32 +349,44 @@ impl CodexConnector {
             .collect::<Result<_, _>>()?;
 
         let marketplaces = tokio::task::spawn_blocking(move || {
-            let marketplaces = plugins_manager.list_marketplaces_for_config(&config, &roots)?;
-            Ok::<Vec<PluginMarketplaceEntry>, codex_core::plugins::MarketplaceError>(
-                marketplaces
-                    .into_iter()
-                    .filter_map(|marketplace| {
-                        let plugins = marketplace
-                            .plugins
-                            .into_iter()
-                            .filter(|plugin| {
-                                session_source.matches_product_restriction(&plugin.policy.products)
-                            })
-                            .map(map_plugin_summary)
-                            .collect::<Vec<_>>();
-
-                        (!plugins.is_empty()).then_some(PluginMarketplaceEntry {
-                            name: marketplace.name,
-                            path: marketplace.path,
-                            interface: marketplace.interface.map(|interface| {
-                                MarketplaceInterface {
-                                    display_name: interface.display_name,
-                                }
-                            }),
-                            plugins,
+            let outcome = plugins_manager.list_marketplaces_for_config(&config, &roots)?;
+            let marketplace_load_errors: Vec<MarketplaceLoadErrorInfo> = outcome
+                .errors
+                .into_iter()
+                .map(|e| MarketplaceLoadErrorInfo {
+                    marketplace_path: e.path,
+                    message: e.message,
+                })
+                .collect();
+            let marketplaces: Vec<PluginMarketplaceEntry> = outcome
+                .marketplaces
+                .into_iter()
+                .filter_map(|marketplace| {
+                    let plugins = marketplace
+                        .plugins
+                        .into_iter()
+                        .filter(|plugin| {
+                            session_source.matches_product_restriction(
+                                plugin.policy.products.as_deref().unwrap_or(&[]),
+                            )
                         })
+                        .map(map_plugin_summary)
+                        .collect::<Vec<_>>();
+
+                    (!plugins.is_empty()).then_some(PluginMarketplaceEntry {
+                        name: marketplace.name,
+                        path: marketplace.path,
+                        interface: marketplace.interface.map(|interface| {
+                            MarketplaceInterface {
+                                display_name: interface.display_name,
+                            }
+                        }),
+                        plugins,
                     })
-                    .collect(),
+                })
+                .collect();
+            Ok::<(Vec<PluginMarketplaceEntry>, Vec<MarketplaceLoadErrorInfo>), codex_core::plugins::MarketplaceError>(
+                (marketplaces, marketplace_load_errors),
             )
         })
         .await
@@ -379,9 +397,13 @@ impl CodexConnector {
             ConnectorError::ProviderError(format!("Failed to list plugin marketplaces: {}", e))
         })?;
 
+        let (marketplaces, marketplace_load_errors) = marketplaces;
+
         Ok(PluginListResponse {
             marketplaces,
+            marketplace_load_errors,
             remote_sync_error,
+            featured_plugin_ids: Vec::new(),
         })
     }
 

--- a/orbitdock-server/crates/connector-codex/src/timeline.rs
+++ b/orbitdock-server/crates/connector-codex/src/timeline.rs
@@ -249,6 +249,8 @@ fn hook_entry_text(entry: &HookOutputEntry) -> Option<String> {
 
 fn hook_event_label(run: &HookRunSummary) -> &'static str {
     match run.event_name {
+        codex_protocol::protocol::HookEventName::PreToolUse => "pre_tool_use",
+        codex_protocol::protocol::HookEventName::PostToolUse => "post_tool_use",
         codex_protocol::protocol::HookEventName::SessionStart => "session start",
         codex_protocol::protocol::HookEventName::UserPromptSubmit => "prompt submit",
         codex_protocol::protocol::HookEventName::Stop => "stop",


### PR DESCRIPTION
## Summary

- Bumps codex-rs dependency from `rust-v0.116.0` to `rust-v0.117.0`
- Fixes repeated migration 21 mismatch warnings when OrbitDock reads Codex state DBs created by Codex CLI 0.117.0
- Adapts connector-codex to all 0.117.0 API changes (moved modules, new enum variants, changed signatures)
- Bumps arc-swap 1.8 -> 1.9 and adds vendored openssl for build environments without libssl-dev

Closes #223

## Test plan

- [ ] `make rust-check` passes
- [ ] `make rust-test` passes
- [ ] Start OrbitDock server against a Codex CLI 0.117.0 state directory - no migration warnings in logs
- [ ] Verify Codex session discovery, restore, and resume still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)