### PR TITLE
♻️ stabilize native session transport and scene architecture

### DIFF
--- a/OrbitDockNative/OrbitDock/Services/Server/API/ControlDeckClient.swift
+++ b/OrbitDockNative/OrbitDock/Services/Server/API/ControlDeckClient.swift
@@ -1,11 +1,6 @@
 import Foundation
 
 struct ControlDeckClient: Sendable {
-  struct SubmitTurnResponse: Decodable {
-    let accepted: Bool
-    let row: ServerConversationRowEntry
-  }
-
   private let http: ServerHTTPClient
   private let requestBuilder: HTTPRequestBuilder
 
@@ -80,7 +75,7 @@ struct ControlDeckClient: Sendable {
   func submitTurn(
     _ sessionId: String,
     request: ServerControlDeckSubmitTurnRequest
-  ) async throws -> SubmitTurnResponse {
+  ) async throws -> ServerControlDeckSubmitTurnResponse {
     try await http.post(
       "/api/sessions/\(requestBuilder.encodePathComponent(sessionId))/control-deck/submit",
       body: request

--- a/OrbitDockNative/OrbitDock/Services/Server/API/ConversationClient.swift
+++ b/OrbitDockNative/OrbitDock/Services/Server/API/ConversationClient.swift
@@ -43,10 +43,12 @@ struct ConversationClient: Sendable {
 
   func fetchConversationBootstrap(
     _ sessionId: String,
-    limit: Int = 200
+    limit: Int = 200,
+    source: String? = nil
   ) async throws -> ServerConversationBootstrap {
     let path = "/api/sessions/\(requestBuilder.encodePathComponent(sessionId))/conversation"
-    let message = "GET \(path)?limit=\(limit) session=\(sessionId)"
+    let sourceLabel = source?.isEmpty == false ? source! : "unspecified"
+    let message = "GET \(path)?limit=\(limit) session=\(sessionId) source=\(sourceLabel)"
     NSLog("[OrbitDock][ConversationClient] %@", message)
     return try await http.get(
       path,

--- a/OrbitDockNative/OrbitDock/Services/Server/Protocol/ControlDeckContracts.swift
+++ b/OrbitDockNative/OrbitDock/Services/Server/Protocol/ControlDeckContracts.swift
@@ -342,3 +342,9 @@ struct ServerControlDeckSubmitTurnRequest: Codable, Sendable {
   let skills: [ServerControlDeckSkillRef]
   let overrides: ServerControlDeckTurnOverrides?
 }
+
+struct ServerControlDeckSubmitTurnResponse: Codable, Sendable {
+  let accepted: Bool
+  let row: ServerConversationRowEntry
+  let snapshot: ServerControlDeckSnapshotPayload?
+}

--- a/OrbitDockNative/OrbitDock/Services/Server/Protocol/ServerConversationContracts.swift
+++ b/OrbitDockNative/OrbitDock/Services/Server/Protocol/ServerConversationContracts.swift
@@ -1203,12 +1203,14 @@ struct ServerReviewComment: Codable, Identifiable {
 struct ServerConversationBootstrap: Decodable {
   let session: ServerSessionState
   let rows: [ServerConversationRowEntry]
+  let replayCursor: UInt64
   let totalRowCount: UInt64
   let hasMoreBefore: Bool
   let oldestSequence: UInt64?
   let newestSequence: UInt64?
 
   enum CodingKeys: String, CodingKey {
+    case replayCursor = "replay_cursor"
     case session
     case rows
     case totalRowCount = "total_row_count"
@@ -1222,6 +1224,10 @@ struct ServerConversationBootstrap: Decodable {
     let container = try decoder.container(keyedBy: CodingKeys.self)
     session = try container.decode(ServerSessionState.self, forKey: .session)
     rows = try container.decodeIfPresent([ServerConversationRowEntry].self, forKey: .rows) ?? session.rows
+    replayCursor =
+      try container.decodeIfPresent(UInt64.self, forKey: .replayCursor)
+      ?? session.revision
+      ?? 0
     let directTotalRowCount = try container.decodeIfPresent(UInt64.self, forKey: .totalRowCount)
     let legacyTotalMessageCount = try container.decodeIfPresent(UInt64.self, forKey: .totalMessageCount)
     totalRowCount = directTotalRowCount ?? legacyTotalMessageCount ?? UInt64(rows.count)

--- a/OrbitDockNative/OrbitDock/Services/Server/SessionStore+CapabilitiesEvents.swift
+++ b/OrbitDockNative/OrbitDock/Services/Server/SessionStore+CapabilitiesEvents.swift
@@ -5,21 +5,22 @@ extension SessionStore {
   func routeCapabilitiesEvent(_ event: ServerEvent) -> Bool {
     switch event {
       case let .skillsList(sessionId, _, _):
-        notifySessionChanged(sessionId)
+        notifyCapabilitiesRefreshRequested(sessionId)
         return true
-      case .skillsUpdateAvailable(_):
+      case let .skillsUpdateAvailable(sessionId):
+        notifyCapabilitiesRefreshRequested(sessionId)
         return true
       case let .mcpToolsList(sessionId, _, _, _, _):
-        notifySessionChanged(sessionId)
+        notifyCapabilitiesRefreshRequested(sessionId)
         return true
       case let .mcpStartupUpdate(sessionId, _, _):
-        notifySessionChanged(sessionId)
+        notifyCapabilitiesRefreshRequested(sessionId)
         return true
       case let .mcpStartupComplete(sessionId, _, _, _):
-        notifySessionChanged(sessionId)
+        notifyCapabilitiesRefreshRequested(sessionId)
         return true
       case let .claudeCapabilities(sessionId, _, _, _, _):
-        notifySessionChanged(sessionId)
+        notifyCapabilitiesRefreshRequested(sessionId)
         return true
       default:
         return false

--- a/OrbitDockNative/OrbitDock/Services/Server/SessionStore+Commands.swift
+++ b/OrbitDockNative/OrbitDock/Services/Server/SessionStore+Commands.swift
@@ -19,7 +19,7 @@ extension SessionStore {
   func submitControlDeckTurn(
     sessionId: String,
     request: ServerControlDeckSubmitTurnRequest
-  ) async throws {
+  ) async throws -> ServerControlDeckSubmitTurnResponse {
     netLog(
       .info,
       cat: .store,
@@ -38,6 +38,7 @@ extension SessionStore {
     ))
     triggerLocalNamingIfNeeded(sessionId: sessionId, prompt: request.text)
     notifySessionChanged(sessionId)
+    return response
   }
 
   func sendMessage(

--- a/OrbitDockNative/OrbitDock/Services/Server/SessionStore+Events.swift
+++ b/OrbitDockNative/OrbitDock/Services/Server/SessionStore+Events.swift
@@ -14,8 +14,12 @@ extension SessionStore {
       case let .sessionDelta(sessionId, changes):
         applyLocalNamingStateDelta(sessionId: sessionId, changes: changes)
         notifySessionChanged(sessionId)
+        notifySessionDetailRefreshRequested(sessionId)
+        notifyControlDeckRefreshRequested(sessionId)
       case let .sessionEnded(sessionId, _):
         notifySessionChanged(sessionId)
+        notifySessionDetailRefreshRequested(sessionId)
+        notifyControlDeckRefreshRequested(sessionId)
       case let .conversationRowsChanged(sessionId, upserted, removedRowIds, _):
         notifyConversationRowDelta(sessionId, ConversationRowDelta(
           upserted: upserted,
@@ -23,56 +27,87 @@ extension SessionStore {
         ))
       case let .approvalRequested(sessionId, _, _):
         notifySessionChanged(sessionId)
+        notifySessionDetailRefreshRequested(sessionId)
+        notifyControlDeckRefreshRequested(sessionId)
       case let .approvalDecisionResult(sessionId, requestId, _, _, _):
         inFlightApprovalDispatches.remove(requestId)
         notifySessionChanged(sessionId)
+        notifySessionDetailRefreshRequested(sessionId)
+        notifyControlDeckRefreshRequested(sessionId)
       case .approvalsList, .approvalDeleted:
         break
       case let .tokensUpdated(sessionId, _, _):
         notifySessionChanged(sessionId)
+        notifySessionDetailRefreshRequested(sessionId)
+        notifyControlDeckRefreshRequested(sessionId)
       case let .modelsList(models):
         codexModels = models
       case .claudeModelsList:
         break
       case let .contextCompacted(sessionId):
         notifySessionChanged(sessionId)
+        notifySessionDetailRefreshRequested(sessionId)
         notifyConversationRefreshRequested(sessionId)
+        notifyControlDeckRefreshRequested(sessionId)
+        notifyReviewRefreshRequested(sessionId)
       case let .undoCompleted(sessionId, _, _):
         notifySessionChanged(sessionId)
+        notifySessionDetailRefreshRequested(sessionId)
         notifyConversationRefreshRequested(sessionId)
+        notifyControlDeckRefreshRequested(sessionId)
+        notifyReviewRefreshRequested(sessionId)
       case .undoStarted:
         break
       case let .threadRolledBack(sessionId, _):
         notifySessionChanged(sessionId)
+        notifySessionDetailRefreshRequested(sessionId)
         notifyConversationRefreshRequested(sessionId)
+        notifyControlDeckRefreshRequested(sessionId)
+        notifyReviewRefreshRequested(sessionId)
       case let .sessionForked(sourceSessionId, newSessionId, _):
         notifySessionChanged(sourceSessionId)
+        notifySessionDetailRefreshRequested(sourceSessionId)
         requestSelection(SessionRef(endpointId: endpointId, sessionId: newSessionId))
       case let .turnDiffSnapshot(sessionId, _, _, _, _, _, _, _):
         notifySessionChanged(sessionId)
+        notifySessionDetailRefreshRequested(sessionId)
+        notifyReviewRefreshRequested(sessionId)
       case let .reviewCommentCreated(sessionId, _, _):
         notifySessionChanged(sessionId)
+        notifyReviewRefreshRequested(sessionId)
       case let .reviewCommentUpdated(sessionId, _, _):
         notifySessionChanged(sessionId)
+        notifyReviewRefreshRequested(sessionId)
       case let .reviewCommentDeleted(sessionId, _, _):
         notifySessionChanged(sessionId)
+        notifyReviewRefreshRequested(sessionId)
       case let .reviewCommentsList(sessionId, _, _):
         notifySessionChanged(sessionId)
+        notifyReviewRefreshRequested(sessionId)
       case let .subagentToolsList(sessionId, _, _):
         notifySessionChanged(sessionId)
       case .shellStarted, .shellOutput:
         break
       case let .rateLimitEvent(sessionId, _):
         notifySessionChanged(sessionId)
+        notifySessionDetailRefreshRequested(sessionId)
+        notifyControlDeckRefreshRequested(sessionId)
       case let .promptSuggestion(sessionId, _):
         notifySessionChanged(sessionId)
+        notifySessionDetailRefreshRequested(sessionId)
+        notifyControlDeckRefreshRequested(sessionId)
       case let .filesPersisted(sessionId, _):
         notifySessionChanged(sessionId)
+        notifySessionDetailRefreshRequested(sessionId)
+        notifyControlDeckRefreshRequested(sessionId)
+        notifyReviewRefreshRequested(sessionId)
       case let .serverInfo(isPrimary, claims):
         serverIsPrimary = isPrimary
         serverPrimaryClaims = claims
       case let .permissionRules(sessionId, _):
         notifySessionChanged(sessionId)
+        notifySessionDetailRefreshRequested(sessionId)
+        notifyControlDeckRefreshRequested(sessionId)
       case let .error(code, message, sessionId):
         handleError(code, message, sessionId)
       case let .connectionStatusChanged(status):
@@ -146,10 +181,15 @@ extension SessionStore {
       switch code {
         case "lagged", "replay_oversized":
           notifySessionChanged(sessionId)
+          notifySessionDetailRefreshRequested(sessionId)
           notifyConversationRefreshRequested(sessionId)
+          notifyControlDeckRefreshRequested(sessionId)
+          notifyReviewRefreshRequested(sessionId)
           return
         case "session_detail_resync_required", "session_composer_resync_required":
           notifySessionChanged(sessionId)
+          notifySessionDetailRefreshRequested(sessionId)
+          notifyControlDeckRefreshRequested(sessionId)
           return
         case "conversation_resync_required":
           notifyConversationRefreshRequested(sessionId)
@@ -171,6 +211,11 @@ extension SessionStore {
     guard status == .connected else { return }
     connectionGeneration &+= 1
     let generation = connectionGeneration
+    NSLog(
+      "[OrbitDock][Bootstrap] connection-connected generation=%llu subscribedSessions=%ld",
+      generation,
+      subscribedSessions.count
+    )
 
     netLog(.info, cat: .store, "Connected — re-subscribing session surfaces", data: [
       "generation": generation,
@@ -191,6 +236,12 @@ extension SessionStore {
       }
     }
     connectionRecoveryTask = GenerationTask(generation: generation, task: task)
+    for sessionId in sessionsToResubscribe {
+      notifySessionDetailRefreshRequested(sessionId)
+      notifyControlDeckRefreshRequested(sessionId)
+      notifyReviewRefreshRequested(sessionId)
+      notifyCapabilitiesRefreshRequested(sessionId)
+    }
   }
 
   func rememberLocalNamingState(_ session: ServerSessionState) {

--- a/OrbitDockNative/OrbitDock/Services/Server/SessionStore.swift
+++ b/OrbitDockNative/OrbitDock/Services/Server/SessionStore.swift
@@ -125,6 +125,11 @@ final class SessionStore {
 
   @ObservationIgnored private var _rowDeltaContinuations: [String: [UUID: AsyncStream<ConversationRowDelta>.Continuation]] = [:]
   @ObservationIgnored private var _conversationRefreshContinuations: [String: [UUID: AsyncStream<Void>.Continuation]] = [:]
+  @ObservationIgnored private var _sessionDetailRefreshContinuations: [String: [UUID: AsyncStream<Void>.Continuation]] = [:]
+  @ObservationIgnored private var _controlDeckRefreshContinuations: [String: [UUID: AsyncStream<Void>.Continuation]] = [:]
+  @ObservationIgnored private var _reviewRefreshContinuations: [String: [UUID: AsyncStream<Void>.Continuation]] = [:]
+  @ObservationIgnored private var _capabilitiesRefreshContinuations: [String: [UUID: AsyncStream<Void>.Continuation]] = [:]
+  @ObservationIgnored private var _conversationRowCache: [String: [String: ServerConversationRowEntry]] = [:]
 
   /// Returns an AsyncStream that yields conversation row deltas as they arrive via WS.
   /// The conversation surface consumes this directly — rows are the one exception
@@ -136,6 +141,9 @@ final class SessionStore {
         _rowDeltaContinuations[sessionId] = [:]
       }
       _rowDeltaContinuations[sessionId]?[id] = continuation
+      if let replayDelta = cachedConversationReplayDelta(for: sessionId) {
+        continuation.yield(replayDelta)
+      }
       continuation.onTermination = { [weak self] _ in
         Task { @MainActor [weak self] in
           self?._rowDeltaContinuations[sessionId]?[id] = nil
@@ -146,6 +154,7 @@ final class SessionStore {
   }
 
   func notifyConversationRowDelta(_ sessionId: String, _ delta: ConversationRowDelta) {
+    cacheConversationRowDelta(sessionId, delta)
     _rowDeltaContinuations[sessionId]?.values.forEach { $0.yield(delta) }
   }
 
@@ -171,6 +180,86 @@ final class SessionStore {
 
   func notifyConversationRefreshRequested(_ sessionId: String) {
     _conversationRefreshContinuations[sessionId]?.values.forEach { $0.yield() }
+  }
+
+  func sessionDetailRefreshRequests(for sessionId: String) -> (stream: AsyncStream<Void>, id: UUID) {
+    let id = UUID()
+    let stream = AsyncStream<Void> { continuation in
+      if _sessionDetailRefreshContinuations[sessionId] == nil {
+        _sessionDetailRefreshContinuations[sessionId] = [:]
+      }
+      _sessionDetailRefreshContinuations[sessionId]?[id] = continuation
+      continuation.onTermination = { [weak self] _ in
+        Task { @MainActor [weak self] in
+          self?._sessionDetailRefreshContinuations[sessionId]?[id] = nil
+        }
+      }
+    }
+    return (stream, id)
+  }
+
+  func notifySessionDetailRefreshRequested(_ sessionId: String) {
+    _sessionDetailRefreshContinuations[sessionId]?.values.forEach { $0.yield() }
+  }
+
+  func controlDeckRefreshRequests(for sessionId: String) -> (stream: AsyncStream<Void>, id: UUID) {
+    let id = UUID()
+    let stream = AsyncStream<Void> { continuation in
+      if _controlDeckRefreshContinuations[sessionId] == nil {
+        _controlDeckRefreshContinuations[sessionId] = [:]
+      }
+      _controlDeckRefreshContinuations[sessionId]?[id] = continuation
+      continuation.onTermination = { [weak self] _ in
+        Task { @MainActor [weak self] in
+          self?._controlDeckRefreshContinuations[sessionId]?[id] = nil
+        }
+      }
+    }
+    return (stream, id)
+  }
+
+  func notifyControlDeckRefreshRequested(_ sessionId: String) {
+    _controlDeckRefreshContinuations[sessionId]?.values.forEach { $0.yield() }
+  }
+
+  func reviewRefreshRequests(for sessionId: String) -> (stream: AsyncStream<Void>, id: UUID) {
+    let id = UUID()
+    let stream = AsyncStream<Void> { continuation in
+      if _reviewRefreshContinuations[sessionId] == nil {
+        _reviewRefreshContinuations[sessionId] = [:]
+      }
+      _reviewRefreshContinuations[sessionId]?[id] = continuation
+      continuation.onTermination = { [weak self] _ in
+        Task { @MainActor [weak self] in
+          self?._reviewRefreshContinuations[sessionId]?[id] = nil
+        }
+      }
+    }
+    return (stream, id)
+  }
+
+  func notifyReviewRefreshRequested(_ sessionId: String) {
+    _reviewRefreshContinuations[sessionId]?.values.forEach { $0.yield() }
+  }
+
+  func capabilitiesRefreshRequests(for sessionId: String) -> (stream: AsyncStream<Void>, id: UUID) {
+    let id = UUID()
+    let stream = AsyncStream<Void> { continuation in
+      if _capabilitiesRefreshContinuations[sessionId] == nil {
+        _capabilitiesRefreshContinuations[sessionId] = [:]
+      }
+      _capabilitiesRefreshContinuations[sessionId]?[id] = continuation
+      continuation.onTermination = { [weak self] _ in
+        Task { @MainActor [weak self] in
+          self?._capabilitiesRefreshContinuations[sessionId]?[id] = nil
+        }
+      }
+    }
+    return (stream, id)
+  }
+
+  func notifyCapabilitiesRefreshRequested(_ sessionId: String) {
+    _capabilitiesRefreshContinuations[sessionId]?.values.forEach { $0.yield() }
   }
 
   // MARK: - Private tracking
@@ -310,6 +399,13 @@ final class SessionStore {
       recoveredSessionGenerations.removeValue(forKey: sessionId)
       removeRecoveredSurfaces(sessionId: sessionId, surfaces: requestedSurfaces)
     }
+    NSLog(
+      "[OrbitDock][Bootstrap] subscribe session=%@ generation=%llu forceRecovery=%@ surfaces=%@",
+      sessionId,
+      connectionGeneration,
+      forceRecovery ? "true" : "false",
+      requestedSurfaces.map(\.rawValue).sorted().joined(separator: ",")
+    )
     netLog(.info, cat: .store, "Subscribe: HTTP bootstrap + WS", sid: sessionId, data: [
       "surfaces": requestedSurfaces.map(\.rawValue).sorted(),
       "forceRecovery": forceRecovery,
@@ -340,20 +436,37 @@ final class SessionStore {
   @discardableResult
   func hydrateSessionFromHTTPBootstrap(
     sessionId: String,
-    generation: UInt64? = nil
+    generation: UInt64? = nil,
+    source: String = "unspecified"
   ) async -> SessionHTTPBootstrap? {
     let targetGeneration = generation ?? connectionGeneration
     let key = SessionGenerationKey(sessionId: sessionId, generation: targetGeneration)
 
     if let existing = inFlightBootstraps[key] {
+      NSLog(
+        "[OrbitDock][Bootstrap] reuse session=%@ generation=%llu source=%@",
+        sessionId,
+        targetGeneration,
+        source
+      )
       return await existing.task.value
     }
 
     let task = Task<SessionHTTPBootstrap?, Never> { [weak self] in
       guard let self else { return nil }
-      return await self.loadSessionBootstrap(sessionId: sessionId, generation: targetGeneration)
+      return await self.loadSessionBootstrap(
+        sessionId: sessionId,
+        generation: targetGeneration,
+        source: source
+      )
     }
 
+    NSLog(
+      "[OrbitDock][Bootstrap] start session=%@ generation=%llu source=%@",
+      sessionId,
+      targetGeneration,
+      source
+    )
     inFlightBootstraps[key] = GenerationTask(generation: targetGeneration, task: task)
     let result = await task.value
     inFlightBootstraps.removeValue(forKey: key)
@@ -394,6 +507,11 @@ final class SessionStore {
       _sessionChangeContinuations.removeValue(forKey: sessionId)
       _rowDeltaContinuations.removeValue(forKey: sessionId)
       _conversationRefreshContinuations.removeValue(forKey: sessionId)
+      _sessionDetailRefreshContinuations.removeValue(forKey: sessionId)
+      _controlDeckRefreshContinuations.removeValue(forKey: sessionId)
+      _reviewRefreshContinuations.removeValue(forKey: sessionId)
+      _capabilitiesRefreshContinuations.removeValue(forKey: sessionId)
+      _conversationRowCache.removeValue(forKey: sessionId)
     } else {
       removeRecoveredSurfaces(sessionId: sessionId, surfaces: targetSurfaces)
     }
@@ -436,14 +554,20 @@ final class SessionStore {
     inFlightSessionRecoveries.removeValue(forKey: key)
   }
 
-  private func loadSessionBootstrap(sessionId: String, generation: UInt64) async -> SessionHTTPBootstrap? {
+  private func loadSessionBootstrap(
+    sessionId: String,
+    generation: UInt64,
+    source: String
+  ) async -> SessionHTTPBootstrap? {
     netLog(.info, cat: .conv, "Fetching HTTP session bootstrap", sid: sessionId, data: [
       "generation": generation,
+      "source": source,
     ])
     do {
       let conversationBootstrap = try await clients.conversation.fetchConversationBootstrap(
         sessionId,
-        limit: 50
+        limit: 50,
+        source: source
       )
       let bootstrap = SessionHTTPBootstrap(
         conversation: conversationBootstrap
@@ -518,7 +642,11 @@ final class SessionStore {
   private func performSessionRecovery(sessionId: String, generation: UInt64) async {
     guard subscribedSessions.contains(sessionId) else { return }
 
-    let bootstrap = await hydrateSessionFromHTTPBootstrap(sessionId: sessionId, generation: generation)
+    let bootstrap = await hydrateSessionFromHTTPBootstrap(
+      sessionId: sessionId,
+      generation: generation,
+      source: "session-recovery"
+    )
     guard subscribedSessions.contains(sessionId), connectionGeneration == generation else {
       netLog(.debug, cat: .store, "Recovery became stale before subscribe", sid: sessionId, data: [
         "generation": generation,
@@ -597,18 +725,15 @@ final class SessionStore {
       "generation": generation,
       "connectionStatus": String(describing: connection.connectionStatus),
     ]
-    if surfaces.contains(.detail) {
-      subscribeData["detailRevision"] = sharedRevision as Any
-    }
-    if surfaces.contains(.composer) {
-      subscribeData["composerRevision"] = sharedRevision as Any
-    }
-    if surfaces.contains(.conversation) {
-      subscribeData["conversationRevision"] = sharedRevision as Any
+    for surface in surfaces {
+      subscribeData["\(surface.rawValue)Revision"] = sharedRevision as Any
+      subscribeData["\(surface.rawValue)ReplayCursor"] = "live-only"
     }
     netLog(.info, cat: .store, "WS subscribeSessionSurface", sid: sessionId, data: subscribeData)
     for surface in surfaces {
-      connection.subscribeSessionSurface(sessionId, surface: surface, sinceRevision: sharedRevision)
+      // After an authoritative HTTP bootstrap, surfaces attach to live WS updates
+      // without attempting a generic event-log replay from the HTTP revision.
+      connection.subscribeSessionSurface(sessionId, surface: surface, sinceRevision: nil)
     }
     var updatedRecoveredSurfaces = recoveredSessionSurfaceGenerations[sessionId] ?? [:]
     for surface in surfaces {
@@ -630,5 +755,33 @@ final class SessionStore {
       inFlightSessionRecoveries[key]?.task.cancel()
       inFlightSessionRecoveries.removeValue(forKey: key)
     }
+  }
+
+  private func cacheConversationRowDelta(_ sessionId: String, _ delta: ConversationRowDelta) {
+    var rowsByID = _conversationRowCache[sessionId] ?? [:]
+    for removedId in delta.removedIds {
+      rowsByID.removeValue(forKey: removedId)
+    }
+    for entry in delta.upserted {
+      rowsByID[entry.id] = entry
+    }
+    if rowsByID.isEmpty {
+      _conversationRowCache.removeValue(forKey: sessionId)
+    } else {
+      _conversationRowCache[sessionId] = rowsByID
+    }
+  }
+
+  private func cachedConversationReplayDelta(for sessionId: String) -> ConversationRowDelta? {
+    guard let rowsByID = _conversationRowCache[sessionId], !rowsByID.isEmpty else { return nil }
+    return ConversationRowDelta(
+      upserted: rowsByID.values.sorted { lhs, rhs in
+        if lhs.sequence == rhs.sequence {
+          return lhs.id < rhs.id
+        }
+        return lhs.sequence < rhs.sequence
+      },
+      removedIds: []
+    )
   }
 }

--- a/OrbitDockNative/OrbitDock/Services/Server/SessionStore.swift
+++ b/OrbitDockNative/OrbitDock/Services/Server/SessionStore.swift
@@ -39,6 +39,10 @@ struct SessionHTTPBootstrap {
   var sharedSurfaceRevision: UInt64? {
     conversation.session.revision
   }
+
+  var replayCursor: UInt64 {
+    conversation.replayCursor
+  }
 }
 
 typealias SessionSurfaceSet = Set<ServerSessionSurface>
@@ -719,6 +723,7 @@ final class SessionStore {
     surfaces: [ServerSessionSurface]
   ) {
     let sharedRevision = bootstrap?.sharedSurfaceRevision
+    let replayCursor = bootstrap?.replayCursor
     var subscribeData: [String: Any] = [
       "surfaces": surfaces.map(\.rawValue).sorted(),
       "bootstrapRowCount": bootstrap?.conversation.rows.count as Any,
@@ -727,13 +732,11 @@ final class SessionStore {
     ]
     for surface in surfaces {
       subscribeData["\(surface.rawValue)Revision"] = sharedRevision as Any
-      subscribeData["\(surface.rawValue)ReplayCursor"] = "live-only"
+      subscribeData["\(surface.rawValue)ReplayCursor"] = replayCursor as Any
     }
     netLog(.info, cat: .store, "WS subscribeSessionSurface", sid: sessionId, data: subscribeData)
     for surface in surfaces {
-      // After an authoritative HTTP bootstrap, surfaces attach to live WS updates
-      // without attempting a generic event-log replay from the HTTP revision.
-      connection.subscribeSessionSurface(sessionId, surface: surface, sinceRevision: nil)
+      connection.subscribeSessionSurface(sessionId, surface: surface, sinceRevision: replayCursor)
     }
     var updatedRecoveredSurfaces = recoveredSessionSurfaceGenerations[sessionId] ?? [:]
     for surface in surfaces {

--- a/OrbitDockNative/OrbitDock/Views/Conversation/ConversationTimelineDeltaPlanner.swift
+++ b/OrbitDockNative/OrbitDock/Views/Conversation/ConversationTimelineDeltaPlanner.swift
@@ -3,6 +3,7 @@ import Foundation
 struct ConversationLatestAppendEvent: Equatable {
   let count: Int
   let nonce: Int
+  let requiredVisibleSuffixCount: Int?
 }
 
 enum ConversationTimelineDeltaPlanner {

--- a/OrbitDockNative/OrbitDock/Views/Conversation/ConversationView.swift
+++ b/OrbitDockNative/OrbitDock/Views/Conversation/ConversationView.swift
@@ -18,10 +18,43 @@ struct ConversationView: View {
 
   let onJumpToLatest: () -> Void
   let onFollowStateChanged: (ConversationFollowState) -> Void
-  @State private var viewModel = ConversationViewModel()
+  @State private var viewModel: ConversationViewModel
   @State private var localFollowState = ConversationFollowState.initial
   private var bindingIdentity: String {
     "\(sessionStore.endpointId.uuidString):\(sessionId ?? ""):\(ObjectIdentifier(sessionStore))"
+  }
+
+  init(
+    sessionId: String?,
+    sessionStore: SessionStore,
+    endpointId: UUID? = nil,
+    isSessionActive: Bool = false,
+    displayStatus: SessionDisplayStatus = .ended,
+    currentTool: String? = nil,
+    showsOrbitStatusIndicator: Bool = true,
+    chatViewMode: ChatViewMode = .focused,
+    scrollCommand: Binding<ConversationScrollCommand?>,
+    onJumpToLatest: @escaping () -> Void,
+    onFollowStateChanged: @escaping (ConversationFollowState) -> Void
+  ) {
+    self.sessionId = sessionId
+    self.sessionStore = sessionStore
+    self.endpointId = endpointId
+    self.isSessionActive = isSessionActive
+    self.displayStatus = displayStatus
+    self.currentTool = currentTool
+    self.showsOrbitStatusIndicator = showsOrbitStatusIndicator
+    self.chatViewMode = chatViewMode
+    _scrollCommand = scrollCommand
+    self.onJumpToLatest = onJumpToLatest
+    self.onFollowStateChanged = onFollowStateChanged
+    _viewModel = State(
+      initialValue: ConversationViewModel(
+        sessionId: sessionId,
+        sessionStore: sessionStore,
+        viewMode: chatViewMode
+      )
+    )
   }
 
   var body: some View {
@@ -84,7 +117,7 @@ struct ConversationView: View {
       let (stream, _) = sessionStore.conversationRefreshRequests(for: sessionId)
       for await _ in stream {
         guard !Task.isCancelled else { break }
-        await viewModel.refresh()
+        await viewModel.refresh(forceHTTPResync: true)
       }
     }
     .task(id: bindingIdentity + ":rows") {

--- a/OrbitDockNative/OrbitDock/Views/Conversation/ConversationViewModel.swift
+++ b/OrbitDockNative/OrbitDock/Views/Conversation/ConversationViewModel.swift
@@ -6,7 +6,7 @@ import SwiftUI
 final class ConversationViewModel {
   var hasShownContent = false
   var currentSessionId: String?
-  var currentSessionStore = SessionStore.preview()
+  var currentSessionStore: SessionStore
   var currentViewMode: ChatViewMode = .focused
   var hasTimeline = false
   var timelineViewModel = ConversationTimelineViewModel()
@@ -28,6 +28,24 @@ final class ConversationViewModel {
   @ObservationIgnored private var bufferedRowDeltas: [SessionStore.ConversationRowDelta] = []
 
   private let pageSize = 50
+
+  init(
+    sessionId: String?,
+    sessionStore: SessionStore,
+    viewMode: ChatViewMode
+  ) {
+    currentSessionId = sessionId
+    currentSessionStore = sessionStore
+    currentViewMode = viewMode
+  }
+
+  convenience init() {
+    self.init(
+      sessionId: nil,
+      sessionStore: SessionStore.preview(),
+      viewMode: .focused
+    )
+  }
 
   func bind(sessionId: String?, sessionStore: SessionStore, viewMode: ChatViewMode) {
     let didChange = currentSessionId != sessionId || currentSessionStore !== sessionStore
@@ -51,10 +69,10 @@ final class ConversationViewModel {
     }
   }
 
-  /// Refresh the authoritative conversation bootstrap from HTTP.
-  /// The row-delta stream stays alive independently so transient transport
-  /// failures do not strand the screen.
-  func refresh() async {
+  /// Conversation bootstrap is owned by the root session subscription.
+  /// This view model only performs an HTTP refresh when the store explicitly
+  /// requests a conversation resync.
+  func refresh(forceHTTPResync: Bool = false) async {
     guard let sessionId = currentSessionId, !sessionId.isEmpty else { return }
     if isRefreshing {
       refreshQueued = true
@@ -73,25 +91,30 @@ final class ConversationViewModel {
 
     let store = currentSessionStore
 
-    do {
-      let bootstrap = try await store.clients.conversation.fetchConversationBootstrap(
-        sessionId,
-        limit: pageSize
-      )
+    guard store.isSessionSubscribed(sessionId) else {
+      drainBufferedRowDeltas()
+      return
+    }
+
+    if !forceHTTPResync {
+      drainBufferedRowDeltas()
+      return
+    }
+
+    if let bootstrap = await store.hydrateSessionFromHTTPBootstrap(
+      sessionId: sessionId,
+      source: "conversation-resync"
+    )?.conversation {
       guard currentSessionId == sessionId, currentSessionStore === store else { return }
       applyBootstrap(bootstrap, store: store)
-      drainBufferedRowDeltas()
-    } catch {
-      netLog(.error, cat: .store, "Conversation bootstrap failed", sid: sessionId, data: [
-        "error": String(describing: error),
-      ])
+    } else {
       guard currentSessionId == sessionId else { return }
       if rowEntries.isEmpty {
         conversationLoaded = true
         rebuildPresentation(changedEntries: [])
       }
-      drainBufferedRowDeltas()
     }
+    drainBufferedRowDeltas()
   }
 
   func handleConversationRowDelta(_ delta: SessionStore.ConversationRowDelta) {
@@ -137,7 +160,11 @@ final class ConversationViewModel {
         rowEntries = mergedPage.rows
         structureRevision += 1
         contentRevision += 1
-        rebuildPresentation(changedEntries: page.rows)
+        rebuildPresentation(
+          changedEntries: page.rows,
+          appendedEntryCount: 0,
+          visibilityEventRowID: nil
+        )
       } catch {
         netLog(.error, cat: .store, "Load older messages failed", sid: currentSessionId, data: [
           "error": String(describing: error),
@@ -163,7 +190,11 @@ final class ConversationViewModel {
     conversationLoaded = true
     structureRevision += 1
     contentRevision += 1
-    rebuildPresentation(changedEntries: bootstrap.rows)
+    rebuildPresentation(
+      changedEntries: bootstrap.rows,
+      appendedEntryCount: 0,
+      visibilityEventRowID: nil
+    )
 
     if let sourceId = bootstrap.session.forkedFromSessionId {
       forkOrigin = ConversationForkOriginPresentation(
@@ -205,7 +236,26 @@ final class ConversationViewModel {
       structureRevision += 1
     }
     contentRevision += 1
-    rebuildPresentation(changedEntries: changed)
+    let appendedEntryCount = structureChanged
+      ? changed.reduce(into: 0) { count, entry in
+          if entry.sequence > lastNewestSequence {
+            count += 1
+          }
+        }
+      : 0
+    let visibilityEventRowID = structureChanged
+      ? changed.max { lhs, rhs in
+          if lhs.sequence == rhs.sequence {
+            return lhs.id < rhs.id
+          }
+          return lhs.sequence < rhs.sequence
+        }?.id
+      : nil
+    rebuildPresentation(
+      changedEntries: changed,
+      appendedEntryCount: appendedEntryCount,
+      visibilityEventRowID: visibilityEventRowID
+    )
   }
 
   private func drainBufferedRowDeltas() {
@@ -217,7 +267,11 @@ final class ConversationViewModel {
     }
   }
 
-  private func rebuildPresentation(changedEntries: [ServerConversationRowEntry]) {
+  private func rebuildPresentation(
+    changedEntries: [ServerConversationRowEntry],
+    appendedEntryCount: Int = 0,
+    visibilityEventRowID: String? = nil
+  ) {
     let previousNewest = lastNewestSequence
     let timeline = ConversationTimelinePresentation(
       entries: rowEntries,
@@ -240,12 +294,17 @@ final class ConversationViewModel {
     if incomingHasTimeline {
       timelineViewModel.apply(presentation: timeline, viewMode: currentViewMode)
 
-      // Detect appended entries for auto-scroll
-      let appendedCount = changedEntries.filter { $0.sequence > previousNewest }.count
-      if appendedCount > 0, previousNewest > 0 {
+      let requiredVisibleSuffixCount = visibilityEventRowID.flatMap { rowID in
+        timelineViewModel.renderWindowRequiredToReveal(rowId: rowID)
+      }
+
+      // Live structural changes should be visible immediately, even when the
+      // inserted row does not qualify as a monotonic append by sequence.
+      if (appendedEntryCount > 0 && previousNewest > 0) || requiredVisibleSuffixCount != nil {
         latestAppendEvent = ConversationLatestAppendEvent(
-          count: appendedCount,
-          nonce: (latestAppendEvent?.nonce ?? 0) + 1
+          count: appendedEntryCount,
+          nonce: (latestAppendEvent?.nonce ?? 0) + 1,
+          requiredVisibleSuffixCount: requiredVisibleSuffixCount
         )
       }
       lastNewestSequence = rowEntries.last?.sequence ?? 0

--- a/OrbitDockNative/OrbitDock/Views/Conversation/TimelineScrollView.swift
+++ b/OrbitDockNative/OrbitDock/Views/Conversation/TimelineScrollView.swift
@@ -195,6 +195,21 @@ struct TimelineScrollView: View {
       }
       .onChange(of: latestAppendEvent) { _, event in
         guard let event else { return }
+        if let requiredVisibleSuffixCount = event.requiredVisibleSuffixCount,
+           requiredVisibleSuffixCount > renderedEntryLimit
+        {
+          var transaction = Transaction()
+          transaction.animation = nil
+          withTransaction(transaction) {
+            renderedEntryLimit = min(viewModel.displayedEntryCount, requiredVisibleSuffixCount)
+          }
+          if localFollowState.mode.isFollowing {
+            setPinnedScrollPosition()
+          }
+        }
+
+        guard event.count > 0 else { return }
+        guard !localFollowState.mode.isFollowing else { return }
         applyIntent(.latestEntriesAppended(event.count))
       }
       .onChange(of: scrollCommand) { _, command in
@@ -208,6 +223,7 @@ struct TimelineScrollView: View {
 
   private func applyIntent(_ intent: ConversationFollowIntent) {
     let plan = ConversationFollowPlanner.apply(current: localFollowState, intent: intent)
+    guard plan.state != localFollowState || plan.scrollAction != nil else { return }
     localFollowState = plan.state
     syncRenderedEntryLimit(totalCount: viewModel.displayedEntryCount, mode: plan.state.mode)
     onFollowStateChanged(plan.state)

--- a/OrbitDockNative/OrbitDock/Views/Review/ReviewCanvas.swift
+++ b/OrbitDockNative/OrbitDock/Views/Review/ReviewCanvas.swift
@@ -58,9 +58,37 @@ struct ReviewCanvas: View {
 
   /// Diff parsing cache — avoids re-parsing on every body evaluation
   @State private var diffParseCache = ReviewDiffParseCache()
-  @State var viewModel = ReviewCanvasViewModel()
+  @State var viewModel: ReviewCanvasViewModel
   private var bindingIdentity: String {
     "\(sessionStore.endpointId.uuidString):\(sessionId):\(ObjectIdentifier(sessionStore))"
+  }
+
+  init(
+    sessionId: String,
+    sessionStore: SessionStore,
+    projectPath: String,
+    isSessionActive: Bool,
+    compact: Bool = false,
+    navigateToFileId: Binding<String?>? = nil,
+    onDismiss: (() -> Void)? = nil,
+    selectedCommentIds: Binding<Set<String>>,
+    navigateToComment: Binding<ServerReviewComment?>? = nil
+  ) {
+    self.sessionId = sessionId
+    self.sessionStore = sessionStore
+    self.projectPath = projectPath
+    self.isSessionActive = isSessionActive
+    self.compact = compact
+    self.navigateToFileId = navigateToFileId
+    self.onDismiss = onDismiss
+    _selectedCommentIds = selectedCommentIds
+    self.navigateToComment = navigateToComment
+    _viewModel = State(
+      initialValue: ReviewCanvasViewModel(
+        sessionId: sessionId,
+        sessionStore: sessionStore
+      )
+    )
   }
 
   private var rawDiff: String? {
@@ -142,7 +170,7 @@ struct ReviewCanvas: View {
       await viewModel.refresh()
     }
     .task(id: bindingIdentity + ":ws") {
-      let (stream, _) = sessionStore.sessionChanges(for: sessionId)
+      let (stream, _) = sessionStore.reviewRefreshRequests(for: sessionId)
       for await _ in stream {
         await viewModel.refresh()
       }
@@ -172,8 +200,6 @@ struct ReviewCanvas: View {
     .onAppear {
       isCanvasFocused = true
       handlePendingNavigation()
-      viewModel.loadReviewCommentsIfNeeded()
-      viewModel.loadDiffsIfNeeded()
     }
   }
 

--- a/OrbitDockNative/OrbitDock/Views/Review/ReviewCanvasViewModel.swift
+++ b/OrbitDockNative/OrbitDock/Views/Review/ReviewCanvasViewModel.swift
@@ -5,7 +5,7 @@ import SwiftUI
 @Observable
 final class ReviewCanvasViewModel {
   var currentSessionId = ""
-  var currentSessionStore = SessionStore.preview()
+  var currentSessionStore: SessionStore
   var turnDiffs: [ServerTurnDiff] = []
   var currentDiff: String?
   var cumulativeDiff: String?
@@ -14,6 +14,21 @@ final class ReviewCanvasViewModel {
   @ObservationIgnored private var isHydratingDiffs = false
   @ObservationIgnored private var isRefreshing = false
   @ObservationIgnored private var refreshQueued = false
+
+  init(
+    sessionId: String,
+    sessionStore: SessionStore
+  ) {
+    currentSessionId = sessionId
+    currentSessionStore = sessionStore
+  }
+
+  convenience init() {
+    self.init(
+      sessionId: "",
+      sessionStore: SessionStore.preview()
+    )
+  }
 
   func bind(sessionId: String, sessionStore: SessionStore) {
     if currentSessionId != sessionId || ObjectIdentifier(currentSessionStore) != ObjectIdentifier(sessionStore) {

--- a/OrbitDockNative/OrbitDock/Views/SessionDetail/SessionDetailSceneModels.swift
+++ b/OrbitDockNative/OrbitDock/Views/SessionDetail/SessionDetailSceneModels.swift
@@ -1,0 +1,281 @@
+import Foundation
+import Observation
+import SwiftUI
+
+@MainActor
+@Observable
+final class SessionDetailConversationModel {
+  var scrollCommand: ConversationScrollCommand?
+  var followState = ConversationFollowState.initial
+
+  @ObservationIgnored private var scrollCommandNonce = 0
+
+  func reset() {
+    followState = .initial
+    scrollCommand = nil
+    scrollCommandNonce = 0
+  }
+
+  func handleFollowStateChanged(_ state: ConversationFollowState) {
+    followState = state
+  }
+
+  func jumpToLatest() {
+    scrollCommandNonce += 1
+    scrollCommand = .jumpToLatest(nonce: scrollCommandNonce)
+  }
+
+  func toggleFollowMode() {
+    scrollCommandNonce += 1
+    scrollCommand = .toggleFollow(nonce: scrollCommandNonce)
+  }
+
+  func openPendingApproval() {
+    scrollCommandNonce += 1
+    scrollCommand = .openPendingApproval(nonce: scrollCommandNonce)
+  }
+
+  func revealMessage(id: String) {
+    scrollCommandNonce += 1
+    scrollCommand = .revealMessage(id: id, nonce: scrollCommandNonce)
+  }
+}
+
+@MainActor
+@Observable
+final class SessionDetailReviewModel {
+  var showDiffBanner = false
+  var reviewFileId: String?
+  var navigateToComment: ServerReviewComment?
+  var selectedCommentIds: Set<String> = []
+
+  func reset() {
+    showDiffBanner = false
+    reviewFileId = nil
+    navigateToComment = nil
+    selectedCommentIds.removeAll()
+  }
+}
+
+@MainActor
+@Observable
+final class SessionDetailTerminalModel {
+  var showPanel = false
+  var activeTerminalId: String?
+  var showInteractiveSheet = false
+  var showInlineTerminal = false
+
+  func reset() {
+    showPanel = false
+    activeTerminalId = nil
+    showInteractiveSheet = false
+    showInlineTerminal = false
+  }
+}
+
+@MainActor
+@Observable
+final class SessionDetailWorkerModel {
+  var selectedWorkerId: String?
+  var state = SessionDetailWorkerState.empty
+  var rosterPresentation: SessionWorkerRosterPresentation?
+  var detailPresentation: SessionWorkerDetailPresentation?
+
+  func reset() {
+    selectedWorkerId = nil
+    state = .empty
+    rosterPresentation = nil
+    detailPresentation = nil
+  }
+
+  func apply(snapshotState: SessionDetailWorkerState, layoutConfig: LayoutConfiguration) {
+    let preservedTools = state.subagentTools
+    let preservedMessages = state.subagentMessages
+
+    state = SessionDetailWorkerState(
+      subagents: snapshotState.subagents,
+      subagentTools: preservedTools,
+      subagentMessages: preservedMessages,
+      timelineRevision: snapshotState.timelineRevision
+    )
+
+    rosterPresentation = SessionWorkerRosterPlanner.presentation(subagents: state.subagents)
+    syncSelectedWorker(layoutConfig: layoutConfig)
+  }
+
+  func syncLayout(_ layoutConfig: LayoutConfiguration) {
+    syncDetailPresentation(layoutConfig: layoutConfig)
+  }
+
+  func loadDetails(
+    sessionId: String,
+    sessionStore: SessionStore,
+    layoutConfig: LayoutConfiguration,
+    for workerId: String? = nil
+  ) {
+    guard let workerId = workerId ?? selectedWorkerId else { return }
+
+    Task {
+      let tools = try? await sessionStore.clients.sessions.getSubagentTools(
+        sessionId: sessionId,
+        subagentId: workerId
+      )
+      let messages = try? await sessionStore.clients.sessions.getSubagentMessages(
+        sessionId: sessionId,
+        subagentId: workerId
+      )
+
+      state.subagentTools[workerId] = tools ?? []
+      state.subagentMessages[workerId] = messages ?? []
+      syncDetailPresentation(layoutConfig: layoutConfig)
+    }
+  }
+
+  func select(
+    workerId: String,
+    sessionId: String,
+    sessionStore: SessionStore,
+    layoutConfig: LayoutConfiguration
+  ) {
+    guard !workerId.isEmpty else { return }
+    selectedWorkerId = workerId
+    syncDetailPresentation(layoutConfig: layoutConfig)
+    loadDetails(
+      sessionId: sessionId,
+      sessionStore: sessionStore,
+      layoutConfig: layoutConfig,
+      for: workerId
+    )
+  }
+
+  func focus(
+    workerId: String,
+    sessionId: String,
+    sessionStore: SessionStore,
+    layoutConfig: LayoutConfiguration
+  ) {
+    select(
+      workerId: workerId,
+      sessionId: sessionId,
+      sessionStore: sessionStore,
+      layoutConfig: layoutConfig
+    )
+  }
+
+  private func syncSelectedWorker(layoutConfig: LayoutConfiguration) {
+    let nextSelectedWorkerId = SessionWorkerRosterPlanner.preferredSelectedWorkerID(
+      currentSelectionID: selectedWorkerId,
+      subagents: state.subagents
+    )
+
+    if selectedWorkerId != nextSelectedWorkerId {
+      selectedWorkerId = nextSelectedWorkerId
+    }
+
+    syncDetailPresentation(layoutConfig: layoutConfig)
+  }
+
+  private func syncDetailPresentation(layoutConfig: LayoutConfiguration) {
+    guard layoutConfig != .reviewOnly, let selectedWorkerId else {
+      detailPresentation = nil
+      return
+    }
+
+    let hasLoadedWorkerPayload =
+      state.subagentTools[selectedWorkerId] != nil
+      || state.subagentMessages[selectedWorkerId] != nil
+
+    guard hasLoadedWorkerPayload else {
+      detailPresentation = nil
+      return
+    }
+
+    detailPresentation = SessionWorkerRosterPlanner.detailPresentation(
+      subagents: state.subagents,
+      selectedWorkerID: selectedWorkerId,
+      toolsByWorker: state.subagentTools,
+      messagesByWorker: state.subagentMessages,
+      timelineEntries: []
+    )
+  }
+}
+
+@MainActor
+@Observable
+final class SessionDetailWorktreeCleanupModel {
+  var dismissed = false
+  var deleteBranchOnCleanup = true
+  var isCleaningUp = false
+  var errorMessage: String?
+
+  func reset() {
+    dismissed = false
+    deleteBranchOnCleanup = true
+    isCleaningUp = false
+    errorMessage = nil
+  }
+
+  func bannerState(
+    worktreeState: SessionDetailWorktreeState,
+    worktreesByRepo: [String: [ServerWorktreeSummary]]
+  ) -> SessionDetailWorktreeCleanupBannerState? {
+    SessionDetailWorktreeCleanupPlanner.bannerState(
+      status: worktreeState.status,
+      isWorktree: worktreeState.isWorktree,
+      dismissed: dismissed,
+      worktree: worktree(
+        worktreeState: worktreeState,
+        worktreesByRepo: worktreesByRepo
+      ),
+      branch: worktreeState.branch,
+      isCleaningUp: isCleaningUp
+    )
+  }
+
+  func worktree(
+    worktreeState: SessionDetailWorktreeState,
+    worktreesByRepo: [String: [ServerWorktreeSummary]]
+  ) -> ServerWorktreeSummary? {
+    SessionDetailWorktreeCleanupPlanner.resolveWorktree(
+      worktreesByRepo: worktreesByRepo,
+      worktreeId: worktreeState.worktreeId,
+      projectPath: worktreeState.projectPath
+    )
+  }
+
+  func dismiss() {
+    dismissed = true
+  }
+
+  func cleanUp(
+    worktreeState: SessionDetailWorktreeState,
+    worktreesByRepo: [String: [ServerWorktreeSummary]],
+    sessionStore: SessionStore
+  ) {
+    guard let request = SessionDetailWorktreeCleanupPlanner.cleanupRequest(
+      worktree: worktree(worktreeState: worktreeState, worktreesByRepo: worktreesByRepo),
+      deleteBranch: deleteBranchOnCleanup
+    ) else {
+      return
+    }
+
+    isCleaningUp = true
+    errorMessage = nil
+
+    Task {
+      do {
+        try await sessionStore.clients.worktrees.removeWorktree(
+          worktreeId: request.worktreeId,
+          force: request.force,
+          deleteBranch: request.deleteBranch
+        )
+        withAnimation(Motion.gentle) {
+          dismissed = true
+        }
+      } catch {
+        errorMessage = error.localizedDescription
+      }
+      isCleaningUp = false
+    }
+  }
+}

--- a/OrbitDockNative/OrbitDock/Views/SessionDetail/SessionDetailSnapshot.swift
+++ b/OrbitDockNative/OrbitDock/Views/SessionDetail/SessionDetailSnapshot.swift
@@ -1,0 +1,214 @@
+import Foundation
+
+struct SessionDetailSnapshot {
+  let screenPresentation: SessionDetailScreenPresentation
+  let usageSource: SessionDetailUsageSource
+  let worktreeState: SessionDetailWorktreeState
+  let reviewState: SessionDetailReviewState
+  let workerState: SessionDetailWorkerState
+  let currentTool: String?
+  let lastActivityAt: Date?
+  let footerMode: SessionDetailFooterMode
+  let sessionStoreEndpointId: UUID
+  let sessionId: String
+
+  func reviewPresentation(layoutConfig: LayoutConfiguration) -> SessionDetailReviewSectionPresentation {
+    SessionDetailReviewSectionPresentation(
+      sessionId: sessionId,
+      projectPath: screenPresentation.projectPath,
+      isSessionActive: screenPresentation.isActive,
+      compact: layoutConfig == .split
+    )
+  }
+
+  var conversationPresentation: SessionDetailConversationSectionPresentation {
+    SessionDetailConversationSectionPresentation(
+      sessionId: sessionId,
+      endpointId: sessionStoreEndpointId,
+      isSessionActive: screenPresentation.isActive,
+      displayStatus: screenPresentation.displayStatus,
+      currentTool: currentTool,
+      projectPath: screenPresentation.projectPath,
+      canOpenFileInReview: screenPresentation.isDirect
+    )
+  }
+
+  static func empty(endpointId: UUID, sessionId: String) -> SessionDetailSnapshot {
+    SessionDetailSnapshot(
+      screenPresentation: .empty,
+      usageSource: .empty,
+      worktreeState: .empty,
+      reviewState: .empty,
+      workerState: .empty,
+      currentTool: nil,
+      lastActivityAt: nil,
+      footerMode: .passive,
+      sessionStoreEndpointId: endpointId,
+      sessionId: sessionId
+    )
+  }
+}
+
+struct SessionDetailScreenPresentation {
+  let displayName: String
+  let isDirect: Bool
+  let isActive: Bool
+  let displayStatus: SessionDisplayStatus
+  let workStatus: Session.WorkStatus
+  let provider: Provider
+  let model: String?
+  let effort: String?
+  let endpointName: String?
+  let projectPath: String
+  let issueIdentifier: String?
+  let missionId: String?
+  let capabilities: [SessionCapability]
+  let continuation: SessionContinuation
+  let debugContext: SessionDetailDebugContext
+
+  static let empty = SessionDetailScreenPresentation(
+    displayName: "Session",
+    isDirect: false,
+    isActive: false,
+    displayStatus: .ended,
+    workStatus: .unknown,
+    provider: .claude,
+    model: nil,
+    effort: nil,
+    endpointName: nil,
+    projectPath: "",
+    issueIdentifier: nil,
+    missionId: nil,
+    capabilities: [],
+    continuation: SessionContinuation(
+      endpointId: UUID(),
+      sessionId: "",
+      provider: .claude,
+      displayName: "Session",
+      projectPath: "",
+      model: nil,
+      hasGitRepository: false,
+      sourceServerInstanceId: nil,
+      sourceIsRemoteConnection: false
+    ),
+    debugContext: .empty
+  )
+}
+
+struct SessionDetailDebugContext {
+  let sessionId: String
+  let threadId: String?
+  let projectPath: String
+  let provider: Provider
+  let codexIntegrationMode: String?
+  let claudeIntegrationMode: String?
+
+  static let empty = SessionDetailDebugContext(
+    sessionId: "",
+    threadId: nil,
+    projectPath: "",
+    provider: .claude,
+    codexIntegrationMode: nil,
+    claudeIntegrationMode: nil
+  )
+}
+
+struct SessionDetailConversationSectionPresentation {
+  let sessionId: String
+  let endpointId: UUID
+  let isSessionActive: Bool
+  let displayStatus: SessionDisplayStatus
+  let currentTool: String?
+  let projectPath: String
+  let canOpenFileInReview: Bool
+
+  static let empty = SessionDetailConversationSectionPresentation(
+    sessionId: "",
+    endpointId: UUID(),
+    isSessionActive: false,
+    displayStatus: .ended,
+    currentTool: nil,
+    projectPath: "",
+    canOpenFileInReview: false
+  )
+}
+
+struct SessionDetailReviewSectionPresentation {
+  let sessionId: String
+  let projectPath: String
+  let isSessionActive: Bool
+  let compact: Bool
+
+  static let empty = SessionDetailReviewSectionPresentation(
+    sessionId: "",
+    projectPath: "",
+    isSessionActive: false,
+    compact: false
+  )
+}
+
+struct SessionDetailUsageSource {
+  let model: String?
+  let inputTokens: Int?
+  let outputTokens: Int?
+  let cachedTokens: Int?
+  let contextUsed: Int
+  let totalTokens: Int?
+
+  static let empty = SessionDetailUsageSource(
+    model: nil,
+    inputTokens: nil,
+    outputTokens: nil,
+    cachedTokens: nil,
+    contextUsed: 0,
+    totalTokens: nil
+  )
+}
+
+struct SessionDetailWorktreeState {
+  let status: Session.SessionStatus
+  let isWorktree: Bool
+  let branch: String?
+  let worktreeId: String?
+  let projectPath: String
+
+  static let empty = SessionDetailWorktreeState(
+    status: .active,
+    isWorktree: false,
+    branch: nil,
+    worktreeId: nil,
+    projectPath: ""
+  )
+}
+
+struct SessionDetailReviewState {
+  let diff: String?
+  let cumulativeDiff: String?
+  let turnDiffs: [ServerTurnDiff]
+  let reviewComments: [ServerReviewComment]
+  let isDirect: Bool
+  let turnCount: UInt64
+
+  static let empty = SessionDetailReviewState(
+    diff: nil,
+    cumulativeDiff: nil,
+    turnDiffs: [],
+    reviewComments: [],
+    isDirect: false,
+    turnCount: 0
+  )
+}
+
+struct SessionDetailWorkerState {
+  let subagents: [ServerSubagentInfo]
+  var subagentTools: [String: [ServerSubagentTool]]
+  var subagentMessages: [String: [ServerConversationRowEntry]]
+  let timelineRevision: Int
+
+  static let empty = SessionDetailWorkerState(
+    subagents: [],
+    subagentTools: [:],
+    subagentMessages: [:],
+    timelineRevision: 0
+  )
+}

--- a/OrbitDockNative/OrbitDock/Views/SessionDetail/SessionDetailSnapshotBuilder.swift
+++ b/OrbitDockNative/OrbitDock/Views/SessionDetail/SessionDetailSnapshotBuilder.swift
@@ -1,0 +1,131 @@
+import Foundation
+
+enum SessionDetailSnapshotBuilder {
+  static func build(
+    payload: ServerSessionDetailSnapshotPayload,
+    endpointId: UUID,
+    sourceServerInstanceId: String?,
+    sourceIsRemoteConnection: Bool
+  ) -> SessionDetailSnapshot {
+    let session = payload.session
+    let sessionId = session.id
+    let isDirect = session.controlMode == .direct
+    let isActive = session.lifecycleState != .ended
+    let provider: Provider = session.provider == .codex ? .codex : .claude
+    let displayName = resolveDisplayName(session)
+    let displayStatus = resolveDisplayStatus(session, isActive: isActive)
+    let workStatus = session.workStatus.toSessionWorkStatus()
+    let hasGitRepository = session.gitBranch != nil || session.currentCwd != nil || session.isWorktree
+
+    return SessionDetailSnapshot(
+      screenPresentation: SessionDetailScreenPresentation(
+        displayName: displayName,
+        isDirect: isDirect,
+        isActive: isActive,
+        displayStatus: displayStatus,
+        workStatus: workStatus,
+        provider: provider,
+        model: session.model,
+        effort: session.effort,
+        endpointName: nil,
+        projectPath: session.projectPath,
+        issueIdentifier: session.issueIdentifier,
+        missionId: session.missionId,
+        capabilities: isDirect ? [.direct] : (provider == .codex ? [.passive] : []),
+        continuation: SessionContinuation(
+          endpointId: endpointId,
+          sessionId: sessionId,
+          provider: provider,
+          displayName: displayName,
+          projectPath: session.projectPath,
+          model: session.model,
+          hasGitRepository: hasGitRepository,
+          sourceServerInstanceId: sourceServerInstanceId,
+          sourceIsRemoteConnection: sourceIsRemoteConnection
+        ),
+        debugContext: SessionDetailDebugContext(
+          sessionId: sessionId,
+          threadId: nil,
+          projectPath: session.projectPath,
+          provider: provider,
+          codexIntegrationMode: session.codexIntegrationMode.map { String(describing: $0) },
+          claudeIntegrationMode: session.claudeIntegrationMode.map { String(describing: $0) }
+        )
+      ),
+      usageSource: SessionDetailUsageSource(
+        model: session.model,
+        inputTokens: Int(session.tokenUsage.inputTokens),
+        outputTokens: Int(session.tokenUsage.outputTokens),
+        cachedTokens: Int(session.tokenUsage.cachedTokens),
+        contextUsed: Int(session.tokenUsage.contextWindow),
+        totalTokens: Int(session.tokenUsage.inputTokens + session.tokenUsage.outputTokens)
+      ),
+      worktreeState: SessionDetailWorktreeState(
+        status: mapSessionStatus(session.status),
+        isWorktree: session.isWorktree,
+        branch: session.gitBranch,
+        worktreeId: session.worktreeId,
+        projectPath: session.projectPath
+      ),
+      reviewState: SessionDetailReviewState(
+        diff: session.currentDiff,
+        cumulativeDiff: session.cumulativeDiff,
+        turnDiffs: session.turnDiffs,
+        reviewComments: [],
+        isDirect: isDirect,
+        turnCount: session.turnCount
+      ),
+      workerState: SessionDetailWorkerState(
+        subagents: session.subagents,
+        subagentTools: [:],
+        subagentMessages: [:],
+        timelineRevision: 0
+      ),
+      currentTool: session.pendingToolName,
+      lastActivityAt: parseServerTimestamp(session.lastActivityAt),
+      footerMode: SessionDetailFooterPlanner.mode(
+        controlMode: isDirect ? .direct : .passive,
+        lifecycleState: session.lifecycleState
+      ),
+      sessionStoreEndpointId: endpointId,
+      sessionId: sessionId
+    )
+  }
+
+  private static func resolveDisplayName(_ session: ServerSessionState) -> String {
+    SessionSemantics.displayName(
+      customName: session.customName,
+      summary: session.summary,
+      firstPrompt: session.firstPrompt,
+      projectName: session.projectName,
+      projectPath: session.projectPath
+    )
+  }
+
+  private static func resolveDisplayStatus(
+    _ session: ServerSessionState,
+    isActive: Bool
+  ) -> SessionDisplayStatus {
+    guard isActive else { return .ended }
+    if session.pendingApproval != nil {
+      switch session.pendingApproval?.type {
+      case .permissions: return .permission
+      case .question: return .question
+      default: return .permission
+      }
+    }
+    switch session.workStatus {
+    case .working: return .working
+    case .permission: return .permission
+    case .question: return .question
+    case .waiting, .reply, .ended: return .reply
+    }
+  }
+
+  private static func mapSessionStatus(_ status: ServerSessionStatus) -> Session.SessionStatus {
+    switch status {
+    case .active: .active
+    case .ended: .ended
+    }
+  }
+}

--- a/OrbitDockNative/OrbitDock/Views/SessionDetail/SessionDetailView+Lifecycle.swift
+++ b/OrbitDockNative/OrbitDock/Views/SessionDetail/SessionDetailView+Lifecycle.swift
@@ -3,29 +3,23 @@ import SwiftUI
 extension SessionDetailView {
   func handleReviewTurnCountChange(oldCount: UInt64, newCount: UInt64) {
     guard viewModel.handleReviewTurnCountChange(oldCount: oldCount, newCount: newCount) else { return }
-    withAnimation(Motion.standard) {
-      viewModel.showDiffBanner = true
-    }
-    Task {
-      try? await Task.sleep(for: .seconds(8))
-      await MainActor.run {
-        withAnimation(Motion.standard) {
-          viewModel.showDiffBanner = false
-        }
-      }
-    }
+    presentDiffBanner()
   }
 
   func handleDiffChange(oldDiff: String?, newDiff: String?) {
     guard viewModel.handleDiffChange(oldDiff: oldDiff, newDiff: newDiff) else { return }
+    presentDiffBanner()
+  }
+
+  private func presentDiffBanner() {
     withAnimation(Motion.standard) {
-      viewModel.showDiffBanner = true
+      viewModel.review.showDiffBanner = true
     }
     Task {
       try? await Task.sleep(for: .seconds(8))
       await MainActor.run {
         withAnimation(Motion.standard) {
-          viewModel.showDiffBanner = false
+          viewModel.review.showDiffBanner = false
         }
       }
     }
@@ -33,12 +27,22 @@ extension SessionDetailView {
 
   func selectWorkerInPanel(_ workerId: String) {
     guard !workerId.isEmpty else { return }
-    viewModel.selectWorkerInPanel(workerId)
+    viewModel.worker.select(
+      workerId: workerId,
+      sessionId: sessionId,
+      sessionStore: scopedServerState,
+      layoutConfig: viewModel.layoutConfig
+    )
   }
 
   func focusWorkerInDeck(_ workerId: String) {
     guard !workerId.isEmpty else { return }
     showWorkerPanel = true
-    viewModel.focusWorkerInDeck(workerId)
+    viewModel.worker.focus(
+      workerId: workerId,
+      sessionId: sessionId,
+      sessionStore: scopedServerState,
+      layoutConfig: viewModel.layoutConfig
+    )
   }
 }

--- a/OrbitDockNative/OrbitDock/Views/SessionDetail/SessionDetailView+Sections.swift
+++ b/OrbitDockNative/OrbitDock/Views/SessionDetail/SessionDetailView+Sections.swift
@@ -2,12 +2,12 @@ import SwiftUI
 
 extension SessionDetailView {
   var workerRosterPresentation: SessionWorkerRosterPresentation? {
-    viewModel.workerRosterPresentation
+    viewModel.worker.rosterPresentation
   }
 
   var workerDetailPresentation: SessionWorkerDetailPresentation? {
     guard showWorkerPanel else { return nil }
-    return viewModel.workerDetailPresentation
+    return viewModel.worker.detailPresentation
   }
 
   @ViewBuilder
@@ -19,7 +19,7 @@ extension SessionDetailView {
       SessionWorkerCompanionPanel(
         rosterPresentation: workerRosterPresentation,
         detailPresentation: workerDetailPresentation,
-        selectedWorkerID: viewModel.selectedWorkerId,
+        selectedWorkerID: viewModel.worker.selectedWorkerId,
         onSelectWorker: { workerId in
           selectWorkerInPanel(workerId)
         },
@@ -117,7 +117,7 @@ extension SessionDetailView {
       focusWorkerInDeck: workerRosterPresentation != nil ? { workerId in
         focusWorkerInDeck(workerId)
       } : nil,
-      scrollCommand: $viewModel.conversationScrollCommand,
+      scrollCommand: $viewModel.conversation.scrollCommand,
       onJumpToLatest: viewModel.jumpConversationToLatest,
       onFollowStateChanged: viewModel.handleConversationFollowStateChanged
     )
@@ -132,9 +132,9 @@ extension SessionDetailView {
       projectPath: presentation.projectPath,
       isSessionActive: presentation.isSessionActive,
       compact: presentation.compact,
-      reviewFileId: $viewModel.reviewFileId,
-      selectedCommentIds: $viewModel.selectedCommentIds,
-      navigateToComment: $viewModel.navigateToComment,
+      reviewFileId: $viewModel.review.reviewFileId,
+      selectedCommentIds: $viewModel.review.selectedCommentIds,
+      navigateToComment: $viewModel.review.navigateToComment,
       onDismiss: {
         withAnimation(Motion.gentle) {
           viewModel.dismissReview()
@@ -159,25 +159,27 @@ extension SessionDetailView {
   }
 
   var showWorktreeCleanupBanner: Bool {
-    viewModel.showWorktreeCleanupBanner
-  }
-
-  var worktreeForSession: ServerWorktreeSummary? {
-    viewModel.worktreeForSession
+    sessionDetailWorktreeCleanupState != nil
   }
 
   var worktreeCleanupBanner: some View {
     SessionDetailWorktreeCleanupBanner(
       bannerState: sessionDetailWorktreeCleanupState,
-      errorMessage: viewModel.worktreeCleanupError,
-      deleteBranchOnCleanup: $viewModel.deleteBranchOnCleanup,
-      isCleaningUp: viewModel.isCleaningUpWorktree,
+      errorMessage: viewModel.cleanup.errorMessage,
+      deleteBranchOnCleanup: $viewModel.cleanup.deleteBranchOnCleanup,
+      isCleaningUp: viewModel.cleanup.isCleaningUp,
       onKeep: {
         withAnimation(Motion.gentle) {
-          viewModel.worktreeCleanupDismissed = true
+          viewModel.cleanup.dismiss()
         }
       },
-      onCleanUp: viewModel.cleanUpWorktree
+      onCleanUp: {
+        viewModel.cleanup.cleanUp(
+          worktreeState: viewModel.worktreeState,
+          worktreesByRepo: scopedServerState.worktreesByRepo,
+          sessionStore: scopedServerState
+        )
+      }
     )
   }
 
@@ -191,5 +193,12 @@ extension SessionDetailView {
 
   var footerMode: SessionDetailFooterMode {
     viewModel.footerMode
+  }
+
+  var sessionDetailWorktreeCleanupState: SessionDetailWorktreeCleanupBannerState? {
+    viewModel.cleanup.bannerState(
+      worktreeState: viewModel.worktreeState,
+      worktreesByRepo: scopedServerState.worktreesByRepo
+    )
   }
 }

--- a/OrbitDockNative/OrbitDock/Views/SessionDetail/SessionDetailView+Sections.swift
+++ b/OrbitDockNative/OrbitDock/Views/SessionDetail/SessionDetailView+Sections.swift
@@ -101,9 +101,9 @@ extension SessionDetailView {
     let presentation = viewModel.conversationPresentation
 
     return SessionDetailConversationSection(
-      sessionId: presentation.sessionId,
+      sessionId: sessionId,
       sessionStore: scopedServerState,
-      endpointId: presentation.endpointId,
+      endpointId: endpointId,
       isSessionActive: presentation.isSessionActive,
       displayStatus: presentation.displayStatus,
       currentTool: presentation.currentTool,
@@ -127,7 +127,7 @@ extension SessionDetailView {
     let presentation = viewModel.reviewPresentation
 
     return SessionDetailReviewSection(
-      sessionId: presentation.sessionId,
+      sessionId: sessionId,
       sessionStore: scopedServerState,
       projectPath: presentation.projectPath,
       isSessionActive: presentation.isSessionActive,

--- a/OrbitDockNative/OrbitDock/Views/SessionDetail/SessionDetailView+TerminalChrome.swift
+++ b/OrbitDockNative/OrbitDock/Views/SessionDetail/SessionDetailView+TerminalChrome.swift
@@ -1,0 +1,398 @@
+import SwiftUI
+
+extension SessionDetailView {
+  func missionContextBanner(issueIdentifier: String, missionId: String?) -> some View {
+    HStack(spacing: Spacing.sm) {
+      Image(systemName: "target")
+        .font(.system(size: TypeScale.caption, weight: .bold))
+        .foregroundStyle(.blue)
+
+      Text(issueIdentifier)
+        .font(.system(size: TypeScale.caption, weight: .bold))
+        .foregroundStyle(.blue)
+
+      Text("Mission session")
+        .font(.system(size: TypeScale.caption))
+        .foregroundStyle(Color.textSecondary)
+
+      Spacer()
+
+      if let missionId {
+        Button {
+          router.navigateToMission(missionId: missionId, endpointId: endpointId)
+        } label: {
+          Text("View Mission")
+            .font(.system(size: TypeScale.caption, weight: .medium))
+            .foregroundStyle(.blue)
+        }
+        .buttonStyle(.plain)
+      }
+    }
+    .padding(.horizontal, Spacing.md)
+    .padding(.vertical, Spacing.sm)
+    .background(Color.blue.opacity(0.08))
+  }
+
+  @ViewBuilder
+  var terminalStripSection: some View {
+    if screenPresentation.isDirect {
+      EmptyView()
+    } else if viewModel.terminal.showPanel,
+      let terminalId = viewModel.terminal.activeTerminalId,
+      let session = terminalRegistry.session(for: terminalId)
+    {
+      VStack(spacing: 0) {
+        TerminalLiveStrip(session: session, onTap: {
+          handleTerminalStripTap(session: session)
+        }, fallbackPath: screenPresentation.projectPath)
+        .transition(.move(edge: .bottom).combined(with: .opacity))
+
+        if !isCompactLayout && viewModel.terminal.showInlineTerminal {
+          terminalPanel(session: session)
+            .transition(.move(edge: .bottom).combined(with: .opacity))
+        }
+      }
+      #if os(iOS)
+        .fullScreenCover(isPresented: $viewModel.terminal.showInteractiveSheet) {
+          TerminalInteractiveSheet(session: session)
+        }
+      #endif
+    } else if screenPresentation.isActive {
+      terminalLaunchStrip
+    }
+  }
+
+  var directSessionFooter: some View {
+    VStack(spacing: 0) {
+      if screenPresentation.isActive || screenPresentation.displayStatus != .ended {
+        directSessionDockHeader
+      }
+
+      if !isCompactLayout, let session = controlDeckTerminalSession, viewModel.terminal.showInlineTerminal {
+        dividerLine
+
+        terminalPanel(session: session)
+          .frame(maxWidth: .infinity, minHeight: 200, maxHeight: 320)
+          .transition(.move(edge: .bottom).combined(with: .opacity))
+      }
+
+      dividerLine
+
+      ControlDeckScreen(
+        sessionId: sessionId,
+        sessionStore: scopedServerState,
+        chromeStyle: .embedded,
+        terminalTitle: controlDeckTerminalSession?.title,
+        sessionDisplayStatus: screenPresentation.displayStatus,
+        currentTool: currentTool,
+        onFocusStateChange: { isDirectControlDeckFocused = $0 },
+        onToggleTerminal: {
+          if let session = controlDeckTerminalSession {
+            handleTerminalStripTap(session: session)
+          }
+        }
+      )
+    }
+    .background(
+      RoundedRectangle(cornerRadius: Radius.xl, style: .continuous)
+        .fill(Color.backgroundSecondary)
+    )
+    .overlay(
+      RoundedRectangle(cornerRadius: Radius.xl, style: .continuous)
+        .strokeBorder(
+          directSessionControlDeckBorderColor,
+          lineWidth: directSessionControlDeckBorderWidth
+        )
+    )
+    .padding(.horizontal, Spacing.sm)
+    .padding(.bottom, Spacing.xs)
+    #if os(iOS)
+      .fullScreenCover(isPresented: $viewModel.terminal.showInteractiveSheet) {
+        if let session = controlDeckTerminalSession {
+          TerminalInteractiveSheet(session: session)
+        } else {
+          Color.clear
+        }
+      }
+    #endif
+  }
+
+  @ViewBuilder
+  var topChrome: some View {
+    #if os(macOS)
+      HeaderView(
+        sessionId: sessionId,
+        endpointId: endpointId,
+        presentation: screenPresentation,
+        codexAccountStatus: scopedServerState.codexAccountStatus,
+        onEndSession: screenPresentation.isActive ? { viewModel.endSession() } : nil,
+        layoutConfig: screenPresentation.isDirect ? $viewModel.layoutConfig : nil,
+        chatViewMode: $chatViewMode,
+        workerPanelVisible: $showWorkerPanel,
+        hasWorkerPanelContent: workerRosterPresentation != nil
+      )
+
+      Divider()
+        .foregroundStyle(Color.panelBorder)
+    #else
+      iOSStatusStrip
+
+      Divider()
+        .foregroundStyle(Color.panelBorder)
+    #endif
+  }
+
+  private var controlDeckTerminalSession: TerminalSessionController? {
+    guard viewModel.terminal.showPanel,
+      let terminalId = viewModel.terminal.activeTerminalId
+    else { return nil }
+    return terminalRegistry.session(for: terminalId)
+  }
+
+  private var directSessionControlDeckBorderColor: Color {
+    if screenPresentation.displayStatus == .working {
+      return Color.feedbackWarning.opacity(OpacityTier.vivid)
+    }
+    if isDirectControlDeckFocused {
+      return Color.accent.opacity(0.5)
+    }
+    return Color.panelBorder
+  }
+
+  private var directSessionControlDeckBorderWidth: CGFloat {
+    isDirectControlDeckFocused || screenPresentation.displayStatus == .working ? 1.25 : 1
+  }
+
+  private var directSessionDockHeader: some View {
+    OrbitStatusIndicator(
+      displayStatus: screenPresentation.displayStatus,
+      currentTool: currentTool,
+      chromeStyle: .embedded,
+      showsDetail: !isCompactLayout
+    )
+    .overlay(alignment: .trailing) {
+      if let session = controlDeckTerminalSession {
+        inlineTerminalStrip(session: session)
+          .padding(.trailing, Spacing.md)
+      } else if screenPresentation.isActive {
+        inlineTerminalLaunchStrip
+          .padding(.trailing, Spacing.md)
+      }
+    }
+    .padding(.top, Spacing.xs)
+    .padding(.bottom, Spacing.xxs)
+  }
+
+  private var dividerLine: some View {
+    Color.surfaceBorder.opacity(0.28)
+      .frame(height: 1)
+      .padding(.horizontal, Spacing.md)
+  }
+
+  private var terminalLaunchTitle: String {
+    shortenedTerminalPath(screenPresentation.projectPath) ?? "Launch interactive shell"
+  }
+
+  private var inlineTerminalLaunchStrip: some View {
+    Button {
+      launchTerminal()
+    } label: {
+      HStack(spacing: Spacing.xs) {
+        Image(systemName: "chevron.right")
+          .font(.system(size: TypeScale.mini, weight: .bold, design: .monospaced))
+          .foregroundStyle(Color.terminal)
+        Text("Terminal")
+          .font(.system(size: TypeScale.meta, weight: .semibold, design: .monospaced))
+          .foregroundStyle(Color.textPrimary)
+        if !isCompactLayout {
+          Text("·")
+            .font(.system(size: TypeScale.meta, weight: .medium))
+            .foregroundStyle(Color.textQuaternary)
+          Text(terminalLaunchTitle)
+            .font(.system(size: TypeScale.meta, weight: .medium, design: .monospaced))
+            .foregroundStyle(Color.textQuaternary)
+            .lineLimit(1)
+          Image(systemName: "plus.circle.fill")
+            .font(.system(size: IconScale.xs, weight: .bold))
+            .foregroundStyle(Color.accent)
+        }
+      }
+      .padding(.leading, Spacing.sm)
+      .frame(maxWidth: isCompactLayout ? 160 : 420, alignment: .trailing)
+    }
+    .buttonStyle(.plain)
+    .help("Launch terminal")
+  }
+
+  private var terminalLaunchStrip: some View {
+    Button {
+      launchTerminal()
+    } label: {
+      HStack(alignment: .firstTextBaseline, spacing: Spacing.sm_) {
+        Image(systemName: "chevron.right")
+          .font(.system(size: TypeScale.mini, weight: .bold, design: .monospaced))
+          .foregroundStyle(Color.terminal)
+          .frame(width: 12, height: 16)
+
+        HStack(spacing: Spacing.xs) {
+          Text("Terminal")
+            .font(.system(size: TypeScale.meta, weight: .semibold, design: .monospaced))
+            .foregroundStyle(Color.textPrimary)
+
+          Text("·")
+            .font(.system(size: TypeScale.meta, weight: .medium))
+            .foregroundStyle(Color.textQuaternary)
+
+          Text(terminalLaunchTitle)
+            .font(.system(size: TypeScale.meta, weight: .medium, design: .monospaced))
+            .foregroundStyle(Color.textQuaternary)
+            .lineLimit(1)
+        }
+
+        Spacer(minLength: 0)
+
+        Image(systemName: "plus.circle.fill")
+          .font(.system(size: IconScale.xs, weight: .bold))
+          .foregroundStyle(Color.accent)
+      }
+      .padding(.horizontal, Spacing.md)
+      .padding(.vertical, Spacing.xs)
+      .contentShape(Rectangle())
+    }
+    .buttonStyle(.plain)
+    .help("Launch terminal")
+  }
+
+  private func inlineTerminalTitle(_ session: TerminalSessionController) -> String {
+    let title = session.title.trimmingCharacters(in: .whitespacesAndNewlines)
+    if title.isEmpty || title == "Terminal" {
+      return shortenedTerminalPath(screenPresentation.projectPath) ?? "Terminal"
+    }
+    if title.contains("/") {
+      return shortenedTerminalPath(title) ?? title
+    }
+    return title
+  }
+
+  private func inlineTerminalStrip(session: TerminalSessionController) -> some View {
+    Button {
+      handleTerminalStripTap(session: session)
+    } label: {
+      HStack(spacing: Spacing.xs) {
+        Text("Terminal")
+          .font(.system(size: TypeScale.meta, weight: .semibold, design: .monospaced))
+          .foregroundStyle(Color.textPrimary)
+        if !isCompactLayout {
+          Text("·")
+            .font(.system(size: TypeScale.meta, weight: .medium))
+            .foregroundStyle(Color.textQuaternary)
+          Text(inlineTerminalTitle(session))
+            .font(.system(size: TypeScale.meta, weight: .medium, design: .monospaced))
+            .foregroundStyle(Color.textSecondary)
+            .lineLimit(1)
+        }
+      }
+      .padding(.leading, Spacing.sm)
+      .frame(maxWidth: isCompactLayout ? 160 : 420, alignment: .trailing)
+    }
+    .buttonStyle(.plain)
+  }
+
+  private func shortenedTerminalPath(_ raw: String?) -> String? {
+    guard let raw else { return nil }
+    let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !trimmed.isEmpty else { return nil }
+
+    let path = trimmed.replacingOccurrences(of: "^~", with: NSHomeDirectory(), options: .regularExpression)
+    let home = NSHomeDirectory()
+    if path.hasPrefix(home) {
+      let suffix = String(path.dropFirst(home.count)).trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+      if suffix.isEmpty { return "~" }
+      if let last = suffix.split(separator: "/").last {
+        return "~/\(last)"
+      }
+      return "~"
+    }
+
+    if let last = path.split(separator: "/").last, !last.isEmpty {
+      return String(last)
+    }
+    return trimmed
+  }
+
+  private func handleTerminalStripTap(session: TerminalSessionController) {
+    if isCompactLayout {
+      #if os(iOS)
+        viewModel.terminal.showInteractiveSheet = true
+      #endif
+    } else {
+      withAnimation(Motion.gentle) {
+        viewModel.terminal.showInlineTerminal.toggle()
+      }
+    }
+  }
+
+  private func launchTerminal() {
+    let terminalId = "term-\(sessionId)-\(UUID().uuidString.prefix(8).lowercased())"
+    let controller = TerminalSessionController(terminalId: terminalId)
+
+    let endpointId = self.endpointId
+    controller.sendToServer = { [weak runtimeRegistry] data in
+      guard let runtime = runtimeRegistry?.runtimesByEndpointId[endpointId] else { return }
+      runtime.connection.sendTerminalInput(terminalId: terminalId, data: data)
+    }
+    controller.sendResize = { [weak runtimeRegistry] cols, rows in
+      guard let runtime = runtimeRegistry?.runtimesByEndpointId[endpointId] else { return }
+      runtime.connection.sendTerminalResize(terminalId: terminalId, cols: cols, rows: rows)
+    }
+
+    terminalRegistry.register(controller)
+
+    withAnimation(Motion.gentle) {
+      viewModel.terminal.activeTerminalId = terminalId
+      viewModel.terminal.showPanel = true
+      if isCompactLayout {
+        #if os(iOS)
+          viewModel.terminal.showInteractiveSheet = true
+        #endif
+      } else {
+        viewModel.terminal.showInlineTerminal = true
+      }
+    }
+    Platform.services.playHaptic(.selection)
+
+    let cwd = screenPresentation.projectPath
+    if let runtime = runtimeRegistry.runtimesByEndpointId[endpointId] {
+      let token = runtime.connection.addListener { [weak controller] event in
+        switch event {
+        case let .terminalOutput(tid, data) where tid == terminalId:
+          controller?.feedOutput(data)
+          controller?.setConnected(true)
+        case let .terminalExited(tid, _) where tid == terminalId:
+          controller?.setConnected(false)
+          controller?.removeListener?()
+        default:
+          break
+        }
+      }
+      let connection = runtime.connection
+      controller.removeListener = { [weak connection] in
+        connection?.removeListener(token)
+      }
+
+      connection.sendCreateTerminal(
+        terminalId: terminalId,
+        cwd: cwd.isEmpty ? "~" : cwd,
+        cols: 80,
+        rows: 24,
+        sessionId: sessionId
+      )
+    }
+  }
+
+  private func terminalPanel(session: TerminalSessionController) -> some View {
+    TerminalView(session: session)
+      .frame(maxWidth: .infinity, minHeight: 200, maxHeight: 320)
+      .background(Color.backgroundCode)
+  }
+}

--- a/OrbitDockNative/OrbitDock/Views/SessionDetail/SessionDetailView.swift
+++ b/OrbitDockNative/OrbitDock/Views/SessionDetail/SessionDetailView.swift
@@ -15,18 +15,30 @@ struct SessionDetailView: View {
   let endpointId: UUID
   let sessionStore: SessionStore
 
-  var scopedServerState: SessionStore {
-    viewModel.sessionStore
+  @State var viewModel: SessionDetailViewModel
+  @State private var isDirectControlDeckFocused = false
+
+  init(sessionId: String, endpointId: UUID, sessionStore: SessionStore) {
+    self.sessionId = sessionId
+    self.endpointId = endpointId
+    self.sessionStore = sessionStore
+    _viewModel = State(
+      initialValue: SessionDetailViewModel(
+        sessionId: sessionId,
+        endpointId: endpointId,
+        sessionStore: sessionStore
+      )
+    )
   }
 
-  @State var viewModel = SessionDetailViewModel()
-  @State private var isDirectControlDeckFocused = false
+  var scopedServerState: SessionStore {
+    sessionStore
+  }
 
   @AppStorage("chatViewMode") var chatViewMode: ChatViewMode = .focused
   @AppStorage("sessionDetail.showWorkerPanel") var showWorkerPanel = false
   private var bindingIdentity: String {
-    let resolvedStore = runtimeRegistry.sessionStore(for: endpointId, fallback: sessionStore)
-    return "\(endpointId.uuidString):\(sessionId):\(ObjectIdentifier(resolvedStore))"
+    "\(endpointId.uuidString):\(sessionId):\(ObjectIdentifier(sessionStore))"
   }
 
   var isCompactLayout: Bool {
@@ -95,8 +107,7 @@ struct SessionDetailView: View {
       viewModel.bind(
         sessionId: sessionId,
         endpointId: endpointId,
-        runtimeRegistry: runtimeRegistry,
-        fallbackStore: sessionStore,
+        sessionStore: sessionStore,
         modelPricingService: modelPricingService
       )
       await viewModel.refresh()
@@ -113,8 +124,7 @@ struct SessionDetailView: View {
       }
     }
     .task(id: bindingIdentity + ":ws") {
-      let resolvedStore = runtimeRegistry.sessionStore(for: endpointId, fallback: sessionStore)
-      let (stream, _) = resolvedStore.sessionChanges(for: sessionId)
+      let (stream, _) = sessionStore.sessionDetailRefreshRequests(for: sessionId)
       for await _ in stream {
         await viewModel.refresh()
       }

--- a/OrbitDockNative/OrbitDock/Views/SessionDetail/SessionDetailView.swift
+++ b/OrbitDockNative/OrbitDock/Views/SessionDetail/SessionDetailView.swift
@@ -16,7 +16,7 @@ struct SessionDetailView: View {
   let sessionStore: SessionStore
 
   @State var viewModel: SessionDetailViewModel
-  @State private var isDirectControlDeckFocused = false
+  @State var isDirectControlDeckFocused = false
 
   init(sessionId: String, endpointId: UUID, sessionStore: SessionStore) {
     self.sessionId = sessionId
@@ -112,15 +112,19 @@ struct SessionDetailView: View {
       )
       await viewModel.refresh()
       // Restore terminal if one already exists in the registry for this session
-      if viewModel.activeTerminalId == nil {
+      if viewModel.terminal.activeTerminalId == nil {
         let prefix = "term-\(sessionId)-"
         if let existingId = terminalRegistry.sessions.keys.first(where: { $0.hasPrefix(prefix) }) {
-          viewModel.activeTerminalId = existingId
-          viewModel.showTerminalPanel = true
+          viewModel.terminal.activeTerminalId = existingId
+          viewModel.terminal.showPanel = true
         }
       }
       if showWorkerPanel {
-        viewModel.loadSelectedWorkerTools()
+        viewModel.worker.loadDetails(
+          sessionId: sessionId,
+          sessionStore: scopedServerState,
+          layoutConfig: viewModel.layoutConfig
+        )
       }
     }
     .task(id: bindingIdentity + ":ws") {
@@ -144,7 +148,11 @@ struct SessionDetailView: View {
     .environment(scopedServerState)
     .onChange(of: showWorkerPanel) { _, visible in
       guard visible else { return }
-      viewModel.loadSelectedWorkerTools()
+      viewModel.worker.loadDetails(
+        sessionId: sessionId,
+        sessionStore: scopedServerState,
+        layoutConfig: viewModel.layoutConfig
+      )
     }
     // Layout keyboard shortcuts
     .onKeyPress(phases: .down) { keyPress in
@@ -171,12 +179,8 @@ struct SessionDetailView: View {
       handleReviewTurnCountChange(oldCount: oldCount, newCount: newCount)
     }
     .focusedSceneValue(\.sessionDetailTerminalToggle) {
-      viewModel.showTerminalPanel.toggle()
+      viewModel.terminal.showPanel.toggle()
     }
-  }
-
-  var sessionDetailWorktreeCleanupState: SessionDetailWorktreeCleanupBannerState? {
-    viewModel.sessionDetailWorktreeCleanupState
   }
 
   // MARK: - iOS Native Nav Bar
@@ -280,414 +284,6 @@ struct SessionDetailView: View {
 
   // Remaining sections and imperative handlers live in companion files so this root
   // stays focused on feature composition and lifecycle wiring.
-
-  // MARK: - Mission Context Banner
-
-  func missionContextBanner(issueIdentifier: String, missionId: String?) -> some View {
-    HStack(spacing: Spacing.sm) {
-      Image(systemName: "target")
-        .font(.system(size: TypeScale.caption, weight: .bold))
-        .foregroundStyle(.blue)
-
-      Text(issueIdentifier)
-        .font(.system(size: TypeScale.caption, weight: .bold))
-        .foregroundStyle(.blue)
-
-      Text("Mission session")
-        .font(.system(size: TypeScale.caption))
-        .foregroundStyle(Color.textSecondary)
-
-      Spacer()
-
-      if let missionId {
-        Button {
-          router.navigateToMission(missionId: missionId, endpointId: endpointId)
-        } label: {
-          Text("View Mission")
-            .font(.system(size: TypeScale.caption, weight: .medium))
-            .foregroundStyle(.blue)
-        }
-        .buttonStyle(.plain)
-      }
-    }
-    .padding(.horizontal, Spacing.md)
-    .padding(.vertical, Spacing.sm)
-    .background(Color.blue.opacity(0.08))
-  }
-
-  // MARK: - Terminal Strip
-
-  private var controlDeckTerminalSession: TerminalSessionController? {
-    guard viewModel.showTerminalPanel,
-          let terminalId = viewModel.activeTerminalId
-    else { return nil }
-    return terminalRegistry.session(for: terminalId)
-  }
-
-  @ViewBuilder
-  var terminalStripSection: some View {
-    if screenPresentation.isDirect {
-      EmptyView()
-    } else if viewModel.showTerminalPanel,
-       let terminalId = viewModel.activeTerminalId,
-       let session = terminalRegistry.session(for: terminalId) {
-      VStack(spacing: 0) {
-        TerminalLiveStrip(session: session, onTap: {
-          handleTerminalStripTap(session: session)
-        }, fallbackPath: screenPresentation.projectPath)
-        .transition(.move(edge: .bottom).combined(with: .opacity))
-
-        if !isCompactLayout && viewModel.showInlineTerminal {
-          terminalPanel(session: session)
-            .transition(.move(edge: .bottom).combined(with: .opacity))
-        }
-      }
-      #if os(iOS)
-      .fullScreenCover(isPresented: $viewModel.showTerminalInteractiveSheet) {
-        TerminalInteractiveSheet(session: session)
-      }
-      #endif
-    } else if screenPresentation.isActive {
-      // No terminal — show launch button
-      terminalLaunchStrip
-    }
-  }
-
-  private var directSessionFooter: some View {
-    VStack(spacing: 0) {
-      if screenPresentation.isActive || screenPresentation.displayStatus != .ended {
-        directSessionDockHeader
-      }
-
-      if !isCompactLayout, let session = controlDeckTerminalSession, viewModel.showInlineTerminal {
-        dividerLine
-
-        terminalPanel(session: session)
-          .frame(maxWidth: .infinity, minHeight: 200, maxHeight: 320)
-          .transition(.move(edge: .bottom).combined(with: .opacity))
-      }
-
-      dividerLine
-
-      ControlDeckScreen(
-        sessionId: sessionId,
-        sessionStore: scopedServerState,
-        chromeStyle: .embedded,
-        terminalTitle: controlDeckTerminalSession?.title,
-        sessionDisplayStatus: screenPresentation.displayStatus,
-        currentTool: currentTool,
-        onFocusStateChange: { isDirectControlDeckFocused = $0 },
-        onToggleTerminal: {
-          if let session = controlDeckTerminalSession {
-            handleTerminalStripTap(session: session)
-          }
-        }
-      )
-    }
-    .background(
-      RoundedRectangle(cornerRadius: Radius.xl, style: .continuous)
-        .fill(Color.backgroundSecondary)
-    )
-    .overlay(
-      RoundedRectangle(cornerRadius: Radius.xl, style: .continuous)
-        .strokeBorder(
-          directSessionControlDeckBorderColor,
-          lineWidth: directSessionControlDeckBorderWidth
-        )
-    )
-    .padding(.horizontal, Spacing.sm)
-    .padding(.bottom, Spacing.xs)
-    #if os(iOS)
-    .fullScreenCover(isPresented: $viewModel.showTerminalInteractiveSheet) {
-      if let session = controlDeckTerminalSession {
-        TerminalInteractiveSheet(session: session)
-      } else {
-        Color.clear
-      }
-    }
-    #endif
-  }
-
-  private var directSessionControlDeckBorderColor: Color {
-    if screenPresentation.displayStatus == .working {
-      return Color.feedbackWarning.opacity(OpacityTier.vivid)
-    }
-    if isDirectControlDeckFocused {
-      return Color.accent.opacity(0.5)
-    }
-    return Color.panelBorder
-  }
-
-  private var directSessionControlDeckBorderWidth: CGFloat {
-    isDirectControlDeckFocused || screenPresentation.displayStatus == .working ? 1.25 : 1
-  }
-
-  @ViewBuilder
-  private var topChrome: some View {
-    #if os(macOS)
-      // Custom header on macOS (no native nav bar)
-      HeaderView(
-        sessionId: sessionId,
-        endpointId: endpointId,
-        presentation: screenPresentation,
-        codexAccountStatus: scopedServerState.codexAccountStatus,
-        onEndSession: screenPresentation.isActive ? { viewModel.endSession() } : nil,
-        layoutConfig: screenPresentation.isDirect ? $viewModel.layoutConfig : nil,
-        chatViewMode: $chatViewMode,
-        workerPanelVisible: $showWorkerPanel,
-        hasWorkerPanelContent: workerRosterPresentation != nil
-      )
-
-      Divider()
-        .foregroundStyle(Color.panelBorder)
-    #else
-      // iOS: status strip only (native nav bar handles title + back)
-      iOSStatusStrip
-
-      Divider()
-        .foregroundStyle(Color.panelBorder)
-    #endif
-  }
-
-  @ViewBuilder
-  private var directSessionDockHeader: some View {
-    OrbitStatusIndicator(
-      displayStatus: screenPresentation.displayStatus,
-      currentTool: currentTool,
-      chromeStyle: .embedded,
-      showsDetail: !isCompactLayout
-    )
-    .overlay(alignment: .trailing) {
-      if let session = controlDeckTerminalSession {
-        inlineTerminalStrip(session: session)
-          .padding(.trailing, Spacing.md)
-      } else if screenPresentation.isActive {
-        inlineTerminalLaunchStrip
-          .padding(.trailing, Spacing.md)
-      }
-    }
-    .padding(.top, Spacing.xs)
-    .padding(.bottom, Spacing.xxs)
-  }
-
-  private var dividerLine: some View {
-    Color.surfaceBorder.opacity(0.28)
-      .frame(height: 1)
-      .padding(.horizontal, Spacing.md)
-  }
-
-  private var terminalLaunchTitle: String {
-    shortenedTerminalPath(screenPresentation.projectPath) ?? "Launch interactive shell"
-  }
-
-  private func inlineTerminalTitle(_ session: TerminalSessionController) -> String {
-    let title = session.title.trimmingCharacters(in: .whitespacesAndNewlines)
-    if title.isEmpty || title == "Terminal" {
-      return shortenedTerminalPath(screenPresentation.projectPath) ?? "Terminal"
-    }
-    if title.contains("/") {
-      return shortenedTerminalPath(title) ?? title
-    }
-    return title
-  }
-
-  private func inlineTerminalStrip(session: TerminalSessionController) -> some View {
-    Button {
-      handleTerminalStripTap(session: session)
-    } label: {
-      HStack(spacing: Spacing.xs) {
-        Text("Terminal")
-          .font(.system(size: TypeScale.meta, weight: .semibold, design: .monospaced))
-          .foregroundStyle(Color.textPrimary)
-        if !isCompactLayout {
-          Text("·")
-            .font(.system(size: TypeScale.meta, weight: .medium))
-            .foregroundStyle(Color.textQuaternary)
-          Text(inlineTerminalTitle(session))
-            .font(.system(size: TypeScale.meta, weight: .medium, design: .monospaced))
-            .foregroundStyle(Color.textSecondary)
-            .lineLimit(1)
-        }
-      }
-      .padding(.leading, Spacing.sm)
-      .frame(maxWidth: isCompactLayout ? 160 : 420, alignment: .trailing)
-    }
-    .buttonStyle(.plain)
-  }
-
-  private var inlineTerminalLaunchStrip: some View {
-    Button {
-      launchTerminal()
-    } label: {
-      HStack(spacing: Spacing.xs) {
-        Image(systemName: "chevron.right")
-          .font(.system(size: TypeScale.mini, weight: .bold, design: .monospaced))
-          .foregroundStyle(Color.terminal)
-        Text("Terminal")
-          .font(.system(size: TypeScale.meta, weight: .semibold, design: .monospaced))
-          .foregroundStyle(Color.textPrimary)
-        if !isCompactLayout {
-          Text("·")
-            .font(.system(size: TypeScale.meta, weight: .medium))
-            .foregroundStyle(Color.textQuaternary)
-          Text(terminalLaunchTitle)
-            .font(.system(size: TypeScale.meta, weight: .medium, design: .monospaced))
-            .foregroundStyle(Color.textQuaternary)
-            .lineLimit(1)
-          Image(systemName: "plus.circle.fill")
-            .font(.system(size: IconScale.xs, weight: .bold))
-            .foregroundStyle(Color.accent)
-        }
-      }
-      .padding(.leading, Spacing.sm)
-      .frame(maxWidth: isCompactLayout ? 160 : 420, alignment: .trailing)
-    }
-    .buttonStyle(.plain)
-    .help("Launch terminal")
-  }
-
-  private var terminalLaunchStrip: some View {
-    Button {
-      launchTerminal()
-    } label: {
-      HStack(alignment: .firstTextBaseline, spacing: Spacing.sm_) {
-        Image(systemName: "chevron.right")
-          .font(.system(size: TypeScale.mini, weight: .bold, design: .monospaced))
-          .foregroundStyle(Color.terminal)
-          .frame(width: 12, height: 16)
-
-        HStack(spacing: Spacing.xs) {
-          Text("Terminal")
-            .font(.system(size: TypeScale.meta, weight: .semibold, design: .monospaced))
-            .foregroundStyle(Color.textPrimary)
-
-          Text("·")
-            .font(.system(size: TypeScale.meta, weight: .medium))
-            .foregroundStyle(Color.textQuaternary)
-
-          Text(terminalLaunchTitle)
-            .font(.system(size: TypeScale.meta, weight: .medium, design: .monospaced))
-            .foregroundStyle(Color.textQuaternary)
-            .lineLimit(1)
-        }
-
-        Spacer(minLength: 0)
-
-        Image(systemName: "plus.circle.fill")
-          .font(.system(size: IconScale.xs, weight: .bold))
-          .foregroundStyle(Color.accent)
-      }
-      .padding(.horizontal, Spacing.md)
-      .padding(.vertical, Spacing.xs)
-      .contentShape(Rectangle())
-    }
-    .buttonStyle(.plain)
-    .help("Launch terminal")
-  }
-
-  private func shortenedTerminalPath(_ raw: String?) -> String? {
-    guard let raw else { return nil }
-    let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
-    guard !trimmed.isEmpty else { return nil }
-
-    let path = trimmed.replacingOccurrences(of: "^~", with: NSHomeDirectory(), options: .regularExpression)
-    let home = NSHomeDirectory()
-    if path.hasPrefix(home) {
-      let suffix = String(path.dropFirst(home.count)).trimmingCharacters(in: CharacterSet(charactersIn: "/"))
-      if suffix.isEmpty { return "~" }
-      if let last = suffix.split(separator: "/").last {
-        return "~/\(last)"
-      }
-      return "~"
-    }
-
-    if let last = path.split(separator: "/").last, !last.isEmpty {
-      return String(last)
-    }
-    return trimmed
-  }
-
-  private func handleTerminalStripTap(session: TerminalSessionController) {
-    if isCompactLayout {
-      #if os(iOS)
-      viewModel.showTerminalInteractiveSheet = true
-      #endif
-    } else {
-      withAnimation(Motion.gentle) {
-        viewModel.showInlineTerminal.toggle()
-      }
-    }
-  }
-
-  func launchTerminal() {
-    let terminalId = "term-\(sessionId)-\(UUID().uuidString.prefix(8).lowercased())"
-    let controller = TerminalSessionController(terminalId: terminalId)
-
-    let endpointId = self.endpointId
-    controller.sendToServer = { [weak runtimeRegistry] data in
-      guard let runtime = runtimeRegistry?.runtimesByEndpointId[endpointId] else { return }
-      runtime.connection.sendTerminalInput(terminalId: terminalId, data: data)
-    }
-    controller.sendResize = { [weak runtimeRegistry] cols, rows in
-      guard let runtime = runtimeRegistry?.runtimesByEndpointId[endpointId] else { return }
-      runtime.connection.sendTerminalResize(terminalId: terminalId, cols: cols, rows: rows)
-    }
-
-    terminalRegistry.register(controller)
-
-    // Show strip and open terminal immediately
-    withAnimation(Motion.gentle) {
-      viewModel.activeTerminalId = terminalId
-      viewModel.showTerminalPanel = true
-      if isCompactLayout {
-        #if os(iOS)
-        viewModel.showTerminalInteractiveSheet = true
-        #endif
-      } else {
-        viewModel.showInlineTerminal = true
-      }
-    }
-    Platform.services.playHaptic(.selection)
-
-    // Wire server connection and create PTY
-    let cwd = screenPresentation.projectPath
-    if let runtime = runtimeRegistry.runtimesByEndpointId[endpointId] {
-      let token = runtime.connection.addListener { [weak controller] event in
-        switch event {
-        case let .terminalOutput(tid, data) where tid == terminalId:
-          controller?.feedOutput(data)
-          controller?.setConnected(true)
-        case let .terminalExited(tid, _) where tid == terminalId:
-          controller?.setConnected(false)
-          controller?.removeListener?()
-        default:
-          break
-        }
-      }
-      let connection = runtime.connection
-      controller.removeListener = { [weak connection] in
-        connection?.removeListener(token)
-      }
-
-      connection.sendCreateTerminal(
-        terminalId: terminalId,
-        cwd: cwd.isEmpty ? "~" : cwd,
-        cols: 80,
-        rows: 24,
-        sessionId: sessionId
-      )
-    }
-  }
-
-  // MARK: - Terminal Panel (inline)
-
-  func terminalPanel(session: TerminalSessionController) -> some View {
-    TerminalView(session: session)
-      .frame(maxWidth: .infinity, minHeight: 200, maxHeight: 320)
-      .background(Color.backgroundCode)
-  }
-
-  // MARK: - Helpers
 
   var shouldSubscribeToServerSession: Bool {
     viewModel.shouldSubscribeToServerSession

--- a/OrbitDockNative/OrbitDock/Views/SessionDetail/SessionDetailViewModel.swift
+++ b/OrbitDockNative/OrbitDock/Views/SessionDetail/SessionDetailViewModel.swift
@@ -8,7 +8,7 @@ final class SessionDetailViewModel {
   var copiedResume = false
   var currentSessionId = ""
   var currentEndpointId = UUID()
-  var currentSessionStore = SessionStore.preview()
+  var currentSessionStore: SessionStore
   var selectedWorkerId: String?
   var conversationScrollCommand: ConversationScrollCommand?
   var conversationFollowState = ConversationFollowState.initial
@@ -55,21 +55,40 @@ final class SessionDetailViewModel {
   var currentTool: String?
   var lastActivityAt: Date?
 
+  init(
+    sessionId: String,
+    endpointId: UUID,
+    sessionStore: SessionStore
+  ) {
+    currentSessionId = sessionId
+    currentEndpointId = endpointId
+    currentSessionStore = sessionStore
+  }
+
+  convenience init() {
+    self.init(
+      sessionId: "",
+      endpointId: UUID(),
+      sessionStore: SessionStore.preview()
+    )
+  }
+
   func bind(
     sessionId: String,
     endpointId: UUID,
-    runtimeRegistry: ServerRuntimeRegistry,
-    fallbackStore: SessionStore,
+    sessionStore: SessionStore,
     modelPricingService: ModelPricingService
   ) {
-    let resolvedStore = runtimeRegistry.sessionStore(for: endpointId, fallback: fallbackStore)
     self.modelPricingService = modelPricingService
 
-    let didSessionChange = currentSessionId != sessionId || currentEndpointId != endpointId
+    let didSessionChange =
+      currentSessionId != sessionId
+      || currentEndpointId != endpointId
+      || currentSessionStore !== sessionStore
 
     currentSessionId = sessionId
     currentEndpointId = endpointId
-    currentSessionStore = resolvedStore
+    currentSessionStore = sessionStore
 
     if didSessionChange {
       conversationFollowState = .initial

--- a/OrbitDockNative/OrbitDock/Views/SessionDetail/SessionDetailViewModel.swift
+++ b/OrbitDockNative/OrbitDock/Views/SessionDetail/SessionDetailViewModel.swift
@@ -9,36 +9,21 @@ final class SessionDetailViewModel {
   var currentSessionId = ""
   var currentEndpointId = UUID()
   var currentSessionStore: SessionStore
-  var selectedWorkerId: String?
-  var conversationScrollCommand: ConversationScrollCommand?
-  var conversationFollowState = ConversationFollowState.initial
-  var selectedSkills: Set<String> = []
   var layoutConfig: LayoutConfiguration = .conversationOnly {
     didSet {
       syncSectionPresentations()
-      syncWorkerDetailPresentation()
+      worker.syncLayout(layoutConfig)
     }
   }
 
-  var showDiffBanner = false
-  var reviewFileId: String?
-  var navigateToComment: ServerReviewComment?
-  var selectedCommentIds: Set<String> = []
   var pendingApprovalPanelOpenSignal = 0
-  var worktreeCleanupDismissed = false
-  var deleteBranchOnCleanup = true
-  var isCleaningUpWorktree = false
-  var worktreeCleanupError: String?
-
-  /// Terminal panel state
-  var showTerminalPanel = false
-  var activeTerminalId: String?
-  var showTerminalInteractiveSheet = false
-  /// macOS: whether the inline terminal panel is expanded below the strip
-  var showInlineTerminal = false
+  var conversation = SessionDetailConversationModel()
+  var review = SessionDetailReviewModel()
+  var terminal = SessionDetailTerminalModel()
+  var worker = SessionDetailWorkerModel()
+  var cleanup = SessionDetailWorktreeCleanupModel()
 
   @ObservationIgnored private weak var modelPricingService: ModelPricingService?
-  @ObservationIgnored private var conversationScrollCommandNonce = 0
   @ObservationIgnored private var isRefreshing = false
   @ObservationIgnored private var refreshQueued = false
 
@@ -46,9 +31,6 @@ final class SessionDetailViewModel {
   var usageSource = SessionDetailUsageSource.empty
   var worktreeState = SessionDetailWorktreeState.empty
   var reviewState = SessionDetailReviewState.empty
-  var workerState = SessionDetailWorkerState.empty
-  var workerRosterPresentation: SessionWorkerRosterPresentation?
-  var workerDetailPresentation: SessionWorkerDetailPresentation?
   var conversationPresentation = SessionDetailConversationSectionPresentation.empty
   var reviewPresentation = SessionDetailReviewSectionPresentation.empty
   var footerMode: SessionDetailFooterMode = .passive
@@ -91,9 +73,11 @@ final class SessionDetailViewModel {
     currentSessionStore = sessionStore
 
     if didSessionChange {
-      conversationFollowState = .initial
-      conversationScrollCommand = nil
-      conversationScrollCommandNonce = 0
+      conversation.reset()
+      review.reset()
+      terminal.reset()
+      worker.reset()
+      cleanup.reset()
       pendingApprovalPanelOpenSignal = 0
     }
   }
@@ -121,23 +105,12 @@ final class SessionDetailViewModel {
     )
   }
 
-  var sessionDetailWorktreeCleanupState: SessionDetailWorktreeCleanupBannerState? {
-    SessionDetailWorktreeCleanupPlanner.bannerState(
-      status: worktreeState.status,
-      isWorktree: worktreeState.isWorktree,
-      dismissed: worktreeCleanupDismissed,
-      worktree: worktreeForSession,
-      branch: worktreeState.branch,
-      isCleaningUp: isCleaningUpWorktree
-    )
-  }
-
   var followMode: ConversationFollowMode {
-    conversationFollowState.mode
+    conversation.followState.mode
   }
 
   var unreadCount: Int {
-    conversationFollowState.unreadCount
+    conversation.followState.unreadCount
   }
 
   var usageStats: TranscriptUsageStats {
@@ -162,18 +135,6 @@ final class SessionDetailViewModel {
       return parsedCount
     }
     return reviewState.turnCount > 0 ? 1 : 0
-  }
-
-  var showWorktreeCleanupBanner: Bool {
-    sessionDetailWorktreeCleanupState != nil
-  }
-
-  var worktreeForSession: ServerWorktreeSummary? {
-    SessionDetailWorktreeCleanupPlanner.resolveWorktree(
-      worktreesByRepo: sessionStore.worktreesByRepo,
-      worktreeId: worktreeState.worktreeId,
-      projectPath: worktreeState.projectPath
-    )
   }
 
   var shouldSubscribeToServerSession: Bool {
@@ -211,7 +172,7 @@ final class SessionDetailViewModel {
             endpointId == targetEndpointId,
             sessionStore === targetStore
       else { return }
-      apply(snapshot: Self.buildSnapshot(
+      apply(snapshot: SessionDetailSnapshotBuilder.build(
         payload: payload,
         endpointId: targetEndpointId,
         sourceServerInstanceId: targetStore.serverInstanceId,
@@ -225,29 +186,26 @@ final class SessionDetailViewModel {
   // MARK: - Follow State (mirrored from TimelineScrollView)
 
   func handleConversationFollowStateChanged(_ state: ConversationFollowState) {
-    conversationFollowState = state
+    conversation.handleFollowStateChanged(state)
   }
 
   func jumpConversationToLatest() {
-    conversationScrollCommandNonce += 1
-    conversationScrollCommand = .jumpToLatest(nonce: conversationScrollCommandNonce)
+    conversation.jumpToLatest()
   }
 
   func toggleConversationFollowMode() {
-    conversationScrollCommandNonce += 1
-    conversationScrollCommand = .toggleFollow(nonce: conversationScrollCommandNonce)
+    conversation.toggleFollowMode()
   }
 
   func openPendingApprovalPanel() {
     withAnimation(Motion.standard) {
       pendingApprovalPanelOpenSignal += 1
     }
-    conversationScrollCommandNonce += 1
-    conversationScrollCommand = .openPendingApproval(nonce: conversationScrollCommandNonce)
+    conversation.openPendingApproval()
   }
 
   func navigateToReviewComment(_ comment: ServerReviewComment) {
-    navigateToComment = comment
+    review.navigateToComment = comment
     revealReview()
   }
 
@@ -257,7 +215,7 @@ final class SessionDetailViewModel {
       currentLayout: layoutConfig,
       filePath: filePath
     )
-    reviewFileId = plan.reviewFileId
+    review.reviewFileId = plan.reviewFileId
     layoutConfig = plan.layoutConfig
   }
 
@@ -273,15 +231,14 @@ final class SessionDetailViewModel {
       currentLayout: layoutConfig,
       intent: .revealReviewSplit
     )
-    showDiffBanner = false
+    review.showDiffBanner = false
   }
 
   func revealWorkerConversationEvent(_ messageId: String) {
     if layoutConfig == .reviewOnly {
       layoutConfig = .split
     }
-    conversationScrollCommandNonce += 1
-    conversationScrollCommand = .revealMessage(id: messageId, nonce: conversationScrollCommandNonce)
+    conversation.revealMessage(id: messageId)
   }
 
   func selectLayout(_ layout: LayoutConfiguration) {
@@ -292,7 +249,7 @@ final class SessionDetailViewModel {
     guard reviewState.isDirect, oldDiff == nil, newDiff != nil, layoutConfig == .conversationOnly else {
       return false
     }
-    showDiffBanner = true
+    review.showDiffBanner = true
     return true
   }
 
@@ -300,42 +257,8 @@ final class SessionDetailViewModel {
     guard reviewState.isDirect, newCount > oldCount, layoutConfig == .conversationOnly else {
       return false
     }
-    showDiffBanner = true
+    review.showDiffBanner = true
     return true
-  }
-
-  func syncSelectedWorker() {
-    let nextSelectedWorkerId = SessionWorkerRosterPlanner.preferredSelectedWorkerID(
-      currentSelectionID: selectedWorkerId,
-      subagents: workerState.subagents
-    )
-    if selectedWorkerId != nextSelectedWorkerId {
-      selectedWorkerId = nextSelectedWorkerId
-    }
-    syncWorkerDetailPresentation()
-  }
-
-  func loadSelectedWorkerTools(for workerId: String? = nil) {
-    guard let workerId = workerId ?? selectedWorkerId else { return }
-    Task {
-      let tools = try? await sessionStore.clients.sessions.getSubagentTools(sessionId: sessionId, subagentId: workerId)
-      let messages = try? await sessionStore.clients.sessions.getSubagentMessages(sessionId: sessionId, subagentId: workerId)
-      workerState.subagentTools[workerId] = tools ?? []
-      workerState.subagentMessages[workerId] = messages ?? []
-      syncWorkerDetailPresentation()
-    }
-  }
-
-  func selectWorkerInPanel(_ workerId: String) {
-    guard !workerId.isEmpty else { return }
-    selectedWorkerId = workerId
-    syncWorkerDetailPresentation()
-    loadSelectedWorkerTools(for: workerId)
-  }
-
-  func focusWorkerInDeck(_ workerId: String) {
-    guard !workerId.isEmpty else { return }
-    selectWorkerInPanel(workerId)
   }
 
   func copyResumeCommand() {
@@ -355,38 +278,10 @@ final class SessionDetailViewModel {
     Task { try? await sessionStore.endSession(sessionId) }
   }
 
-  func cleanUpWorktree() {
-    guard let request = SessionDetailWorktreeCleanupPlanner.cleanupRequest(
-      worktree: worktreeForSession,
-      deleteBranch: deleteBranchOnCleanup
-    ) else {
-      return
-    }
-
-    isCleaningUpWorktree = true
-    worktreeCleanupError = nil
-
-    Task {
-      do {
-        try await sessionStore.clients.worktrees.removeWorktree(
-          worktreeId: request.worktreeId,
-          force: request.force,
-          deleteBranch: request.deleteBranch
-        )
-        withAnimation(Motion.gentle) {
-          worktreeCleanupDismissed = true
-        }
-      } catch {
-        worktreeCleanupError = error.localizedDescription
-      }
-      isCleaningUpWorktree = false
-    }
-  }
-
   func sendReviewToModel() {
     guard let plan = SessionDetailReviewSendPlanner.makePlan(
       reviewComments: reviewState.reviewComments,
-      selectedCommentIds: selectedCommentIds,
+      selectedCommentIds: review.selectedCommentIds,
       turnDiffs: reviewState.turnDiffs,
       currentDiff: reviewState.diff,
       cumulativeDiff: reviewState.cumulativeDiff
@@ -405,7 +300,7 @@ final class SessionDetailViewModel {
       }
     }
 
-    selectedCommentIds.removeAll()
+    review.selectedCommentIds.removeAll()
   }
 
   private func apply(snapshot: SessionDetailSnapshot) {
@@ -413,46 +308,12 @@ final class SessionDetailViewModel {
     usageSource = snapshot.usageSource
     worktreeState = snapshot.worktreeState
     reviewState = snapshot.reviewState
-    // Preserve loaded worker tools/messages across refreshes — the snapshot only carries
-    // the subagent roster, not the detail payloads we fetched on-demand.
-    let preservedTools = workerState.subagentTools
-    let preservedMessages = workerState.subagentMessages
-    workerState = SessionDetailWorkerState(
-      subagents: snapshot.workerState.subagents,
-      subagentTools: preservedTools,
-      subagentMessages: preservedMessages,
-      timelineRevision: snapshot.workerState.timelineRevision
-    )
-    workerRosterPresentation = SessionWorkerRosterPlanner.presentation(subagents: workerState.subagents)
-    syncSelectedWorker()
+    worker.apply(snapshotState: snapshot.workerState, layoutConfig: layoutConfig)
     conversationPresentation = snapshot.conversationPresentation
     reviewPresentation = snapshot.reviewPresentation(layoutConfig: layoutConfig)
     footerMode = snapshot.footerMode
     currentTool = snapshot.currentTool
     lastActivityAt = snapshot.lastActivityAt
-  }
-
-  private func syncWorkerDetailPresentation() {
-    guard layoutConfig != .reviewOnly, let selectedWorkerId else {
-      workerDetailPresentation = nil
-      return
-    }
-
-    let hasLoadedWorkerPayload =
-      workerState.subagentTools[selectedWorkerId] != nil || workerState.subagentMessages[selectedWorkerId] != nil
-
-    guard hasLoadedWorkerPayload else {
-      workerDetailPresentation = nil
-      return
-    }
-
-    workerDetailPresentation = SessionWorkerRosterPlanner.detailPresentation(
-      subagents: workerState.subagents,
-      selectedWorkerID: selectedWorkerId,
-      toolsByWorker: workerState.subagentTools,
-      messagesByWorker: workerState.subagentMessages,
-      timelineEntries: []
-    )
   }
 
   private func syncSectionPresentations() {
@@ -472,342 +333,4 @@ final class SessionDetailViewModel {
       compact: layoutConfig == .split
     )
   }
-
-  private static func buildSnapshot(
-    payload: ServerSessionDetailSnapshotPayload,
-    endpointId: UUID,
-    sourceServerInstanceId: String?,
-    sourceIsRemoteConnection: Bool
-  ) -> SessionDetailSnapshot {
-    let s = payload.session
-    let sessionId = s.id
-    let isDirect = s.controlMode == .direct
-    let isActive = s.lifecycleState != .ended
-    let provider: Provider = s.provider == .codex ? .codex : .claude
-    let displayName = resolveDisplayName(s)
-    let displayStatus = resolveDisplayStatus(s, isActive: isActive)
-    let workStatus = s.workStatus.toSessionWorkStatus()
-    let hasGitRepository = s.gitBranch != nil || s.currentCwd != nil || s.isWorktree
-
-    return SessionDetailSnapshot(
-      screenPresentation: SessionDetailScreenPresentation(
-        displayName: displayName,
-        isDirect: isDirect,
-        isActive: isActive,
-        displayStatus: displayStatus,
-        workStatus: workStatus,
-        provider: provider,
-        model: s.model,
-        effort: s.effort,
-        endpointName: nil,
-        projectPath: s.projectPath,
-        issueIdentifier: s.issueIdentifier,
-        missionId: s.missionId,
-        capabilities: isDirect ? [.direct] : (provider == .codex ? [.passive] : []),
-        continuation: SessionContinuation(
-          endpointId: endpointId,
-          sessionId: sessionId,
-          provider: provider,
-          displayName: displayName,
-          projectPath: s.projectPath,
-          model: s.model,
-          hasGitRepository: hasGitRepository,
-          sourceServerInstanceId: sourceServerInstanceId,
-          sourceIsRemoteConnection: sourceIsRemoteConnection
-        ),
-        debugContext: SessionDetailDebugContext(
-          sessionId: sessionId,
-          threadId: nil,
-          projectPath: s.projectPath,
-          provider: provider,
-          codexIntegrationMode: s.codexIntegrationMode.map { String(describing: $0) },
-          claudeIntegrationMode: s.claudeIntegrationMode.map { String(describing: $0) }
-        )
-      ),
-      usageSource: SessionDetailUsageSource(
-        model: s.model,
-        inputTokens: Int(s.tokenUsage.inputTokens),
-        outputTokens: Int(s.tokenUsage.outputTokens),
-        cachedTokens: Int(s.tokenUsage.cachedTokens),
-        contextUsed: Int(s.tokenUsage.contextWindow),
-        totalTokens: Int(s.tokenUsage.inputTokens + s.tokenUsage.outputTokens)
-      ),
-      worktreeState: SessionDetailWorktreeState(
-        status: mapSessionStatus(s.status),
-        isWorktree: s.isWorktree,
-        branch: s.gitBranch,
-        worktreeId: s.worktreeId,
-        projectPath: s.projectPath
-      ),
-      reviewState: SessionDetailReviewState(
-        diff: s.currentDiff,
-        cumulativeDiff: s.cumulativeDiff,
-        turnDiffs: s.turnDiffs,
-        reviewComments: [],
-        isDirect: isDirect,
-        turnCount: s.turnCount
-      ),
-      workerState: SessionDetailWorkerState(
-        subagents: s.subagents,
-        subagentTools: [:],
-        subagentMessages: [:],
-        timelineRevision: 0
-      ),
-      currentTool: s.pendingToolName,
-      lastActivityAt: parseServerTimestamp(s.lastActivityAt),
-      footerMode: SessionDetailFooterPlanner.mode(
-        controlMode: isDirect ? .direct : .passive,
-        lifecycleState: s.lifecycleState
-      ),
-      sessionStoreEndpointId: endpointId,
-      sessionId: sessionId
-    )
-  }
-
-  private static func resolveDisplayName(_ s: ServerSessionState) -> String {
-    SessionSemantics.displayName(
-      customName: s.customName,
-      summary: s.summary,
-      firstPrompt: s.firstPrompt,
-      projectName: s.projectName,
-      projectPath: s.projectPath
-    )
-  }
-
-  private static func resolveDisplayStatus(_ s: ServerSessionState, isActive: Bool) -> SessionDisplayStatus {
-    guard isActive else { return .ended }
-    if s.pendingApproval != nil {
-      switch s.pendingApproval?.type {
-        case .permissions: return .permission
-        case .question: return .question
-        default: return .permission
-      }
-    }
-    switch s.workStatus {
-      case .working: return .working
-      case .permission: return .permission
-      case .question: return .question
-      case .waiting, .reply, .ended: return .reply
-    }
-  }
-
-  private static func mapSessionStatus(_ status: ServerSessionStatus) -> Session.SessionStatus {
-    switch status {
-      case .active: .active
-      case .ended: .ended
-    }
-  }
-}
-
-struct SessionDetailSnapshot {
-  let screenPresentation: SessionDetailScreenPresentation
-  let usageSource: SessionDetailUsageSource
-  let worktreeState: SessionDetailWorktreeState
-  let reviewState: SessionDetailReviewState
-  let workerState: SessionDetailWorkerState
-  let currentTool: String?
-  let lastActivityAt: Date?
-  let footerMode: SessionDetailFooterMode
-  let sessionStoreEndpointId: UUID
-  let sessionId: String
-
-  func reviewPresentation(layoutConfig: LayoutConfiguration) -> SessionDetailReviewSectionPresentation {
-    SessionDetailReviewSectionPresentation(
-      sessionId: sessionId,
-      projectPath: screenPresentation.projectPath,
-      isSessionActive: screenPresentation.isActive,
-      compact: layoutConfig == .split
-    )
-  }
-
-  var conversationPresentation: SessionDetailConversationSectionPresentation {
-    SessionDetailConversationSectionPresentation(
-      sessionId: sessionId,
-      endpointId: sessionStoreEndpointId,
-      isSessionActive: screenPresentation.isActive,
-      displayStatus: screenPresentation.displayStatus,
-      currentTool: currentTool,
-      projectPath: screenPresentation.projectPath,
-      canOpenFileInReview: screenPresentation.isDirect
-    )
-  }
-
-  static func empty(endpointId: UUID, sessionId: String) -> SessionDetailSnapshot {
-    SessionDetailSnapshot(
-      screenPresentation: .empty,
-      usageSource: .empty,
-      worktreeState: .empty,
-      reviewState: .empty,
-      workerState: .empty,
-      currentTool: nil,
-      lastActivityAt: nil,
-      footerMode: .passive,
-      sessionStoreEndpointId: endpointId,
-      sessionId: sessionId
-    )
-  }
-}
-
-struct SessionDetailScreenPresentation {
-  let displayName: String
-  let isDirect: Bool
-  let isActive: Bool
-  let displayStatus: SessionDisplayStatus
-  let workStatus: Session.WorkStatus
-  let provider: Provider
-  let model: String?
-  let effort: String?
-  let endpointName: String?
-  let projectPath: String
-  let issueIdentifier: String?
-  let missionId: String?
-  let capabilities: [SessionCapability]
-  let continuation: SessionContinuation
-  let debugContext: SessionDetailDebugContext
-
-  static let empty = SessionDetailScreenPresentation(
-    displayName: "Session",
-    isDirect: false,
-    isActive: false,
-    displayStatus: .ended,
-    workStatus: .unknown,
-    provider: .claude,
-    model: nil,
-    effort: nil,
-    endpointName: nil,
-    projectPath: "",
-    issueIdentifier: nil,
-    missionId: nil,
-    capabilities: [],
-    continuation: SessionContinuation(
-      endpointId: UUID(),
-      sessionId: "",
-      provider: .claude,
-      displayName: "Session",
-      projectPath: "",
-      model: nil,
-      hasGitRepository: false,
-      sourceServerInstanceId: nil,
-      sourceIsRemoteConnection: false
-    ),
-    debugContext: .empty
-  )
-}
-
-struct SessionDetailDebugContext {
-  let sessionId: String
-  let threadId: String?
-  let projectPath: String
-  let provider: Provider
-  let codexIntegrationMode: String?
-  let claudeIntegrationMode: String?
-
-  static let empty = SessionDetailDebugContext(
-    sessionId: "",
-    threadId: nil,
-    projectPath: "",
-    provider: .claude,
-    codexIntegrationMode: nil,
-    claudeIntegrationMode: nil
-  )
-}
-
-struct SessionDetailConversationSectionPresentation {
-  let sessionId: String
-  let endpointId: UUID
-  let isSessionActive: Bool
-  let displayStatus: SessionDisplayStatus
-  let currentTool: String?
-  let projectPath: String
-  let canOpenFileInReview: Bool
-
-  static let empty = SessionDetailConversationSectionPresentation(
-    sessionId: "",
-    endpointId: UUID(),
-    isSessionActive: false,
-    displayStatus: .ended,
-    currentTool: nil,
-    projectPath: "",
-    canOpenFileInReview: false
-  )
-}
-
-struct SessionDetailReviewSectionPresentation {
-  let sessionId: String
-  let projectPath: String
-  let isSessionActive: Bool
-  let compact: Bool
-
-  static let empty = SessionDetailReviewSectionPresentation(
-    sessionId: "",
-    projectPath: "",
-    isSessionActive: false,
-    compact: false
-  )
-}
-
-struct SessionDetailUsageSource {
-  let model: String?
-  let inputTokens: Int?
-  let outputTokens: Int?
-  let cachedTokens: Int?
-  let contextUsed: Int
-  let totalTokens: Int?
-
-  static let empty = SessionDetailUsageSource(
-    model: nil,
-    inputTokens: nil,
-    outputTokens: nil,
-    cachedTokens: nil,
-    contextUsed: 0,
-    totalTokens: nil
-  )
-}
-
-struct SessionDetailWorktreeState {
-  let status: Session.SessionStatus
-  let isWorktree: Bool
-  let branch: String?
-  let worktreeId: String?
-  let projectPath: String
-
-  static let empty = SessionDetailWorktreeState(
-    status: .active,
-    isWorktree: false,
-    branch: nil,
-    worktreeId: nil,
-    projectPath: ""
-  )
-}
-
-struct SessionDetailReviewState {
-  let diff: String?
-  let cumulativeDiff: String?
-  let turnDiffs: [ServerTurnDiff]
-  let reviewComments: [ServerReviewComment]
-  let isDirect: Bool
-  let turnCount: UInt64
-
-  static let empty = SessionDetailReviewState(
-    diff: nil,
-    cumulativeDiff: nil,
-    turnDiffs: [],
-    reviewComments: [],
-    isDirect: false,
-    turnCount: 0
-  )
-}
-
-struct SessionDetailWorkerState {
-  let subagents: [ServerSubagentInfo]
-  var subagentTools: [String: [ServerSubagentTool]]
-  var subagentMessages: [String: [ServerConversationRowEntry]]
-  let timelineRevision: Int
-
-  static let empty = SessionDetailWorkerState(
-    subagents: [],
-    subagentTools: [:],
-    subagentMessages: [:],
-    timelineRevision: 0
-  )
 }

--- a/OrbitDockNative/OrbitDock/Views/Sessions/Capabilities/McpServersTab.swift
+++ b/OrbitDockNative/OrbitDock/Views/Sessions/Capabilities/McpServersTab.swift
@@ -124,9 +124,15 @@ struct McpServersTab: View {
   let sessionId: String
   let sessionStore: SessionStore
 
-  @State private var viewModel = McpServersTabViewModel()
+  @State private var viewModel: McpServersTabViewModel
   private var bindingIdentity: String {
     "\(sessionStore.endpointId.uuidString):\(sessionId):\(ObjectIdentifier(sessionStore))"
+  }
+
+  init(sessionId: String, sessionStore: SessionStore) {
+    self.sessionId = sessionId
+    self.sessionStore = sessionStore
+    _viewModel = State(initialValue: McpServersTabViewModel(sessionId: sessionId, sessionStore: sessionStore))
   }
 
   var body: some View {
@@ -183,7 +189,7 @@ struct McpServersTab: View {
       await viewModel.refresh()
     }
     .task(id: bindingIdentity + ":ws") {
-      let (stream, _) = sessionStore.sessionChanges(for: sessionId)
+      let (stream, _) = sessionStore.capabilitiesRefreshRequests(for: sessionId)
       for await _ in stream {
         await viewModel.refresh()
       }

--- a/OrbitDockNative/OrbitDock/Views/Sessions/Capabilities/McpServersTabViewModel.swift
+++ b/OrbitDockNative/OrbitDock/Views/Sessions/Capabilities/McpServersTabViewModel.swift
@@ -4,7 +4,7 @@ import Observation
 @Observable
 final class McpServersTabViewModel {
   var currentSessionId: String?
-  var currentSessionStore: SessionStore?
+  var currentSessionStore: SessionStore
   var expandedServers: Set<String> = []
 
   // Snapshot state — owned by this VM, populated via HTTP
@@ -21,7 +21,7 @@ final class McpServersTabViewModel {
   var provider: Provider? { _provider }
 
   var capabilityNotice: McpCapabilityNotice? {
-    guard let provider, let currentSessionStore else { return nil }
+    guard let provider else { return nil }
     return McpServersTabPlanner.capabilityNotice(
       provider: provider,
       codexAccountStatus: currentSessionStore.codexAccountStatus
@@ -55,6 +55,18 @@ final class McpServersTabViewModel {
     }
   }
 
+  init(
+    sessionId: String?,
+    sessionStore: SessionStore
+  ) {
+    currentSessionId = sessionId
+    currentSessionStore = sessionStore
+  }
+
+  convenience init() {
+    self.init(sessionId: nil, sessionStore: SessionStore.preview())
+  }
+
   func bind(sessionId: String, sessionStore: SessionStore, provider: Provider? = nil) {
     currentSessionId = sessionId
     currentSessionStore = sessionStore
@@ -65,7 +77,8 @@ final class McpServersTabViewModel {
   @ObservationIgnored private var refreshQueued = false
 
   func refresh() async {
-    guard let sessionId = currentSessionId, let store = currentSessionStore else { return }
+    guard let sessionId = currentSessionId else { return }
+    let store = currentSessionStore
     if isRefreshing { refreshQueued = true; return }
     isRefreshing = true
     defer {
@@ -84,7 +97,8 @@ final class McpServersTabViewModel {
   }
 
   func refreshMcpServers() async {
-    guard let sessionId = currentSessionId, let store = currentSessionStore else { return }
+    guard let sessionId = currentSessionId else { return }
+    let store = currentSessionStore
     try? await store.clients.mcp.refreshServers(sessionId: sessionId)
     await refresh()
   }

--- a/OrbitDockNative/OrbitDock/Views/Sessions/Capabilities/SkillsTab.swift
+++ b/OrbitDockNative/OrbitDock/Views/Sessions/Capabilities/SkillsTab.swift
@@ -12,9 +12,16 @@ struct SkillsTab: View {
   let sessionStore: SessionStore
   @Binding var selectedSkills: Set<String>
 
-  @State private var viewModel = SkillsTabViewModel()
+  @State private var viewModel: SkillsTabViewModel
   private var bindingIdentity: String {
     "\(sessionStore.endpointId.uuidString):\(sessionId):\(ObjectIdentifier(sessionStore))"
+  }
+
+  init(sessionId: String, sessionStore: SessionStore, selectedSkills: Binding<Set<String>>) {
+    self.sessionId = sessionId
+    self.sessionStore = sessionStore
+    _selectedSkills = selectedSkills
+    _viewModel = State(initialValue: SkillsTabViewModel(sessionId: sessionId, sessionStore: sessionStore))
   }
 
   var body: some View {
@@ -35,7 +42,7 @@ struct SkillsTab: View {
       await viewModel.refresh()
     }
     .task(id: bindingIdentity + ":ws") {
-      let (stream, _) = sessionStore.sessionChanges(for: sessionId)
+      let (stream, _) = sessionStore.capabilitiesRefreshRequests(for: sessionId)
       for await _ in stream {
         await viewModel.refresh()
       }

--- a/OrbitDockNative/OrbitDock/Views/Sessions/Capabilities/SkillsTabViewModel.swift
+++ b/OrbitDockNative/OrbitDock/Views/Sessions/Capabilities/SkillsTabViewModel.swift
@@ -6,7 +6,7 @@ final class SkillsTabViewModel {
   private let scopeOrder: [ServerSkillScope] = [.repo, .user, .system, .admin]
 
   var currentSessionId: String?
-  var currentSessionStore: SessionStore?
+  var currentSessionStore: SessionStore
 
   // Snapshot state — owned by this VM, populated via HTTP
   private var _skills: [ServerSkillMetadata] = []
@@ -28,6 +28,18 @@ final class SkillsTabViewModel {
     }
   }
 
+  init(
+    sessionId: String?,
+    sessionStore: SessionStore
+  ) {
+    currentSessionId = sessionId
+    currentSessionStore = sessionStore
+  }
+
+  convenience init() {
+    self.init(sessionId: nil, sessionStore: SessionStore.preview())
+  }
+
   func bind(sessionId: String, sessionStore: SessionStore) {
     currentSessionId = sessionId
     currentSessionStore = sessionStore
@@ -37,7 +49,8 @@ final class SkillsTabViewModel {
   @ObservationIgnored private var refreshQueued = false
 
   func refresh() async {
-    guard let sessionId = currentSessionId, let store = currentSessionStore else { return }
+    guard let sessionId = currentSessionId else { return }
+    let store = currentSessionStore
     if isRefreshing { refreshQueued = true; return }
     isRefreshing = true
     defer {
@@ -53,7 +66,8 @@ final class SkillsTabViewModel {
   }
 
   func refreshSkills() async {
-    guard let sessionId = currentSessionId, let store = currentSessionStore else { return }
+    guard let sessionId = currentSessionId else { return }
+    let store = currentSessionStore
     _ = try? await store.clients.skills.listSkills(sessionId: sessionId, forceReload: true)
     await refresh()
   }

--- a/OrbitDockNative/OrbitDock/Views/Sessions/ControlDeck/ControlDeckComposerModel.swift
+++ b/OrbitDockNative/OrbitDock/Views/Sessions/ControlDeck/ControlDeckComposerModel.swift
@@ -1,0 +1,357 @@
+import Foundation
+import ImageIO
+import SwiftUI
+import UniformTypeIdentifiers
+
+enum ControlDeckKeyCommandResult {
+  case ignored
+  case handled
+  case submit
+  case accept(ControlDeckCompletionSuggestion)
+}
+
+@MainActor
+@Observable
+final class ControlDeckComposerModel {
+  var draft = ControlDeckDraft()
+  var completionState = ControlDeckCompletionState()
+  var focusState = ControlDeckFocusState()
+  var isSubmitting = false
+  var uploadedImageIds: [String: String] = [:]
+  var isImportingAttachments = false
+  var dictationController = LocalDictationController()
+  var dictationDraftBase: String?
+  var controlDeckWidth: CGFloat = 0
+  var completionPanelHeight: CGFloat = 0
+
+  func restoreDraft(for sessionId: String) {
+    draft = ControlDeckDraft.restore(for: sessionId)
+  }
+
+  func persistDraft(for sessionId: String) {
+    ControlDeckDraft.save(draft, for: sessionId)
+  }
+
+  func clearDraft(for sessionId: String) {
+    draft.clearAfterSubmit()
+    uploadedImageIds = [:]
+    completionState.dismiss()
+    ControlDeckDraft.clear(for: sessionId)
+    focusState.requestFocus()
+  }
+
+  @discardableResult
+  func handleTextChange(_ text: String, availableSkills: [ControlDeckSkill]) -> Bool {
+    syncSelectedSkillsFromText(text, availableSkills: availableSkills)
+
+    let nextMode = ControlDeckAutocompletePlanner.completionMode(for: text)
+    switch nextMode {
+    case .skill:
+      completionState.activate(nextMode)
+      return availableSkills.isEmpty
+    case .mention:
+      completionState.activate(nextMode)
+      return false
+    case .inactive, .command:
+      completionState.dismiss()
+      return false
+    }
+  }
+
+  func currentSuggestions(
+    availableSkills: [ControlDeckSkill],
+    projectPath: String?,
+    projectFileIndex: ProjectFileIndex?
+  ) -> [ControlDeckCompletionSuggestion] {
+    switch completionState.mode {
+    case .inactive:
+      return []
+    case let .mention(query):
+      guard let projectPath else { return [] }
+      let files = projectFileIndex?.search(query, in: projectPath) ?? []
+      return files.prefix(ControlDeckAutocompletePlanner.maxSuggestionCount).map { file in
+        ControlDeckCompletionSuggestion(
+          id: file.id,
+          kind: .file,
+          title: file.name,
+          subtitle: file.relativePath
+        )
+      }
+    case let .skill(query):
+      return ControlDeckAutocompletePlanner.skillSuggestions(for: query, skills: availableSkills)
+    case .command:
+      return []
+    }
+  }
+
+  func handleKeyCommand(
+    _ command: ControlDeckTextAreaKeyCommand,
+    suggestions: [ControlDeckCompletionSuggestion],
+    canSubmit: Bool
+  ) -> ControlDeckKeyCommandResult {
+    if completionState.isActive {
+      switch command {
+      case .escape:
+        completionState.dismiss()
+        return .handled
+      case .upArrow, .controlP:
+        completionState.moveUp()
+        return .handled
+      case .downArrow, .controlN:
+        completionState.moveDown(itemCount: suggestions.count)
+        return .handled
+      case .tab, .returnKey:
+        guard suggestions.indices.contains(completionState.selectedIndex) else {
+          return .ignored
+        }
+        return .accept(suggestions[completionState.selectedIndex])
+      default:
+        return .ignored
+      }
+    }
+
+    if command == .returnKey, canSubmit {
+      return .submit
+    }
+
+    return .ignored
+  }
+
+  func handleFocusEvent(_ event: ControlDeckTextAreaFocusEvent) -> Bool {
+    switch event {
+    case .began:
+      focusState.isFocused = true
+      return true
+    case .ended(userInitiated: _):
+      focusState.isFocused = false
+      return false
+    }
+  }
+
+  func acceptSuggestion(
+    _ suggestion: ControlDeckCompletionSuggestion,
+    availableSkills: [ControlDeckSkill],
+    projectPath: String?,
+    projectFileIndex: ProjectFileIndex?
+  ) {
+    switch suggestion.kind {
+    case .file:
+      acceptFileSuggestion(
+        suggestion,
+        projectPath: projectPath,
+        projectFileIndex: projectFileIndex
+      )
+    case .skill:
+      acceptSkillSuggestion(suggestion, availableSkills: availableSkills)
+    case .command:
+      break
+    }
+  }
+
+  func handleAttachmentImport(
+    _ result: Result<[URL], Error>,
+    projectPath: String?
+  ) -> String? {
+    guard case let .success(urls) = result, !urls.isEmpty else {
+      if case let .failure(error) = result {
+        return String(describing: error)
+      }
+      return nil
+    }
+
+    for url in urls {
+      do {
+        if let imagePayload = try Self.makeImagePayloadIfNeeded(from: url) {
+          draft.attachments.appendImage(imagePayload)
+        } else {
+          try appendFileMention(from: url, projectPath: projectPath)
+        }
+      } catch {
+        return String(describing: error)
+      }
+    }
+
+    return nil
+  }
+
+  func appendDroppedImage(_ payload: ControlDeckImageDraft) {
+    draft.attachments.appendImage(payload)
+  }
+
+  func updateDictationLivePreview(_ transcript: String) {
+    guard let base = dictationDraftBase else { return }
+    let normalized = DictationTextFormatter.normalizeTranscription(transcript)
+    let merged = DictationTextFormatter.merge(existing: base, dictated: normalized)
+    guard merged != draft.text else { return }
+    draft.text = merged
+    focusState.moveCursorToEnd()
+  }
+
+  func toggleDictation(localDictationEnabled: Bool) async -> String? {
+    guard localDictationEnabled else { return nil }
+
+    if dictationController.isRecording {
+      if let dictated = await dictationController.stop() {
+        let normalized = DictationTextFormatter.normalizeTranscription(dictated)
+        if let base = dictationDraftBase {
+          let currentWithoutPreview = removeLivePreviewSuffix(from: draft.text, base: base)
+          draft.text = DictationTextFormatter.merge(existing: currentWithoutPreview, dictated: normalized)
+        } else {
+          draft.text = DictationTextFormatter.merge(existing: draft.text, dictated: normalized)
+        }
+      }
+      dictationDraftBase = nil
+      focusState.moveCursorToEnd()
+      Platform.services.playHaptic(.action)
+      return nil
+    }
+
+    dictationDraftBase = draft.text
+    await dictationController.start()
+    if dictationController.isRecording {
+      Platform.services.playHaptic(.action)
+      return nil
+    }
+
+    dictationDraftBase = nil
+    if let message = dictationController.errorMessage {
+      Platform.services.playHaptic(.error)
+      return message
+    }
+
+    return nil
+  }
+
+  func cancelDictation() async {
+    await dictationController.cancel()
+    dictationDraftBase = nil
+  }
+
+  func syncSelectedSkillsFromText(_ text: String, availableSkills: [ControlDeckSkill]) {
+    guard !availableSkills.isEmpty else { return }
+    let matched = ControlDeckSkillResolver.matchedSkillPaths(
+      in: text,
+      availableSkills: availableSkills
+    )
+    guard matched != draft.selectedSkillPaths else { return }
+    draft.selectedSkillPaths = matched
+  }
+
+  private func acceptFileSuggestion(
+    _ suggestion: ControlDeckCompletionSuggestion,
+    projectPath: String?,
+    projectFileIndex: ProjectFileIndex?
+  ) {
+    guard let projectPath,
+      let file = projectFileIndex?.files(for: projectPath).first(where: { $0.id == suggestion.id })
+    else { return }
+
+    draft.text = ControlDeckTextEditing.replacingTrailingToken(
+      in: draft.text,
+      prefix: "@",
+      with: "@\(file.name) "
+    )
+    let absolutePath = (projectPath as NSString).appendingPathComponent(file.relativePath)
+    draft.attachments.appendMention(
+      ControlDeckMentionDraft(
+        fileId: file.id,
+        name: file.name,
+        absolutePath: absolutePath,
+        relativePath: file.relativePath,
+        kind: .file
+      )
+    )
+    completionState.dismiss()
+    focusState.requestFocus()
+    focusState.moveCursorToEnd()
+  }
+
+  private func acceptSkillSuggestion(
+    _ suggestion: ControlDeckCompletionSuggestion,
+    availableSkills: [ControlDeckSkill]
+  ) {
+    guard let skill = availableSkills.first(where: { $0.id == suggestion.id }) else { return }
+
+    draft.text = ControlDeckTextEditing.replacingTrailingToken(
+      in: draft.text,
+      prefix: "$",
+      with: "$\(skill.name) "
+    )
+    draft.selectedSkillPaths.insert(skill.path)
+    completionState.dismiss()
+    focusState.requestFocus()
+    focusState.moveCursorToEnd()
+  }
+
+  private func appendFileMention(from url: URL, projectPath: String?) throws {
+    let requiresScope = url.startAccessingSecurityScopedResource()
+    defer {
+      if requiresScope {
+        url.stopAccessingSecurityScopedResource()
+      }
+    }
+
+    let standardizedURL = url.standardizedFileURL
+    let absolutePath = standardizedURL.path
+    guard !absolutePath.isEmpty else { return }
+
+    let trimmedProjectPath = projectPath?.trimmingCharacters(in: .whitespacesAndNewlines)
+    let relativePath: String?
+    if let trimmedProjectPath, !trimmedProjectPath.isEmpty, absolutePath.hasPrefix(trimmedProjectPath + "/") {
+      relativePath = String(absolutePath.dropFirst(trimmedProjectPath.count + 1))
+    } else {
+      relativePath = nil
+    }
+
+    _ = draft.attachments.appendMention(
+      ControlDeckMentionDraft(
+        fileId: absolutePath,
+        name: standardizedURL.lastPathComponent,
+        absolutePath: absolutePath,
+        relativePath: relativePath,
+        kind: .file
+      )
+    )
+  }
+
+  private func removeLivePreviewSuffix(from current: String, base: String) -> String {
+    current.hasPrefix(base) ? base : current
+  }
+
+  nonisolated static func makeImagePayloadIfNeeded(from url: URL) throws -> ControlDeckImageDraft? {
+    let utType = UTType(filenameExtension: url.pathExtension.lowercased())
+    guard utType?.conforms(to: .image) == true else { return nil }
+
+    let requiresScope = url.startAccessingSecurityScopedResource()
+    defer {
+      if requiresScope {
+        url.stopAccessingSecurityScopedResource()
+      }
+    }
+
+    let data = try Data(contentsOf: url)
+    let dims = imageDimensions(from: data)
+    return ControlDeckImageDraft(
+      localId: UUID().uuidString,
+      thumbnailData: data.count < 500_000 ? data : nil,
+      uploadData: data,
+      uploadMimeType: utType?.preferredMIMEType ?? "image/png",
+      displayName: url.lastPathComponent,
+      pixelWidth: dims.width,
+      pixelHeight: dims.height
+    )
+  }
+
+  nonisolated static func imageDimensions(from data: Data) -> (width: Int?, height: Int?) {
+    guard let source = CGImageSourceCreateWithData(data as CFData, nil),
+      let props = CGImageSourceCopyPropertiesAtIndex(source, 0, nil) as? [CFString: Any]
+    else {
+      return (nil, nil)
+    }
+
+    return (
+      props[kCGImagePropertyPixelWidth] as? Int,
+      props[kCGImagePropertyPixelHeight] as? Int
+    )
+  }
+}

--- a/OrbitDockNative/OrbitDock/Views/Sessions/ControlDeck/ControlDeckScreen+Actions.swift
+++ b/OrbitDockNative/OrbitDock/Views/Sessions/ControlDeck/ControlDeckScreen+Actions.swift
@@ -1,0 +1,146 @@
+import SwiftUI
+
+extension ControlDeckScreen {
+  func handleTextChange(_ text: String) {
+    let shouldLoadSkills = composer.handleTextChange(text, availableSkills: sessionModel.skills)
+    if shouldLoadSkills {
+      Task { await sessionModel.loadSkills() }
+    }
+  }
+
+  func handleKeyCommand(_ command: ControlDeckTextAreaKeyCommand) -> Bool {
+    switch composer.handleKeyCommand(command, suggestions: currentSuggestions, canSubmit: canSubmit) {
+    case .ignored:
+      return false
+    case .handled:
+      return true
+    case .submit:
+      submitDraft()
+      return true
+    case let .accept(suggestion):
+      acceptSuggestion(suggestion)
+      return true
+    }
+  }
+
+  func handleFocusEvent(_ event: ControlDeckTextAreaFocusEvent) {
+    onFocusStateChange?(composer.handleFocusEvent(event))
+  }
+
+  func handleModuleAction(_ module: ControlDeckStatusModule, _ value: String) {
+    netLog(.info, cat: .store, "ControlDeck module action tapped", sid: sessionId, data: [
+      "module": module.rawValue,
+      "value": value,
+    ])
+    Task {
+      switch module {
+      case .model:
+        await sessionModel.updateModel(value)
+      case .effort:
+        await sessionModel.updateEffort(value)
+      case .autonomy:
+        await sessionModel.updatePermissionMode(value)
+      case .approvalMode:
+        await sessionModel.updateApprovalPolicy(value)
+      case .collaborationMode:
+        await sessionModel.updateCollaborationMode(value)
+      case .autoReview:
+        await sessionModel.updateAutoReview(value)
+      default:
+        break
+      }
+    }
+  }
+
+  func handleApprovalReviewerAction(_ reviewer: ServerCodexApprovalsReviewer) {
+    netLog(.info, cat: .store, "ControlDeck approval reviewer action tapped", sid: sessionId, data: [
+      "reviewer": reviewer.rawValue
+    ])
+    Task {
+      await sessionModel.updateApprovalsReviewer(reviewer)
+    }
+  }
+
+  func handleSandboxPolicyAction(_ policy: ServerCodexSandboxPolicy) {
+    netLog(.info, cat: .store, "ControlDeck sandbox policy action tapped", sid: sessionId, data: [
+      "policy": policy.legacySummary
+    ])
+    Task {
+      await sessionModel.updateSandboxPolicy(policy)
+    }
+  }
+
+  func acceptSuggestion(_ suggestion: ControlDeckCompletionSuggestion) {
+    composer.acceptSuggestion(
+      suggestion,
+      availableSkills: sessionModel.skills,
+      projectPath: sessionModel.projectPath,
+      projectFileIndex: sessionModel.projectFileIndex
+    )
+  }
+
+  func submitDraft() {
+    guard composer.draft.hasContent, !composer.isSubmitting else { return }
+
+    let shouldSteer = currentMode == .steer || sessionModel.steerable
+    composer.isSubmitting = true
+    let currentDraft = composer.draft
+
+    Task {
+      defer { composer.isSubmitting = false }
+
+      do {
+        var imageIds = composer.uploadedImageIds
+        for image in currentDraft.attachments.images where imageIds[image.localId] == nil {
+          let attachmentId = try await sessionModel.uploadImage(
+            data: image.uploadData,
+            mimeType: image.uploadMimeType,
+            displayName: image.displayName,
+            pixelWidth: image.pixelWidth,
+            pixelHeight: image.pixelHeight
+          )
+          imageIds[image.localId] = attachmentId
+        }
+
+        composer.uploadedImageIds = imageIds
+
+        if shouldSteer {
+          try await sessionModel.steerTurn(draft: currentDraft, uploadedImageIds: imageIds)
+        } else {
+          try await sessionModel.submitTurn(draft: currentDraft, uploadedImageIds: imageIds)
+        }
+
+        sessionModel.lastError = nil
+        composer.clearDraft(for: sessionId)
+      } catch {
+        sessionModel.lastError = String(describing: error)
+        await sessionModel.refresh()
+      }
+    }
+  }
+
+  func resumeSession() {
+    guard !composer.isSubmitting else { return }
+    netLog(.info, cat: .store, "ControlDeckScreen resume tapped", sid: sessionId, data: [
+      "isSubmitting": composer.isSubmitting,
+      "isResuming": sessionModel.isResuming,
+      "presentationMode": sessionModel.presentation?.mode.debugLabel ?? "nil",
+      "canResume": sessionModel.presentation?.canResume ?? false
+    ])
+    Task { await sessionModel.resumeSession() }
+  }
+
+  func handleAttachmentImport(_ result: Result<[URL], Error>) {
+    if let error = composer.handleAttachmentImport(result, projectPath: sessionModel.projectPath) {
+      sessionModel.lastError = error
+    }
+  }
+
+  func toggleDictation() {
+    Task {
+      if let error = await composer.toggleDictation(localDictationEnabled: localDictationEnabled) {
+        sessionModel.lastError = error
+      }
+    }
+  }
+}

--- a/OrbitDockNative/OrbitDock/Views/Sessions/ControlDeck/ControlDeckScreen+Attachments.swift
+++ b/OrbitDockNative/OrbitDock/Views/Sessions/ControlDeck/ControlDeckScreen+Attachments.swift
@@ -1,0 +1,137 @@
+import ImageIO
+import SwiftUI
+import UniformTypeIdentifiers
+
+#if os(macOS)
+  import AppKit
+#endif
+
+#if os(iOS)
+  import UIKit
+#endif
+
+#if os(macOS)
+  extension ControlDeckScreen {
+    var supportsImageClipboardPaste: Bool {
+      NSPasteboard.general.availableType(from: [.tiff, .png]) != nil
+    }
+
+    @discardableResult
+    func pasteImageFromClipboard() -> Bool {
+      let pasteboard = NSPasteboard.general
+      guard let imageType = pasteboard.availableType(from: [.tiff, .png]),
+            let data = pasteboard.data(forType: imageType),
+            let normalized = Self.normalizedPNG(from: data)
+      else { return false }
+
+      let dims = ControlDeckComposerModel.imageDimensions(from: normalized)
+      composer.appendDroppedImage(
+        ControlDeckImageDraft(
+          localId: UUID().uuidString,
+          thumbnailData: normalized.count < 500_000 ? normalized : nil,
+          uploadData: normalized,
+          uploadMimeType: "image/png",
+          displayName: "Clipboard Image",
+          pixelWidth: dims.width,
+          pixelHeight: dims.height
+        )
+      )
+      return true
+    }
+
+    func handleDrop(_ providers: [NSItemProvider]) -> Bool {
+      var handled = false
+      for provider in providers where provider.hasItemConformingToTypeIdentifier(UTType.fileURL.identifier) {
+        provider.loadItem(forTypeIdentifier: UTType.fileURL.identifier, options: nil) { item, _ in
+          guard let url = Self.droppedFileURL(from: item),
+                url.isFileURL,
+                UTType(filenameExtension: url.pathExtension)?.conforms(to: .image) == true,
+                let payload = try? ControlDeckComposerModel.makeImagePayloadIfNeeded(from: url)
+          else { return }
+
+          Task { @MainActor in
+            composer.appendDroppedImage(payload)
+          }
+        }
+        handled = true
+      }
+      return handled
+    }
+
+    private static func normalizedPNG(from data: Data) -> Data? {
+      guard let source = CGImageSourceCreateWithData(data as CFData, nil),
+            let cgImage = CGImageSourceCreateImageAtIndex(source, 0, nil)
+      else { return nil }
+
+      let out = NSMutableData()
+      guard let destination = CGImageDestinationCreateWithData(
+        out,
+        UTType.png.identifier as CFString,
+        1,
+        nil
+      ) else { return nil }
+
+      CGImageDestinationAddImage(destination, cgImage, nil)
+      guard CGImageDestinationFinalize(destination) else { return nil }
+      return out as Data
+    }
+
+    private static func droppedFileURL(from item: NSSecureCoding?) -> URL? {
+      (item as? URL)
+        ?? (item as? NSURL) as URL?
+        ?? (item as? Data).flatMap { URL(dataRepresentation: $0, relativeTo: nil) }
+    }
+  }
+#endif
+
+#if os(iOS)
+  extension ControlDeckScreen {
+    var supportsImageClipboardPaste: Bool {
+      UIPasteboard.general.hasImages
+    }
+
+    @discardableResult
+    func pasteImageFromClipboard() -> Bool {
+      guard let image = UIPasteboard.general.image, let data = image.pngData() else { return false }
+
+      let dims = ControlDeckComposerModel.imageDimensions(from: data)
+      composer.appendDroppedImage(
+        ControlDeckImageDraft(
+          localId: UUID().uuidString,
+          thumbnailData: data.count < 500_000 ? data : nil,
+          uploadData: data,
+          uploadMimeType: "image/png",
+          displayName: "Clipboard Image",
+          pixelWidth: dims.width,
+          pixelHeight: dims.height
+        )
+      )
+      return true
+    }
+
+    func handleDrop(_ providers: [NSItemProvider]) -> Bool {
+      var handled = false
+      for provider in providers where provider.canLoadObject(ofClass: UIImage.self) {
+        provider.loadObject(ofClass: UIImage.self) { object, _ in
+          guard let image = object as? UIImage, let data = image.pngData() else { return }
+
+          let dims = ControlDeckComposerModel.imageDimensions(from: data)
+          let payload = ControlDeckImageDraft(
+            localId: UUID().uuidString,
+            thumbnailData: data.count < 500_000 ? data : nil,
+            uploadData: data,
+            uploadMimeType: "image/png",
+            displayName: "Dropped Image",
+            pixelWidth: dims.width,
+            pixelHeight: dims.height
+          )
+          Task { @MainActor in
+            composer.appendDroppedImage(payload)
+          }
+        }
+        handled = true
+      }
+      return handled
+    }
+  }
+#endif

--- a/OrbitDockNative/OrbitDock/Views/Sessions/ControlDeck/ControlDeckScreen+Sections.swift
+++ b/OrbitDockNative/OrbitDock/Views/Sessions/ControlDeck/ControlDeckScreen+Sections.swift
@@ -1,0 +1,201 @@
+import SwiftUI
+
+extension ControlDeckScreen {
+  var currentMode: ControlDeckMode {
+    sessionModel.presentation?.mode ?? .disabled
+  }
+
+  var canSubmit: Bool {
+    let modeAllowsInput = currentMode == .compose || currentMode == .steer
+    return modeAllowsInput && composer.draft.hasContent && !composer.isSubmitting && !sessionModel.isResuming
+  }
+
+  var isInputEnabled: Bool {
+    (currentMode == .compose || currentMode == .steer) && !composer.isSubmitting && !sessionModel.isResuming
+  }
+
+  var shouldShowDictation: Bool {
+    localDictationEnabled && LocalDictationAvailabilityResolver.current == .available
+  }
+
+  var isDictationActive: Bool {
+    composer.dictationController.state == .recording
+      || composer.dictationController.state == .requestingPermission
+      || composer.dictationController.state == .transcribing
+  }
+
+  var dictationAction: (() -> Void)? {
+    shouldShowDictation ? { toggleDictation() } : nil
+  }
+
+  var isApprovalMode: Bool {
+    currentMode == .approval && sessionModel.pendingApproval != nil
+  }
+
+  var shouldShowCompletionPanel: Bool {
+    composer.completionState.isActive && !isApprovalMode
+  }
+
+  var isCompact: Bool {
+    horizontalSizeClass == .compact
+  }
+
+  var horizontalContentPadding: CGFloat {
+    isCompact ? Spacing.sm : Spacing.md
+  }
+
+  var completionPanelWidth: CGFloat {
+    let available = max(composer.controlDeckWidth - (horizontalContentPadding * 2), 0)
+    guard available > 0 else { return 520 }
+    return available
+  }
+
+  var currentSuggestions: [ControlDeckCompletionSuggestion] {
+    composer.currentSuggestions(
+      availableSkills: sessionModel.skills,
+      projectPath: sessionModel.projectPath,
+      projectFileIndex: sessionModel.projectFileIndex
+    )
+  }
+
+  var controlDeckBody: some View {
+    ControlDeckView(
+      composer: composer,
+      isSubmitting: composer.isSubmitting,
+      isResuming: sessionModel.isResuming,
+      isInputEnabled: isInputEnabled,
+      canSubmit: canSubmit,
+      presentation: sessionModel.presentation,
+      pendingApproval: sessionModel.pendingApproval,
+      errorMessage: sessionModel.lastError,
+      chromeStyle: chromeStyle,
+      onTextChange: handleTextChange,
+      onKeyCommand: handleKeyCommand,
+      onFocusEvent: handleFocusEvent,
+      onPasteImage: pasteImageFromClipboard,
+      canPasteImage: { supportsImageClipboardPaste },
+      onAddImage: { composer.isImportingAttachments = true },
+      onRemoveAttachment: { composer.draft.attachments.remove(id: $0) },
+      onDropImages: handleDrop,
+      onSubmit: submitDraft,
+      onResume: resumeSession,
+      onApprove: { Task { await sessionModel.approveTool(decision: .approved) } },
+      onApproveForSession: { Task { await sessionModel.approveTool(decision: .approvedForSession) } },
+      onApproveAlwaysForHost: { host in
+        Task { await sessionModel.approveToolAlwaysAllowHost(host) }
+      },
+      onDeny: { Task { await sessionModel.approveTool(decision: .denied) } },
+      onAnswer: { answer, promptId in
+        Task { await sessionModel.answerQuestion(answer: answer, questionId: promptId) }
+      },
+      onSubmitAllAnswers: { answers in
+        Task { await sessionModel.answerQuestionBatch(answers: answers) }
+      },
+      onGrantPermission: { Task { await sessionModel.respondToPermission(grant: true, scope: .turn) } },
+      onGrantPermissionForSession: {
+        Task { await sessionModel.respondToPermission(grant: true, scope: .session) }
+      },
+      onDenyPermission: { Task { await sessionModel.respondToPermission(grant: false) } },
+      terminalTitle: terminalTitle,
+      sessionDisplayStatus: sessionDisplayStatus,
+      currentTool: currentTool,
+      onToggleTerminal: onToggleTerminal,
+      onModuleAction: handleModuleAction,
+      onApprovalReviewerAction: handleApprovalReviewerAction,
+      onSandboxPolicyAction: handleSandboxPolicyAction,
+      isDictating: isDictationActive,
+      isSessionWorking: sessionModel.steerable,
+      onDictation: dictationAction,
+      onInterrupt: { Task { await sessionModel.interruptSession() } }
+    )
+    .background(
+      GeometryReader { proxy in
+        Color.clear.preference(key: ControlDeckWidthPreferenceKey.self, value: proxy.size.width)
+      }
+    )
+    .overlay(alignment: .topLeading) {
+      if shouldShowCompletionPanel {
+        completionPanelOverlay
+      }
+    }
+    .onPreferenceChange(ControlDeckWidthPreferenceKey.self) { width in
+      guard width > 0 else { return }
+      composer.controlDeckWidth = width
+    }
+    .onPreferenceChange(ControlDeckCompletionPanelHeightPreferenceKey.self) { height in
+      guard height > 0 else { return }
+      composer.completionPanelHeight = height
+    }
+    .zIndex(2)
+  }
+
+  var completionPanelOverlay: some View {
+    ControlDeckCompletionPanel(
+      mode: composer.completionState.mode,
+      suggestions: currentSuggestions,
+      selectedIndex: composer.completionState.selectedIndex,
+      onSelect: acceptSuggestion
+    )
+    .frame(width: completionPanelWidth, alignment: .leading)
+    .background(
+      GeometryReader { proxy in
+        Color.clear.preference(
+          key: ControlDeckCompletionPanelHeightPreferenceKey.self,
+          value: proxy.size.height
+        )
+      }
+    )
+    .offset(x: horizontalContentPadding, y: -(composer.completionPanelHeight + Spacing.xs))
+    .transition(.move(edge: .top).combined(with: .opacity))
+    .animation(Motion.gentle, value: shouldShowCompletionPanel)
+    .zIndex(10)
+  }
+
+  var loadingView: some View {
+    ProgressView()
+      .controlSize(.small)
+      .frame(maxWidth: .infinity, minHeight: 60)
+      .background(Color.backgroundSecondary)
+      .clipShape(RoundedRectangle(cornerRadius: Radius.xl, style: .continuous))
+      .overlay(
+        RoundedRectangle(cornerRadius: Radius.xl, style: .continuous)
+          .strokeBorder(Color.panelBorder, lineWidth: 1)
+      )
+  }
+
+  func errorView(_ error: String) -> some View {
+    VStack(spacing: Spacing.sm) {
+      Text(error)
+        .font(.system(size: TypeScale.caption, weight: .medium, design: .monospaced))
+        .foregroundStyle(Color.statusPermission)
+        .lineLimit(3)
+      Button("Retry") { Task { await sessionModel.refresh() } }
+        .buttonStyle(.bordered)
+        .controlSize(.small)
+    }
+    .padding(Spacing.lg)
+    .frame(maxWidth: .infinity)
+    .background(Color.backgroundSecondary)
+    .clipShape(RoundedRectangle(cornerRadius: Radius.xl, style: .continuous))
+    .overlay(
+      RoundedRectangle(cornerRadius: Radius.xl, style: .continuous)
+        .strokeBorder(Color.panelBorder, lineWidth: 1)
+    )
+  }
+}
+
+struct ControlDeckWidthPreferenceKey: PreferenceKey {
+  static var defaultValue: CGFloat = 0
+
+  static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
+    value = max(value, nextValue())
+  }
+}
+
+struct ControlDeckCompletionPanelHeightPreferenceKey: PreferenceKey {
+  static var defaultValue: CGFloat = 0
+
+  static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
+    value = max(value, nextValue())
+  }
+}

--- a/OrbitDockNative/OrbitDock/Views/Sessions/ControlDeck/ControlDeckScreen.swift
+++ b/OrbitDockNative/OrbitDock/Views/Sessions/ControlDeck/ControlDeckScreen.swift
@@ -1,98 +1,31 @@
-import ImageIO
 import SwiftUI
 import UniformTypeIdentifiers
-#if os(macOS)
-  import AppKit
-#endif
-#if os(iOS)
-  import UIKit
-#endif
 
 struct ControlDeckScreen: View {
-  @Environment(\.horizontalSizeClass) private var horizontalSizeClass
+  @Environment(\.horizontalSizeClass) var horizontalSizeClass
 
   let sessionId: String
   let sessionStore: SessionStore
   var chromeStyle: ControlDeckChromeStyle = .standalone
-
-  // Terminal integration — passed from SessionDetailView
   var terminalTitle: String?
   var sessionDisplayStatus: SessionDisplayStatus = .ended
   var currentTool: String?
   var onFocusStateChange: ((Bool) -> Void)?
   var onToggleTerminal: (() -> Void)?
 
-  @State private var viewModel = ControlDeckViewModel()
-  @State private var draft = ControlDeckDraft()
-  @State private var completionState = ControlDeckCompletionState()
-  @State private var focusState = ControlDeckFocusState()
-  @State private var isSubmitting = false
-  @State private var uploadedImageIds: [String: String] = [:]
-  @State private var isImportingAttachments = false
-  @State private var dictationController = LocalDictationController()
-  @State private var dictationDraftBase: String?
-  @State private var controlDeckWidth: CGFloat = 0
-  @State private var completionPanelHeight: CGFloat = 0
-  @AppStorage("localDictationEnabled") private var localDictationEnabled = true
-  private var bindingIdentity: String {
+  @State var sessionModel = ControlDeckSessionModel()
+  @State var composer = ControlDeckComposerModel()
+  @AppStorage("localDictationEnabled") var localDictationEnabled = true
+
+  var bindingIdentity: String {
     "\(sessionStore.endpointId.uuidString):\(sessionId):\(ObjectIdentifier(sessionStore))"
   }
 
-  private var currentMode: ControlDeckMode {
-    viewModel.presentation?.mode ?? .disabled
-  }
-
-  private var canSubmit: Bool {
-    let modeAllowsInput = currentMode == .compose || currentMode == .steer
-    return modeAllowsInput && draft.hasContent && !isSubmitting && !viewModel.isResuming
-  }
-
-  private var isInputEnabled: Bool {
-    return (currentMode == .compose || currentMode == .steer) && !isSubmitting && !viewModel.isResuming
-  }
-
-  private var shouldShowDictation: Bool {
-    localDictationEnabled && LocalDictationAvailabilityResolver.current == .available
-  }
-
-  private var isDictationActive: Bool {
-    dictationController.state == .recording ||
-      dictationController.state == .requestingPermission ||
-      dictationController.state == .transcribing
-  }
-
-  private var dictationAction: (() -> Void)? {
-    shouldShowDictation ? { toggleDictation() } : nil
-  }
-
-  private var isApprovalMode: Bool {
-    currentMode == .approval && viewModel.pendingApproval != nil
-  }
-
-  private var shouldShowCompletionPanel: Bool {
-    completionState.isActive && !isApprovalMode
-  }
-
-  private var isCompact: Bool {
-    horizontalSizeClass == .compact
-  }
-
-  private var horizontalContentPadding: CGFloat {
-    isCompact ? Spacing.sm : Spacing.md
-  }
-
-  private var completionPanelWidth: CGFloat {
-    let available = max(controlDeckWidth - (horizontalContentPadding * 2), 0)
-    guard available > 0 else { return 520 }
-    return available
-  }
-
-
   var body: some View {
     Group {
-      if viewModel.isLoading, viewModel.snapshot == nil {
+      if sessionModel.isLoading, sessionModel.snapshot == nil {
         loadingView
-      } else if let error = viewModel.lastError, viewModel.snapshot == nil {
+      } else if let error = sessionModel.lastError, sessionModel.snapshot == nil {
         errorView(error)
       } else {
         controlDeckBody
@@ -102,683 +35,50 @@ struct ControlDeckScreen: View {
     .padding(.top, chromeStyle == .embedded ? Spacing.xxs : 0)
     .padding(.bottom, Spacing.xs)
     .task(id: bindingIdentity) {
-      draft = ControlDeckDraft.restore(for: sessionId)
-      viewModel.bind(sessionId: sessionId, sessionStore: sessionStore)
-      await viewModel.refresh()
+      composer.restoreDraft(for: sessionId)
+      sessionModel.bind(sessionId: sessionId, sessionStore: sessionStore)
+      await sessionModel.refresh()
     }
-    .onChange(of: draft) { _, newDraft in
-      ControlDeckDraft.save(newDraft, for: sessionId)
+    .onChange(of: composer.draft) { _, _ in
+      composer.persistDraft(for: sessionId)
     }
-    .onChange(of: viewModel.skills) { _, _ in
-      syncSelectedSkillsFromText(draft.text)
+    .onChange(of: sessionModel.skills) { _, _ in
+      composer.syncSelectedSkillsFromText(composer.draft.text, availableSkills: sessionModel.skills)
     }
     .task(id: bindingIdentity + ":ws") {
-      // Re-fetch only when the control deck contract says this surface changed.
       let (stream, _) = sessionStore.controlDeckRefreshRequests(for: sessionId)
       for await _ in stream {
         guard !Task.isCancelled else { break }
         netLog(.debug, cat: .store, "ControlDeckScreen refresh signal", sid: sessionId)
-        await viewModel.refresh()
+        await sessionModel.refresh()
       }
     }
-    .onChange(of: viewModel.pendingApproval) { old, new in
+    .onChange(of: sessionModel.pendingApproval) { old, new in
       if old == nil, new != nil {
         Platform.services.playHaptic(.warning)
       }
     }
-    .onChange(of: dictationController.liveTranscript) { _, transcript in
-      guard dictationController.isRecording else { return }
-      updateDictationLivePreview(transcript)
+    .onChange(of: composer.dictationController.liveTranscript) { _, transcript in
+      guard composer.dictationController.isRecording else { return }
+      composer.updateDictationLivePreview(transcript)
     }
     .onChange(of: localDictationEnabled) { _, enabled in
       if !enabled {
-        Task { await dictationController.cancel(); dictationDraftBase = nil }
+        Task { await composer.cancelDictation() }
       }
     }
-    .task(id: viewModel.snapshot?.state.projectPath ?? "") {
-      guard let path = viewModel.snapshot?.state.projectPath, !path.isEmpty else { return }
-      await viewModel.projectFileIndex?.loadIfNeeded(path)
+    .task(id: sessionModel.snapshot?.state.projectPath ?? "") {
+      guard let path = sessionModel.snapshot?.state.projectPath, !path.isEmpty else { return }
+      await sessionModel.projectFileIndex?.loadIfNeeded(path)
     }
     .fileImporter(
-      isPresented: $isImportingAttachments,
+      isPresented: Binding(
+        get: { composer.isImportingAttachments },
+        set: { composer.isImportingAttachments = $0 }
+      ),
       allowedContentTypes: [.item],
       allowsMultipleSelection: true,
       onCompletion: handleAttachmentImport
     )
   }
-
-  private var controlDeckBody: some View {
-    ControlDeckView(
-      draft: $draft,
-      focusState: $focusState,
-      isSubmitting: isSubmitting,
-      isResuming: viewModel.isResuming,
-      isInputEnabled: isInputEnabled,
-      canSubmit: canSubmit,
-      presentation: viewModel.presentation,
-      pendingApproval: viewModel.pendingApproval,
-      errorMessage: viewModel.lastError,
-      chromeStyle: chromeStyle,
-      onTextChange: handleTextChange,
-      onKeyCommand: handleKeyCommand,
-      onFocusEvent: handleFocusEvent,
-      onPasteImage: pasteImageFromClipboard,
-      canPasteImage: { supportsImageClipboardPaste },
-      onAddImage: { isImportingAttachments = true },
-      onRemoveAttachment: { draft.attachments.remove(id: $0) },
-      onDropImages: handleDrop,
-      onSubmit: submitDraft,
-      onResume: resumeSession,
-      onApprove: { Task { await viewModel.approveTool(decision: .approved) } },
-      onApproveForSession: { Task { await viewModel.approveTool(decision: .approvedForSession) } },
-      onApproveAlwaysForHost: { host in
-        Task { await viewModel.approveToolAlwaysAllowHost(host) }
-      },
-      onDeny: { Task { await viewModel.approveTool(decision: .denied) } },
-      onAnswer: { answer, promptId in
-        Task { await viewModel.answerQuestion(answer: answer, questionId: promptId) }
-      },
-      onSubmitAllAnswers: { answers in
-        Task { await viewModel.answerQuestionBatch(answers: answers) }
-      },
-      onGrantPermission: { Task { await viewModel.respondToPermission(grant: true, scope: .turn) } },
-      onGrantPermissionForSession: { Task { await viewModel.respondToPermission(grant: true, scope: .session) } },
-      onDenyPermission: { Task { await viewModel.respondToPermission(grant: false) } },
-      terminalTitle: terminalTitle,
-      sessionDisplayStatus: sessionDisplayStatus,
-      currentTool: currentTool,
-      onToggleTerminal: onToggleTerminal,
-      onModuleAction: handleModuleAction,
-      onApprovalReviewerAction: handleApprovalReviewerAction,
-      onSandboxPolicyAction: handleSandboxPolicyAction,
-      isDictating: isDictationActive,
-      isSessionWorking: viewModel.steerable,
-      onDictation: dictationAction,
-      onInterrupt: { Task { await viewModel.interruptSession() } }
-    )
-    .background(
-      GeometryReader { proxy in
-        Color.clear.preference(key: ControlDeckWidthPreferenceKey.self, value: proxy.size.width)
-      }
-    )
-    .overlay(alignment: .topLeading) {
-      if shouldShowCompletionPanel {
-        completionPanelOverlay
-      }
-    }
-    .onPreferenceChange(ControlDeckWidthPreferenceKey.self) { width in
-      guard width > 0 else { return }
-      controlDeckWidth = width
-    }
-    .onPreferenceChange(ControlDeckCompletionPanelHeightPreferenceKey.self) { height in
-      guard height > 0 else { return }
-      completionPanelHeight = height
-    }
-    .zIndex(2)
-  }
-
-  private var completionPanelOverlay: some View {
-    ControlDeckCompletionPanel(
-      mode: completionState.mode,
-      suggestions: currentSuggestions,
-      selectedIndex: completionState.selectedIndex,
-      onSelect: acceptSuggestion
-    )
-    .frame(width: completionPanelWidth, alignment: .leading)
-    .background(
-      GeometryReader { proxy in
-        Color.clear.preference(key: ControlDeckCompletionPanelHeightPreferenceKey.self, value: proxy.size.height)
-      }
-    )
-    .offset(x: horizontalContentPadding, y: -(completionPanelHeight + Spacing.xs))
-    .transition(.move(edge: .top).combined(with: .opacity))
-    .animation(Motion.gentle, value: shouldShowCompletionPanel)
-    .zIndex(10)
-  }
-
-  // MARK: - Loading / Error
-
-  private var loadingView: some View {
-    ProgressView()
-      .controlSize(.small)
-      .frame(maxWidth: .infinity, minHeight: 60)
-      .background(Color.backgroundSecondary)
-      .clipShape(RoundedRectangle(cornerRadius: Radius.xl, style: .continuous))
-      .overlay(
-        RoundedRectangle(cornerRadius: Radius.xl, style: .continuous)
-          .strokeBorder(Color.panelBorder, lineWidth: 1)
-      )
-  }
-
-  private func errorView(_ error: String) -> some View {
-    VStack(spacing: Spacing.sm) {
-      Text(error)
-        .font(.system(size: TypeScale.caption, weight: .medium, design: .monospaced))
-        .foregroundStyle(Color.statusPermission)
-        .lineLimit(3)
-      Button("Retry") { Task { await viewModel.refresh() } }
-        .buttonStyle(.bordered)
-        .controlSize(.small)
-    }
-    .padding(Spacing.lg)
-    .frame(maxWidth: .infinity)
-    .background(Color.backgroundSecondary)
-    .clipShape(RoundedRectangle(cornerRadius: Radius.xl, style: .continuous))
-    .overlay(
-      RoundedRectangle(cornerRadius: Radius.xl, style: .continuous)
-        .strokeBorder(Color.panelBorder, lineWidth: 1)
-    )
-  }
-
-  // MARK: - Text Change → Completions
-
-  private func handleTextChange(_ text: String) {
-    syncSelectedSkillsFromText(text)
-
-    let nextMode = ControlDeckAutocompletePlanner.completionMode(for: text)
-    switch nextMode {
-      case .skill:
-        if viewModel.skills.isEmpty {
-          Task { await viewModel.loadSkills() }
-        }
-        completionState.activate(nextMode)
-      case .mention:
-        completionState.activate(nextMode)
-      case .inactive, .command:
-        completionState.dismiss()
-    }
-  }
-
-  private var currentSuggestions: [ControlDeckCompletionSuggestion] {
-    switch completionState.mode {
-      case .inactive:
-        return []
-      case let .mention(query):
-        let files = viewModel.projectFileIndex?.search(query, in: viewModel.projectPath ?? "") ?? []
-        return files.prefix(ControlDeckAutocompletePlanner.maxSuggestionCount).map { file in
-          ControlDeckCompletionSuggestion(id: file.id, kind: .file, title: file.name, subtitle: file.relativePath)
-        }
-      case let .skill(query):
-        return ControlDeckAutocompletePlanner.skillSuggestions(for: query, skills: viewModel.skills)
-      case .command:
-        return []
-    }
-  }
-
-  // MARK: - Keyboard Commands
-
-  private func handleKeyCommand(_ command: ControlDeckTextAreaKeyCommand) -> Bool {
-    if completionState.isActive {
-      let suggestions = currentSuggestions
-      switch command {
-        case .escape:
-          completionState.dismiss()
-          return true
-        case .upArrow, .controlP:
-          completionState.moveUp()
-          return true
-        case .downArrow, .controlN:
-          completionState.moveDown(itemCount: suggestions.count)
-          return true
-        case .tab, .returnKey:
-          guard suggestions.indices.contains(completionState.selectedIndex) else { return false }
-          acceptSuggestion(suggestions[completionState.selectedIndex])
-          return true
-        default:
-          return false
-      }
-    }
-
-    if command == .returnKey, canSubmit {
-      submitDraft()
-      return true
-    }
-
-    return false
-  }
-
-  // MARK: - Focus
-
-  private func handleFocusEvent(_ event: ControlDeckTextAreaFocusEvent) {
-    switch event {
-      case .began:
-        focusState.isFocused = true
-        onFocusStateChange?(true)
-      case .ended(userInitiated: _):
-        focusState.isFocused = false
-        onFocusStateChange?(false)
-    }
-  }
-
-  // MARK: - Module Actions
-
-  private func handleModuleAction(_ module: ControlDeckStatusModule, _ value: String) {
-    netLog(.info, cat: .store, "ControlDeck module action tapped", sid: sessionId, data: [
-      "module": module.rawValue,
-      "value": value,
-    ])
-    Task {
-      switch module {
-        case .model:
-          await viewModel.updateModel(value)
-        case .effort:
-          await viewModel.updateEffort(value)
-        case .autonomy:
-          await viewModel.updatePermissionMode(value)
-        case .approvalMode:
-          await viewModel.updateApprovalPolicy(value)
-        case .collaborationMode:
-          await viewModel.updateCollaborationMode(value)
-        case .autoReview:
-          await viewModel.updateAutoReview(value)
-        default:
-          break
-      }
-    }
-  }
-
-  private func handleApprovalReviewerAction(_ reviewer: ServerCodexApprovalsReviewer) {
-    netLog(.info, cat: .store, "ControlDeck approval reviewer action tapped", sid: sessionId, data: [
-      "reviewer": reviewer.rawValue,
-    ])
-    Task {
-      await viewModel.updateApprovalsReviewer(reviewer)
-    }
-  }
-
-  private func handleSandboxPolicyAction(_ policy: ServerCodexSandboxPolicy) {
-    netLog(.info, cat: .store, "ControlDeck sandbox policy action tapped", sid: sessionId, data: [
-      "policy": policy.legacySummary,
-    ])
-    Task {
-      await viewModel.updateSandboxPolicy(policy)
-    }
-  }
-
-  // MARK: - Suggestion Acceptance
-
-  private func acceptSuggestion(_ suggestion: ControlDeckCompletionSuggestion) {
-    switch suggestion.kind {
-      case .file:
-        acceptFileSuggestion(suggestion)
-      case .skill:
-        acceptSkillSuggestion(suggestion)
-      case .command:
-        break
-    }
-  }
-
-  private func acceptFileSuggestion(_ suggestion: ControlDeckCompletionSuggestion) {
-    guard let projectPath = viewModel.projectPath,
-          let file = viewModel.projectFileIndex?.files(for: projectPath).first(where: { $0.id == suggestion.id })
-    else { return }
-
-    draft.text = ControlDeckTextEditing.replacingTrailingToken(
-      in: draft.text,
-      prefix: "@",
-      with: "@\(file.name) "
-    )
-    let absolutePath = (projectPath as NSString).appendingPathComponent(file.relativePath)
-    draft.attachments.appendMention(ControlDeckMentionDraft(
-      fileId: file.id,
-      name: file.name,
-      absolutePath: absolutePath,
-      relativePath: file.relativePath,
-      kind: .file
-    ))
-    completionState.dismiss()
-    focusState.requestFocus()
-    focusState.moveCursorToEnd()
-  }
-
-  private func acceptSkillSuggestion(_ suggestion: ControlDeckCompletionSuggestion) {
-    guard let skill = viewModel.skills.first(where: { $0.id == suggestion.id }) else { return }
-
-    draft.text = ControlDeckTextEditing.replacingTrailingToken(
-      in: draft.text,
-      prefix: "$",
-      with: "$\(skill.name) "
-    )
-    draft.selectedSkillPaths.insert(skill.path)
-    completionState.dismiss()
-    focusState.requestFocus()
-    focusState.moveCursorToEnd()
-  }
-
-  // MARK: - Submit
-
-  private func submitDraft() {
-    guard draft.hasContent, !isSubmitting else { return }
-
-    let shouldSteer = currentMode == .steer || viewModel.steerable
-    isSubmitting = true
-    let currentDraft = draft
-
-    Task {
-      defer { isSubmitting = false }
-      do {
-        // Upload images first so both compose and steer can reference the same server attachment IDs.
-        var imageIds = uploadedImageIds
-        for image in currentDraft.attachments.images {
-          if imageIds[image.localId] == nil {
-            let attachmentId = try await viewModel.uploadImage(
-              data: image.uploadData,
-              mimeType: image.uploadMimeType,
-              displayName: image.displayName,
-              pixelWidth: image.pixelWidth,
-              pixelHeight: image.pixelHeight
-            )
-            imageIds[image.localId] = attachmentId
-          }
-        }
-
-        if shouldSteer {
-          try await viewModel.steerTurn(draft: currentDraft, uploadedImageIds: imageIds)
-          uploadedImageIds = [:]
-        } else {
-          try await viewModel.submitTurn(draft: currentDraft, uploadedImageIds: imageIds)
-          uploadedImageIds = [:]
-        }
-
-        draft.clearAfterSubmit()
-        ControlDeckDraft.clear(for: sessionId)
-        completionState.dismiss()
-        viewModel.lastError = nil
-        focusState.requestFocus()
-      } catch {
-        viewModel.lastError = String(describing: error)
-        // Refresh to pick up server-side state changes (e.g. session moved
-        // to Resumable after connector detached) so the UI reflects reality.
-        await viewModel.refresh()
-      }
-    }
-  }
-
-  private func resumeSession() {
-    guard !isSubmitting else { return }
-    netLog(.info, cat: .store, "ControlDeckScreen resume tapped", sid: sessionId, data: [
-      "isSubmitting": isSubmitting,
-      "isResuming": viewModel.isResuming,
-      "presentationMode": debugModeLabel(viewModel.presentation?.mode),
-      "canResume": viewModel.presentation?.canResume ?? false,
-    ])
-    Task { await viewModel.resumeSession() }
-  }
-
-  private func syncSelectedSkillsFromText(_ text: String) {
-    guard !viewModel.skills.isEmpty else { return }
-    let matched = ControlDeckSkillResolver.matchedSkillPaths(in: text, availableSkills: viewModel.skills)
-    guard matched != draft.selectedSkillPaths else { return }
-    draft.selectedSkillPaths = matched
-  }
-
-  // MARK: - Image Handling
-
-  private func handleAttachmentImport(_ result: Result<[URL], Error>) {
-    guard case let .success(urls) = result, !urls.isEmpty else {
-      if case let .failure(error) = result {
-        viewModel.lastError = String(describing: error)
-      }
-      return
-    }
-
-    for url in urls {
-      do {
-        if let imagePayload = try Self.makeImagePayloadIfNeeded(from: url) {
-          draft.attachments.appendImage(imagePayload)
-        } else {
-          try appendFileMention(from: url)
-        }
-      } catch {
-        viewModel.lastError = String(describing: error)
-      }
-    }
-  }
-
-  private func appendFileMention(from url: URL) throws {
-    let requiresScope = url.startAccessingSecurityScopedResource()
-    defer { if requiresScope { url.stopAccessingSecurityScopedResource() } }
-
-    let standardizedURL = url.standardizedFileURL
-    let absolutePath = standardizedURL.path
-    guard !absolutePath.isEmpty else { return }
-
-    let projectPath = viewModel.projectPath?.trimmingCharacters(in: .whitespacesAndNewlines)
-    let relativePath: String?
-    if let projectPath, !projectPath.isEmpty, absolutePath.hasPrefix(projectPath + "/") {
-      relativePath = String(absolutePath.dropFirst(projectPath.count + 1))
-    } else {
-      relativePath = nil
-    }
-
-    _ = draft.attachments.appendMention(ControlDeckMentionDraft(
-      fileId: absolutePath,
-      name: standardizedURL.lastPathComponent,
-      absolutePath: absolutePath,
-      relativePath: relativePath,
-      kind: .file
-    ))
-  }
-
-  private static func makeImagePayloadIfNeeded(from url: URL) throws -> ControlDeckImageDraft? {
-    let utType = UTType(filenameExtension: url.pathExtension.lowercased())
-    guard utType?.conforms(to: .image) == true else { return nil }
-
-    let requiresScope = url.startAccessingSecurityScopedResource()
-    defer { if requiresScope { url.stopAccessingSecurityScopedResource() } }
-
-    let data = try Data(contentsOf: url)
-    let dims = imageDimensions(from: data)
-    return ControlDeckImageDraft(
-      localId: UUID().uuidString,
-      thumbnailData: data.count < 500_000 ? data : nil,
-      uploadData: data,
-      uploadMimeType: utType?.preferredMIMEType ?? "image/png",
-      displayName: url.lastPathComponent,
-      pixelWidth: dims.width,
-      pixelHeight: dims.height
-    )
-  }
-
-  private static func imageDimensions(from data: Data) -> (width: Int?, height: Int?) {
-    guard let source = CGImageSourceCreateWithData(data as CFData, nil),
-          let props = CGImageSourceCopyPropertiesAtIndex(source, 0, nil) as? [CFString: Any]
-    else { return (nil, nil) }
-    return (props[kCGImagePropertyPixelWidth] as? Int, props[kCGImagePropertyPixelHeight] as? Int)
-  }
-
-  private func debugModeLabel(_ mode: ControlDeckMode?) -> String {
-    guard let mode else { return "nil" }
-    switch mode {
-      case .compose: return "compose"
-      case .steer: return "steer"
-      case .approval: return "approval"
-      case .disabled: return "disabled"
-    }
-  }
-
-  // MARK: - Dictation
-
-  private func toggleDictation() {
-    guard shouldShowDictation else { return }
-    Task { @MainActor in
-      if dictationController.isRecording {
-        if let dictated = await dictationController.stop() {
-          let normalized = DictationTextFormatter.normalizeTranscription(dictated)
-          // Replace only the live preview portion, keeping user edits intact
-          if let base = dictationDraftBase {
-            // Remove the live preview suffix and apply final transcript
-            let currentWithoutPreview = removeLivePreviewSuffix(from: draft.text, base: base)
-            draft.text = DictationTextFormatter.merge(existing: currentWithoutPreview, dictated: normalized)
-          } else {
-            draft.text = DictationTextFormatter.merge(existing: draft.text, dictated: normalized)
-          }
-        }
-        dictationDraftBase = nil
-        focusState.moveCursorToEnd()
-        Platform.services.playHaptic(.action)
-      } else {
-        // Snapshot current text as the base — live preview appends after this
-        dictationDraftBase = draft.text
-        await dictationController.start()
-        if dictationController.isRecording {
-          Platform.services.playHaptic(.action)
-        } else {
-          dictationDraftBase = nil
-          if dictationController.errorMessage != nil {
-            viewModel.lastError = dictationController.errorMessage
-            Platform.services.playHaptic(.error)
-          }
-        }
-      }
-    }
-  }
-
-  private func updateDictationLivePreview(_ transcript: String) {
-    guard let base = dictationDraftBase else { return }
-    let normalized = DictationTextFormatter.normalizeTranscription(transcript)
-    // Always merge against the snapshot base so user edits before dictation are preserved
-    let merged = DictationTextFormatter.merge(existing: base, dictated: normalized)
-    guard merged != draft.text else { return }
-    draft.text = merged
-    focusState.moveCursorToEnd()
-  }
-
-  private func removeLivePreviewSuffix(from current: String, base: String) -> String {
-    // If the current text starts with the base, return just the base
-    // (user edits during dictation are in the base region)
-    current.hasPrefix(base) ? base : current
-  }
 }
-
-private struct ControlDeckWidthPreferenceKey: PreferenceKey {
-  static var defaultValue: CGFloat = 0
-
-  static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
-    value = max(value, nextValue())
-  }
-}
-
-private struct ControlDeckCompletionPanelHeightPreferenceKey: PreferenceKey {
-  static var defaultValue: CGFloat = 0
-
-  static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
-    value = max(value, nextValue())
-  }
-}
-
-// MARK: - Platform Clipboard + Drop
-
-#if os(macOS)
-  extension ControlDeckScreen {
-    var supportsImageClipboardPaste: Bool {
-      NSPasteboard.general.availableType(from: [.tiff, .png]) != nil
-    }
-
-    @discardableResult
-    func pasteImageFromClipboard() -> Bool {
-      let pb = NSPasteboard.general
-      guard let imageType = pb.availableType(from: [.tiff, .png]),
-            let data = pb.data(forType: imageType),
-            let normalized = Self.normalizedPNG(from: data)
-      else { return false }
-
-      let dims = Self.imageDimensions(from: normalized)
-      draft.attachments.appendImage(ControlDeckImageDraft(
-        localId: UUID().uuidString,
-        thumbnailData: normalized.count < 500_000 ? normalized : nil,
-        uploadData: normalized,
-        uploadMimeType: "image/png",
-        displayName: "Clipboard Image",
-        pixelWidth: dims.width,
-        pixelHeight: dims.height
-      ))
-      return true
-    }
-
-    func handleDrop(_ providers: [NSItemProvider]) -> Bool {
-      var handled = false
-      for provider in providers {
-        if provider.hasItemConformingToTypeIdentifier(UTType.fileURL.identifier) {
-          provider.loadItem(forTypeIdentifier: UTType.fileURL.identifier, options: nil) { item, _ in
-            guard let url = Self.droppedFileURL(from: item),
-                  url.isFileURL,
-                  UTType(filenameExtension: url.pathExtension)?.conforms(to: .image) == true,
-                  let payload = try? Self.makeImagePayloadIfNeeded(from: url)
-            else { return }
-            Task { @MainActor in draft.attachments.appendImage(payload) }
-          }
-          handled = true
-        }
-      }
-      return handled
-    }
-
-    private static func normalizedPNG(from data: Data) -> Data? {
-      guard let source = CGImageSourceCreateWithData(data as CFData, nil),
-            let cgImage = CGImageSourceCreateImageAtIndex(source, 0, nil)
-      else { return nil }
-      let out = NSMutableData()
-      guard let dest = CGImageDestinationCreateWithData(out, UTType.png.identifier as CFString, 1, nil)
-      else { return nil }
-      CGImageDestinationAddImage(dest, cgImage, nil)
-      guard CGImageDestinationFinalize(dest) else { return nil }
-      return out as Data
-    }
-
-    private static func droppedFileURL(from item: NSSecureCoding?) -> URL? {
-      (item as? URL) ?? (item as? NSURL) as URL? ?? (item as? Data).flatMap { URL(
-        dataRepresentation: $0,
-        relativeTo: nil
-      ) }
-    }
-  }
-#endif
-
-#if os(iOS)
-  extension ControlDeckScreen {
-    var supportsImageClipboardPaste: Bool {
-      UIPasteboard.general.hasImages
-    }
-
-    @discardableResult
-    func pasteImageFromClipboard() -> Bool {
-      guard let image = UIPasteboard.general.image, let data = image.pngData() else { return false }
-      let dims = Self.imageDimensions(from: data)
-      draft.attachments.appendImage(ControlDeckImageDraft(
-        localId: UUID().uuidString,
-        thumbnailData: data.count < 500_000 ? data : nil,
-        uploadData: data,
-        uploadMimeType: "image/png",
-        displayName: "Clipboard Image",
-        pixelWidth: dims.width,
-        pixelHeight: dims.height
-      ))
-      return true
-    }
-
-    func handleDrop(_ providers: [NSItemProvider]) -> Bool {
-      var handled = false
-      for provider in providers {
-        if provider.canLoadObject(ofClass: UIImage.self) {
-          provider.loadObject(ofClass: UIImage.self) { object, _ in
-            guard let image = object as? UIImage, let data = image.pngData() else { return }
-            let dims = Self.imageDimensions(from: data)
-            let payload = ControlDeckImageDraft(
-              localId: UUID().uuidString,
-              thumbnailData: data.count < 500_000 ? data : nil,
-              uploadData: data,
-              uploadMimeType: "image/png",
-              displayName: "Dropped Image",
-              pixelWidth: dims.width,
-              pixelHeight: dims.height
-            )
-            Task { @MainActor in draft.attachments.appendImage(payload) }
-          }
-          handled = true
-        }
-      }
-      return handled
-    }
-  }
-#endif

--- a/OrbitDockNative/OrbitDock/Views/Sessions/ControlDeck/ControlDeckScreen.swift
+++ b/OrbitDockNative/OrbitDock/Views/Sessions/ControlDeck/ControlDeckScreen.swift
@@ -113,11 +113,11 @@ struct ControlDeckScreen: View {
       syncSelectedSkillsFromText(draft.text)
     }
     .task(id: bindingIdentity + ":ws") {
-      // WS events are triggers — re-fetch the authoritative snapshot via HTTP.
-      let (stream, _) = sessionStore.sessionChanges(for: sessionId)
+      // Re-fetch only when the control deck contract says this surface changed.
+      let (stream, _) = sessionStore.controlDeckRefreshRequests(for: sessionId)
       for await _ in stream {
         guard !Task.isCancelled else { break }
-        netLog(.debug, cat: .store, "ControlDeckScreen WS change signal", sid: sessionId)
+        netLog(.debug, cat: .store, "ControlDeckScreen refresh signal", sid: sessionId)
         await viewModel.refresh()
       }
     }
@@ -485,7 +485,6 @@ struct ControlDeckScreen: View {
         completionState.dismiss()
         viewModel.lastError = nil
         focusState.requestFocus()
-        await viewModel.refresh()
       } catch {
         viewModel.lastError = String(describing: error)
         // Refresh to pick up server-side state changes (e.g. session moved

--- a/OrbitDockNative/OrbitDock/Views/Sessions/ControlDeck/ControlDeckSessionModel.swift
+++ b/OrbitDockNative/OrbitDock/Views/Sessions/ControlDeck/ControlDeckSessionModel.swift
@@ -2,7 +2,7 @@ import Foundation
 
 @MainActor
 @Observable
-final class ControlDeckViewModel {
+final class ControlDeckSessionModel {
   private struct BindingContext {
     let sessionId: String
     let store: SessionStore
@@ -352,8 +352,6 @@ final class ControlDeckViewModel {
   }
 
   private func applyConfigUpdate(
-    action: String,
-    value: String,
     configure: (inout ServerControlDeckConfigUpdateRequest) -> Void
   ) async {
     guard let sessionId = currentSessionId, let store = currentSessionStore else { return }
@@ -365,45 +363,45 @@ final class ControlDeckViewModel {
   }
 
   func updateModel(_ model: String) async {
-    await applyConfigUpdate(action: "updateModel", value: model) { request in
+    await applyConfigUpdate { request in
       request.model = model
     }
   }
 
   func updateEffort(_ effort: String) async {
-    await applyConfigUpdate(action: "updateEffort", value: effort) { request in
+    await applyConfigUpdate { request in
       request.effort = effort
     }
   }
 
   func updatePermissionMode(_ mode: String) async {
-    await applyConfigUpdate(action: "updatePermissionMode", value: mode) { request in
+    await applyConfigUpdate { request in
       request.permissionMode = mode
     }
   }
 
   func updateApprovalPolicy(_ policy: String) async {
-    await applyConfigUpdate(action: "updateApprovalPolicy", value: policy) { request in
+    await applyConfigUpdate { request in
       request.approvalPolicy = policy
       request.approvalPolicyDetails = ServerCodexApprovalPolicy.fromLegacySummary(policy)
     }
   }
 
   func updateApprovalsReviewer(_ reviewer: ServerCodexApprovalsReviewer) async {
-    await applyConfigUpdate(action: "updateApprovalsReviewer", value: reviewer.rawValue) { request in
+    await applyConfigUpdate { request in
       request.approvalsReviewer = reviewer
     }
   }
 
   func updateSandboxPolicy(_ policy: ServerCodexSandboxPolicy) async {
-    await applyConfigUpdate(action: "updateSandboxPolicy", value: policy.legacySummary) { request in
+    await applyConfigUpdate { request in
       request.sandboxMode = policy.legacySummary
       request.sandboxPolicyDetails = policy
     }
   }
 
   func updateCollaborationMode(_ mode: String) async {
-    await applyConfigUpdate(action: "updateCollaborationMode", value: mode) { request in
+    await applyConfigUpdate { request in
       request.collaborationMode = mode
     }
   }
@@ -412,7 +410,7 @@ final class ControlDeckViewModel {
     guard let option = snapshot?.capabilities.autoReviewOptions.first(where: { $0.value == value }) else {
       return
     }
-    await applyConfigUpdate(action: "updateAutoReview", value: value) { request in
+    await applyConfigUpdate { request in
       request.approvalPolicy = option.approvalPolicy
       request.approvalPolicyDetails = option.approvalPolicyDetails
       request.sandboxMode = option.sandboxMode
@@ -623,7 +621,7 @@ final class ControlDeckViewModel {
 
 }
 
-private extension ControlDeckMode {
+extension ControlDeckMode {
   var debugLabel: String {
     switch self {
       case .compose: "compose"

--- a/OrbitDockNative/OrbitDock/Views/Sessions/ControlDeck/ControlDeckStatusBar.swift
+++ b/OrbitDockNative/OrbitDock/Views/Sessions/ControlDeck/ControlDeckStatusBar.swift
@@ -183,10 +183,79 @@ struct ControlDeckStatusBar: View {
 
   @ViewBuilder
   private func moduleView(_ module: ControlDeckStatusModuleItem) -> some View {
-    if let specialized = specializedControlView(module) {
-      specialized
-    } else {
-      genericModuleView(module)
+    switch module.id {
+      case .autonomy:
+        ClaudePermissionPill(
+          currentMode: ClaudePermissionMode(fromServer: module.selectedValue),
+          size: .statusBar,
+          onUpdate: { mode in
+            onModuleAction?(module.id, permissionModeValue(mode, for: module))
+          }
+        )
+      case .approvalMode:
+        CodexApprovalPill(
+          currentMode: CodexApprovalMode.from(rawValue: module.selectedValue),
+          currentReviewer: CodexApprovalsReviewer.from(rawValue: module.reviewerValue),
+          currentSandboxPolicy: module.sandboxPolicyDetails,
+          supportedModes: CodexApprovalMode.supportedCases(from: pickerOptions(for: module)),
+          size: .statusBar,
+          onUpdate: { mode in
+            onModuleAction?(module.id, approvalModeValue(mode, for: module))
+          },
+          onReviewerUpdate: { reviewer in
+            onApprovalReviewerAction?(ServerCodexApprovalsReviewer(rawValue: reviewer.rawValue) ?? .user)
+          },
+          onSandboxUpdate: { policy in
+            onSandboxPolicyAction?(policy)
+          }
+        )
+      case .collaborationMode:
+        CodexModePill(
+          currentMode: CodexCollaborationMode.from(rawValue: module.selectedValue),
+          supportedModes: codexCollaborationModes(for: module),
+          size: .statusBar,
+          onUpdate: { mode in
+            onModuleAction?(module.id, collaborationModeValue(mode, for: module))
+          }
+        )
+      case .autoReview:
+        if let level = AutonomyLevel.fromAutoReviewValue(module.selectedValue) {
+          CodexAutoReviewPill(
+            currentLevel: level,
+            supportedLevels: AutonomyLevel.supportedAutoReviewCases(from: pickerOptions(for: module)),
+            size: .statusBar,
+            onUpdate: { level in
+              onModuleAction?(module.id, autoReviewValue(for: level))
+            }
+          )
+        } else {
+          genericModuleView(module)
+        }
+      case .effort:
+        EffortPill(
+          currentLevel: EffortLevel.fromControlDeckValue(module.selectedValue),
+          supportedLevels: EffortLevel.supportedControlDeckCases(from: pickerOptions(for: module)),
+          size: .statusBar,
+          onUpdate: { level in
+            onModuleAction?(module.id, effortValue(level, for: module))
+          }
+        )
+      case .model:
+        let options = pickerOptions(for: module)
+        if !options.isEmpty {
+          ModelPill(
+            currentModel: module.selectedValue,
+            availableModels: options.map(\.value),
+            size: .statusBar,
+            onUpdate: { model in
+              onModuleAction?(module.id, model)
+            }
+          )
+        } else {
+          genericModuleView(module)
+        }
+      default:
+        genericModuleView(module)
     }
   }
 
@@ -308,91 +377,6 @@ struct ControlDeckStatusBar: View {
 
   private var metadataModules: [ControlDeckStatusModuleItem] {
     modules.filter { !isControlModule($0) }
-  }
-
-  private func specializedControlView(_ module: ControlDeckStatusModuleItem) -> AnyView? {
-    switch module.id {
-      case .autonomy:
-        return AnyView(
-          ClaudePermissionPill(
-            currentMode: ClaudePermissionMode(fromServer: module.selectedValue),
-            size: .statusBar,
-            onUpdate: { mode in
-              onModuleAction?(module.id, permissionModeValue(mode, for: module))
-            }
-          )
-        )
-      case .approvalMode:
-        return AnyView(
-          CodexApprovalPill(
-            currentMode: CodexApprovalMode.from(rawValue: module.selectedValue),
-            currentReviewer: CodexApprovalsReviewer.from(rawValue: module.reviewerValue),
-            currentSandboxPolicy: module.sandboxPolicyDetails,
-            supportedModes: CodexApprovalMode.supportedCases(from: pickerOptions(for: module)),
-            size: .statusBar,
-            onUpdate: { mode in
-              onModuleAction?(module.id, approvalModeValue(mode, for: module))
-            },
-            onReviewerUpdate: { reviewer in
-              onApprovalReviewerAction?(ServerCodexApprovalsReviewer(rawValue: reviewer.rawValue) ?? .user)
-            },
-            onSandboxUpdate: { policy in
-              onSandboxPolicyAction?(policy)
-            }
-          )
-        )
-      case .collaborationMode:
-        return AnyView(
-          CodexModePill(
-            currentMode: CodexCollaborationMode.from(rawValue: module.selectedValue),
-            supportedModes: codexCollaborationModes(for: module),
-            size: .statusBar,
-            onUpdate: { mode in
-              onModuleAction?(module.id, collaborationModeValue(mode, for: module))
-            }
-          )
-        )
-      case .autoReview:
-        guard let level = AutonomyLevel.fromAutoReviewValue(module.selectedValue) else {
-          return nil
-        }
-        return AnyView(
-          CodexAutoReviewPill(
-            currentLevel: level,
-            supportedLevels: AutonomyLevel.supportedAutoReviewCases(from: pickerOptions(for: module)),
-            size: .statusBar,
-            onUpdate: { level in
-              onModuleAction?(module.id, autoReviewValue(for: level))
-            }
-          )
-        )
-      case .effort:
-        return AnyView(
-          EffortPill(
-            currentLevel: EffortLevel.fromControlDeckValue(module.selectedValue),
-            supportedLevels: EffortLevel.supportedControlDeckCases(from: pickerOptions(for: module)),
-            size: .statusBar,
-            onUpdate: { level in
-              onModuleAction?(module.id, effortValue(level, for: module))
-            }
-          )
-        )
-      case .model:
-        let options = pickerOptions(for: module)
-        guard !options.isEmpty else { return nil }
-        return AnyView(
-          ModelPill(
-            currentModel: module.selectedValue,
-            availableModels: options.map(\.value),
-            size: .statusBar,
-            onUpdate: { model in
-              onModuleAction?(module.id, model)
-            }
-          )
-        )
-      default:
-        return nil
-    }
   }
 
   private func pickerOptions(for module: ControlDeckStatusModuleItem) -> [ControlDeckStatusModuleItem.Option] {

--- a/OrbitDockNative/OrbitDock/Views/Sessions/ControlDeck/ControlDeckView.swift
+++ b/OrbitDockNative/OrbitDock/Views/Sessions/ControlDeck/ControlDeckView.swift
@@ -7,9 +7,7 @@ enum ControlDeckChromeStyle {
 }
 
 struct ControlDeckView: View {
-  // State from parent
-  @Binding var draft: ControlDeckDraft
-  @Binding var focusState: ControlDeckFocusState
+  let composer: ControlDeckComposerModel
   let isSubmitting: Bool
   let isResuming: Bool
   let isInputEnabled: Bool
@@ -74,6 +72,8 @@ struct ControlDeckView: View {
   }
 
   var body: some View {
+    @Bindable var composer = composer
+
     VStack(alignment: .leading, spacing: 0) {
       if isApprovalMode, let approval = pendingApproval {
         // Approval takeover replaces the entire control deck surface
@@ -136,7 +136,7 @@ struct ControlDeckView: View {
   private var hasBorderHighlight: Bool {
     if isApprovalMode { return true }
     if isWorkingHighlight { return true }
-    return focusState.isFocused
+    return composer.focusState.isFocused
   }
 
   private var borderColor: Color {
@@ -150,7 +150,7 @@ struct ControlDeckView: View {
       }
     }
     if isWorkingHighlight { return Color.feedbackWarning.opacity(OpacityTier.vivid) }
-    return focusState.isFocused ? Color.accent.opacity(0.5) : Color.panelBorder
+    return composer.focusState.isFocused ? Color.accent.opacity(0.5) : Color.panelBorder
   }
 
   private var backgroundStyle: Color {
@@ -183,9 +183,9 @@ struct ControlDeckView: View {
   private var composeContent: some View {
     Group {
       // Attachment chips
-      if draft.attachments.hasItems {
+      if composer.draft.attachments.hasItems {
         ControlDeckAttachmentTray(
-          attachments: draft.attachments.items,
+          attachments: composer.draft.attachments.items,
           onRemove: onRemoveAttachment
         )
         .padding(.horizontal, horizontalContentPadding)
@@ -196,7 +196,7 @@ struct ControlDeckView: View {
       // Text editor
       editorSection
         .padding(.horizontal, horizontalContentPadding)
-        .padding(.top, draft.attachments.hasItems ? 0 : Spacing.sm)
+        .padding(.top, composer.draft.attachments.hasItems ? 0 : Spacing.sm)
 
       // Error
       if let errorMessage, !errorMessage.isEmpty {
@@ -214,8 +214,10 @@ struct ControlDeckView: View {
   // MARK: - Editor
 
   private var editorSection: some View {
-    ZStack(alignment: .topLeading) {
-      if draft.text.isEmpty {
+    @Bindable var composer = composer
+
+    return ZStack(alignment: .topLeading) {
+      if composer.draft.text.isEmpty {
         Text(presentation?.placeholder ?? "Message the session\u{2026}")
           .font(.system(size: TypeScale.body))
           .foregroundStyle(Color.textTertiary)
@@ -225,11 +227,11 @@ struct ControlDeckView: View {
       }
 
       ControlDeckTextArea(
-        text: $draft.text,
-        focusRequestSignal: $focusState.focusRequestSignal,
-        blurRequestSignal: $focusState.blurRequestSignal,
-        moveCursorToEndSignal: $focusState.moveCursorToEndSignal,
-        measuredHeight: $focusState.measuredHeight,
+        text: $composer.draft.text,
+        focusRequestSignal: $composer.focusState.focusRequestSignal,
+        blurRequestSignal: $composer.focusState.blurRequestSignal,
+        moveCursorToEndSignal: $composer.focusState.moveCursorToEndSignal,
+        measuredHeight: $composer.focusState.measuredHeight,
         isEnabled: isInputEnabled,
         minLines: 1,
         maxLines: 8,
@@ -239,9 +241,9 @@ struct ControlDeckView: View {
         onFocusEvent: onFocusEvent
       )
     }
-    .frame(height: max(focusState.measuredHeight, 20))
+    .frame(height: max(composer.focusState.measuredHeight, 20))
     .onDrop(of: [.image, .fileURL], isTargeted: nil, perform: onDropImages)
-    .onChange(of: draft.text) { _, newValue in
+    .onChange(of: composer.draft.text) { _, newValue in
       onTextChange(newValue)
     }
   }

--- a/OrbitDockNative/OrbitDock/Views/Sessions/ControlDeck/ControlDeckViewModel.swift
+++ b/OrbitDockNative/OrbitDock/Views/Sessions/ControlDeck/ControlDeckViewModel.swift
@@ -118,7 +118,12 @@ final class ControlDeckViewModel {
       availableSkills: availableSkills
     )
 
-    try await store.submitControlDeckTurn(sessionId: sessionId, request: request)
+    let response = try await store.submitControlDeckTurn(sessionId: sessionId, request: request)
+    if let snapshot = response.snapshot {
+      applySnapshotPayload(snapshot, source: "submit")
+    } else {
+      await refresh()
+    }
   }
 
   func steerTurn(

--- a/OrbitDockNative/OrbitDockTests/Server/Protocol/ServerSessionContractsTests.swift
+++ b/OrbitDockNative/OrbitDockTests/Server/Protocol/ServerSessionContractsTests.swift
@@ -92,6 +92,7 @@ struct ServerSessionContractsTests {
     let data = Data(
       """
       {
+        "replay_cursor": 42,
         "session": {
           "id": "session-worker",
           "provider": "codex",
@@ -159,6 +160,7 @@ struct ServerSessionContractsTests {
     let bootstrap = try JSONDecoder().decode(ServerConversationBootstrap.self, from: data)
 
     #expect(bootstrap.session.projectName == "OrbitDock")
+    #expect(bootstrap.replayCursor == 42)
     #expect(bootstrap.rows.count == 1)
     #expect(bootstrap.rows.first?.id == "worker-row-1")
 

--- a/OrbitDockNative/OrbitDockTests/Server/Sessions/SessionStoreReconnectRecoveryTests.swift
+++ b/OrbitDockNative/OrbitDockTests/Server/Sessions/SessionStoreReconnectRecoveryTests.swift
@@ -47,9 +47,9 @@ struct SessionStoreReconnectRecoveryTests {
       Set(connection.subscribeCalls.map(\.surface))
         == Set([.detail, .composer, .conversation])
     )
-    #expect(connection.subscribeCalls.first(where: { $0.surface == .detail })?.sinceRevision == nil)
-    #expect(connection.subscribeCalls.first(where: { $0.surface == .composer })?.sinceRevision == nil)
-    #expect(connection.subscribeCalls.first(where: { $0.surface == .conversation })?.sinceRevision == nil)
+    #expect(connection.subscribeCalls.first(where: { $0.surface == .detail })?.sinceRevision == 13)
+    #expect(connection.subscribeCalls.first(where: { $0.surface == .composer })?.sinceRevision == 13)
+    #expect(connection.subscribeCalls.first(where: { $0.surface == .conversation })?.sinceRevision == 13)
     #expect(store.recoveredSessionGenerations["session-1"] == 4)
   }
 
@@ -65,7 +65,7 @@ struct SessionStoreReconnectRecoveryTests {
 
     #expect(connection.subscribeCalls.count == 1)
     #expect(connection.subscribeCalls.first?.surface == .composer)
-    #expect(connection.subscribeCalls.first?.sinceRevision == nil)
+    #expect(connection.subscribeCalls.first?.sinceRevision == 13)
   }
 
   @Test func addingSurfaceAfterRecoveryResubscribesWithoutReconnect() async throws {
@@ -79,7 +79,7 @@ struct SessionStoreReconnectRecoveryTests {
     await store.ensureSessionRecovery("session-1", generation: 6)
     #expect(connection.subscribeCalls.count == 1)
     #expect(connection.subscribeCalls.first?.surface == .detail)
-    #expect(connection.subscribeCalls.first?.sinceRevision == nil)
+    #expect(connection.subscribeCalls.first?.sinceRevision == 13)
 
     connection.clearSubscribeCalls()
     store.subscribeToSession("session-1", surfaces: [.composer])
@@ -87,8 +87,36 @@ struct SessionStoreReconnectRecoveryTests {
 
     #expect(connection.subscribeCalls.count == 1)
     #expect(connection.subscribeCalls.first?.surface == .composer)
-    #expect(connection.subscribeCalls.first?.sinceRevision == nil)
+    #expect(connection.subscribeCalls.first?.sinceRevision == 13)
     #expect(store.recoveredSessionGenerations["session-1"] == 6)
+  }
+
+  @Test func recoveryReplaysConversationRowsThatLandBetweenBootstrapAndSubscribe() async throws {
+    let connection = SessionStoreConnectionSpy()
+    let replayGapRowEntry = try Self.makeReplayGapRowEntry()
+    connection.onSubscribe = { call, connection in
+      guard call.surface == .conversation, call.sinceRevision == 13 else { return }
+      connection.emit(.conversationRowsChanged(
+        sessionId: "session-1",
+        upserted: [replayGapRowEntry],
+        removedRowIds: [],
+        totalRowCount: 2
+      ))
+    }
+    let store = try makeStore(
+      loader: { request in try await ResumeAndConversationMutationFixture().loader(request) },
+      connection: connection
+    )
+    store.startProcessingEvents()
+    prepareRecoveryStore(store, generation: 12)
+
+    await store.ensureSessionRecovery("session-1", generation: 12)
+
+    let (stream, _) = store.conversationRowChanges(for: "session-1")
+    let replayedDelta = await ConversationRowDeltaRecorder.firstEvent(from: stream)
+
+    #expect(replayedDelta.upserted.map(\.id) == ["bootstrap-row-1", "replay-gap-row-1"])
+    #expect(replayedDelta.removedIds.isEmpty)
   }
 
   @Test func forceRecoveryResubscribesEvenWhenSessionWasAlreadyRecovered() async throws {
@@ -350,6 +378,7 @@ struct SessionStoreReconnectRecoveryTests {
     """
     {
       "revision": 13,
+      "replay_cursor": 13,
       "session_id": "session-1",
       "session": \(sessionJSON(revision: 13)),
       "rows": \(rowsJSON),
@@ -435,6 +464,26 @@ struct SessionStoreReconnectRecoveryTests {
     }
     """
   }
+
+  fileprivate nonisolated static var replayGapRowJSON: String {
+    """
+    {
+      "session_id": "session-1",
+      "sequence": 11,
+      "turn_id": "turn-1",
+      "row": {
+        "row_type": "assistant",
+        "id": "replay-gap-row-1",
+        "content": "hello from replay gap",
+        "is_streaming": false
+      }
+    }
+    """
+  }
+
+  fileprivate static func makeReplayGapRowEntry() throws -> ServerConversationRowEntry {
+    try JSONDecoder().decode(ServerConversationRowEntry.self, from: Data(replayGapRowJSON.utf8))
+  }
 }
 
 @MainActor
@@ -451,9 +500,12 @@ final class SessionStoreConnectionSpy: SessionStoreConnection {
   private(set) var appliedSessionLists: [[ServerSessionListItem]] = []
   private(set) var appliedDashboardConversations: [[ServerDashboardConversationItem]] = []
   private(set) var failedConnectionMessages: [String] = []
+  var onSubscribe: ((SubscribeCall, SessionStoreConnectionSpy) -> Void)?
+  private var listeners: [(ServerEvent) -> Void] = []
 
   func addListener(_ listener: @escaping (ServerEvent) -> Void) -> ServerConnectionListenerToken {
-    unsafeBitCast(UUID(), to: ServerConnectionListenerToken.self)
+    listeners.append(listener)
+    return unsafeBitCast(UUID(), to: ServerConnectionListenerToken.self)
   }
 
   func removeListener(_ token: ServerConnectionListenerToken) {}
@@ -468,6 +520,7 @@ final class SessionStoreConnectionSpy: SessionStoreConnection {
         sinceRevision: sinceRevision
       )
     )
+    onSubscribe?(subscribeCalls.last!, self)
   }
 
   func unsubscribeSessionSurface(_ sessionId: String, surface: ServerSessionSurface) {}
@@ -478,6 +531,12 @@ final class SessionStoreConnectionSpy: SessionStoreConnection {
 
   func failConnection(message: String) {
     failedConnectionMessages.append(message)
+  }
+
+  func emit(_ event: ServerEvent) {
+    for listener in listeners {
+      listener(event)
+    }
   }
 
   func applySessionsList(_ sessions: [ServerSessionListItem]) {

--- a/OrbitDockNative/OrbitDockTests/Server/Sessions/SessionStoreReconnectRecoveryTests.swift
+++ b/OrbitDockNative/OrbitDockTests/Server/Sessions/SessionStoreReconnectRecoveryTests.swift
@@ -47,9 +47,9 @@ struct SessionStoreReconnectRecoveryTests {
       Set(connection.subscribeCalls.map(\.surface))
         == Set([.detail, .composer, .conversation])
     )
-    #expect(connection.subscribeCalls.first(where: { $0.surface == .detail })?.sinceRevision == 13)
-    #expect(connection.subscribeCalls.first(where: { $0.surface == .composer })?.sinceRevision == 13)
-    #expect(connection.subscribeCalls.first(where: { $0.surface == .conversation })?.sinceRevision == 13)
+    #expect(connection.subscribeCalls.first(where: { $0.surface == .detail })?.sinceRevision == nil)
+    #expect(connection.subscribeCalls.first(where: { $0.surface == .composer })?.sinceRevision == nil)
+    #expect(connection.subscribeCalls.first(where: { $0.surface == .conversation })?.sinceRevision == nil)
     #expect(store.recoveredSessionGenerations["session-1"] == 4)
   }
 
@@ -65,7 +65,7 @@ struct SessionStoreReconnectRecoveryTests {
 
     #expect(connection.subscribeCalls.count == 1)
     #expect(connection.subscribeCalls.first?.surface == .composer)
-    #expect(connection.subscribeCalls.first?.sinceRevision == 13)
+    #expect(connection.subscribeCalls.first?.sinceRevision == nil)
   }
 
   @Test func addingSurfaceAfterRecoveryResubscribesWithoutReconnect() async throws {
@@ -79,7 +79,7 @@ struct SessionStoreReconnectRecoveryTests {
     await store.ensureSessionRecovery("session-1", generation: 6)
     #expect(connection.subscribeCalls.count == 1)
     #expect(connection.subscribeCalls.first?.surface == .detail)
-    #expect(connection.subscribeCalls.first?.sinceRevision == 13)
+    #expect(connection.subscribeCalls.first?.sinceRevision == nil)
 
     connection.clearSubscribeCalls()
     store.subscribeToSession("session-1", surfaces: [.composer])
@@ -87,7 +87,7 @@ struct SessionStoreReconnectRecoveryTests {
 
     #expect(connection.subscribeCalls.count == 1)
     #expect(connection.subscribeCalls.first?.surface == .composer)
-    #expect(connection.subscribeCalls.first?.sinceRevision == 13)
+    #expect(connection.subscribeCalls.first?.sinceRevision == nil)
     #expect(store.recoveredSessionGenerations["session-1"] == 6)
   }
 
@@ -145,6 +145,25 @@ struct SessionStoreReconnectRecoveryTests {
     // sendMessage now emits the response row via notifyConversationRowDelta
     // instead of re-fetching the full conversation bootstrap.
     #expect(await fixture.conversationRequestCount == 0)
+  }
+
+  @Test func lateConversationRowSubscribersReplayCurrentConversationState() async throws {
+    let fixture = ResumeAndConversationMutationFixture()
+    let store = try makeStore(
+      loader: { request in try await fixture.loader(request) },
+      connection: SessionStoreConnectionSpy()
+    )
+    prepareRecoveryStore(store, generation: 10)
+
+    _ = await store.hydrateSessionFromHTTPBootstrap(sessionId: "session-1", generation: 10)
+    try await store.sendMessage(sessionId: "session-1", content: "hello from test")
+
+    let (stream, _) = store.conversationRowChanges(for: "session-1")
+    let replayedDelta = await ConversationRowDeltaRecorder.firstEvent(from: stream)
+
+    let replayedRowIDs = replayedDelta.upserted.map(\.id)
+    #expect(replayedRowIDs == ["send-row-1", "bootstrap-row-1"])
+    #expect(replayedDelta.removedIds.isEmpty)
   }
 
   @Test func conversationResyncErrorOnlySignalsConversationRefresh() async throws {
@@ -614,5 +633,16 @@ actor VoidStreamRecorder {
     for waiter in readyWaiters {
       waiter.continuation.resume()
     }
+  }
+}
+
+enum ConversationRowDeltaRecorder {
+  static func firstEvent(
+    from stream: AsyncStream<SessionStore.ConversationRowDelta>
+  ) async -> SessionStore.ConversationRowDelta {
+    for await delta in stream {
+      return delta
+    }
+    return SessionStore.ConversationRowDelta(upserted: [], removedIds: [])
   }
 }

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,148 +1,277 @@
 # Architecture
 
-OrbitDock has two architectural halves — a Rust server that owns all business state, and native clients (SwiftUI) that render it. This doc covers both.
+This is the source of truth for OrbitDock's system design.
 
----
+If the code and this doc disagree, treat this doc as the target architecture for new work and refactors. Don't cargo-cult the current implementation if it fights the model described here.
 
-## Part 1: Client Architecture
+OrbitDock has two architectural halves:
 
-The OrbitDock client is organized around one core pattern and a set of guardrails to prevent common pitfalls.
+- the Rust server owns durable business state
+- the native SwiftUI app renders that state through explicit scene and surface boundaries
 
-### The Core Pattern
+## Part 1: Native Client Architecture
 
-Every UI surface follows the same data-flow architecture:
+The Swift app should feel like a native macOS and iOS app, not a web app port with a pile of global state.
 
-1. **HTTP snapshot on view appear** — the view model fetches its data from a REST endpoint and owns it.
-2. **WebSocket subscription while on screen** — server events signal that something changed; the client re-fetches the HTTP snapshot.
-3. **View model is the single source of truth** — for that surface only. No shared mutable session objects.
+That means:
 
-When the user navigates away, the subscription tears down. No background state accumulation.
+- scenes own composition, routing, and stable dependencies
+- feature view models own one surface worth of state
+- `SessionStore` owns transport only
+- the server owns business truth
 
-#### Example Flow
+## The Shape Of The App
 
-```swift
-@Observable
-final class SurfaceViewModel {
-  var snapshot: SurfaceSnapshot?
+Think in two layers:
 
-  func refresh() async {
-    // Coalesce: skip if already refreshing, queue one more
-    let payload = try await store.clients.surface.fetch(sessionId)
-    // Revision guard: never regress
-    guard payload.revision >= (snapshot?.revision ?? 0) else { return }
-    snapshot = SurfaceMapper.map(payload)
-  }
-}
+1. scene owners
+2. feature surfaces
 
-// In the view:
-.task(id: sessionId) {
-  viewModel.bind(...)
-  await viewModel.refresh()
-}
-.task(id: sessionId + ":ws") {
-  let stream = store.sessionChanges(for: sessionId)
-  for await _ in stream {
-    await viewModel.refresh()
-  }
-}
-```
+### Scene Owners
 
-### Surface Model
+Scene owners are the top-level SwiftUI entry points that decide:
 
-Each screen in the app maps to one view model and one HTTP endpoint:
+- what screen or split layout is visible
+- which endpoint-scoped dependencies are active
+- which session surfaces should be subscribed while the scene is on screen
+- which state is scene-scoped instead of feature-scoped
 
-| Surface | HTTP Endpoint | WS Triggers |
-|---------|---|---|
-| Dashboard | `GET /api/dashboard` | `dashboardInvalidated` |
-| Library | `GET /api/library` | `dashboardInvalidated` |
-| Mission Control | `GET /api/missions` | `missionsInvalidated` |
-| Session Detail | `GET /api/sessions/{id}/detail` | `sessionDelta`, `sessionEnded` |
-| Control Deck | `GET /api/sessions/{id}/control-deck` | `sessionDelta`, `approvalRequested`, `tokensUpdated` |
-| Conversation | `GET /api/sessions/{id}/conversation` | `conversationRowsChanged` (data-carrying exception) |
-| Skills/MCP | `GET /api/sessions/{id}/skills`, `/mcp/tools` | `skillsList`, `mcpToolsList` |
-| Review Canvas | `GET /api/sessions/{id}/diffs` | `turnDiffSnapshot`, `reviewComment*` |
+Examples:
 
-### Ownership Rules
+- app root window
+- dashboard scene
+- session detail scene
+- mission scene
+- settings scene
 
-**The server owns all business state.** The Swift client should render server state, not reconstruct business logic by scanning history or guessing queue state. If the client needs new durable truth, change the server contract.
+Scene owners do not parse protocol payloads, synthesize business state, or own multiple feature snapshots in one giant mutable object.
 
-**Each view model owns its screen state** via HTTP snapshots. There is no shared mutable session object. Each surface fetches and owns its own data.
+### Feature Surfaces
 
-- `SessionStore` is a transport shell. It manages the WS connection and exposes change streams. It does not hold session state.
-- View models own screen-specific state and orchestration.
-- Views stay declarative — render state, forward gestures.
+A surface is a renderable feature with one owner and one contract.
 
-### WebSocket Semantics
+Examples:
 
-**WS events are signals, not state.**
+- dashboard
+- library
+- mission control
+- session detail
+- conversation
+- control deck
+- review canvas
+- skills
+- MCP servers
 
-When a WebSocket event arrives (approval requested, config changed, session status), the client should re-fetch the owning HTTP snapshot and apply it as the single source of truth. Do not bridge WS event payloads directly into view model properties — that creates a parallel state tree that drifts from the server and causes bugs where the UI shows stale or missing state until the user navigates away and back.
+Each surface should have:
 
-**The only exception:** conversation row deltas, which carry server-assigned sequence numbers and are applied incrementally by design.
+- one view model
+- one authoritative snapshot model
+- one HTTP bootstrap path
+- one realtime follow-up path
 
-### Global WebSocket
+The surface owner may be a feature view model, or a scene-level coordinator when a single HTTP payload intentionally hydrates multiple closely related surfaces.
 
-One lightweight global WS connection handles infrastructure events only:
+## Client Rules
 
-- `connectionStatusChanged` — triggers reconnect/recovery
-- `error` — server error handling and resync
-- `serverInfo` — server metadata
-- `modelsList` — global model catalog
-- `revision` — revision tracking for replay
+### 1. Scene ownership comes first
 
-These are not per-surface. They affect the transport layer, not UI state.
+Resolve real dependencies before mounting the subtree that uses them.
 
-### What Does NOT Exist
+In practice:
 
-- No `SessionObservable` — no shared mutable object holding all session state.
-- No `SessionStateProjection` — no layer that applies server snapshots to a shared object.
-- No `SessionControlStateReducer` — no state machine processing WS events into transitions.
-- No `CapabilitiesService` — view models call HTTP clients directly.
-- No `withObservationTracking` on shared objects — view models own their state.
+- resolve the endpoint-scoped `SessionStore` in the scene owner
+- pass stable typed dependencies downward
+- avoid remounting child surfaces against placeholder stores
 
-### `SessionStore` Role
+Do not hide dependency resolution inside multiple child view models. That creates unstable identity and lifecycle bugs.
 
-`SessionStore` is a thin transport shell:
+### 2. Feature state is surface-local
 
-- Manages the WS connection lifecycle
-- Exposes `sessionChanges(for:)` — an `AsyncStream<Void>` per session that yields when any WS event arrives
-- Exposes `conversationRowChanges(for:)` — an `AsyncStream<ConversationRowDelta>` per session for row deltas
-- Exposes typed HTTP clients via `store.clients`
-- Handles connection recovery and session re-subscription
+Each feature view model owns only the state needed to render its surface.
 
-`SessionStore` does NOT:
+Good:
 
-- Hold session state
-- Mutate shared observables
-- Own feature logic
-- Decide what UI should show
+- `ConversationViewModel` owns conversation rows and presentation state
+- `ControlDeckViewModel` owns control-deck snapshot and controls
+- `ReviewCanvasViewModel` owns review snapshot and review-specific UI state
 
-### REST And WebSocket Split
+Bad:
 
-Default to REST for client-initiated reads and mutations.
+- one shared session observable holding everything
+- one god object that every screen reads from
+- one transport store that also becomes product state
 
-Use WebSocket for:
+### 3. `SessionStore` is a transport shell
 
-- subscriptions
-- streaming turn interaction
-- server-pushed real-time events
+`SessionStore` exists to do transport work:
 
-If a REST mutation needs to notify other clients, let the server broadcast the result afterward. Do not send the mutation itself over WebSocket just because a broadcast follows.
+- manage WS connection lifecycle
+- expose typed HTTP clients
+- expose targeted async streams for realtime follow-up
+- handle replay and reconnect recovery
 
-### Client Mutation Flow
+`SessionStore` does not:
 
-1. View model receives user intent (tap, submit, config change).
-2. View model calls the typed HTTP client (`store.clients.controlDeck.updateConfig(...)`)
-3. The HTTP response is the authoritative state — view model applies it as the new snapshot.
-4. WS events reconcile any remaining drift via the next refresh cycle.
+- own UI state
+- decide presentation
+- synthesize feature state for every screen
+- become a shared mutable session model
 
----
+### 4. The server owns business truth
 
-## Part 2: Server State Architecture
+The Swift app renders server state. It does not infer durable state by scanning connector output, transcript history, or missing channels.
 
-The Rust server owns all durable session state. Every mutation follows one path: **validate → persist → broadcast**. The database is always the source of truth.
+If the client needs a new durable fact, add it to the server contract.
 
-### The Transition System
+### 5. Mutation responses are authoritative
+
+For user-initiated mutations:
+
+1. send an HTTP request
+2. apply the successful response immediately
+3. let WS reconcile afterward
+
+Do not wait for a later websocket event before updating the visible surface when the HTTP response already contains authoritative state.
+
+## SwiftUI Ownership Rules
+
+These rules align with the native Swift skills OrbitDock should follow.
+
+### Use modern Observation
+
+- use `@Observable` for reference-type UI models
+- own created observable models with `@State`
+- pass observable models explicitly to children
+- use `@Bindable` when a child needs bindings into an injected observable model
+
+Do not introduce new:
+
+- `ObservableObject`
+- `@Published`
+- `@StateObject`
+- `@ObservedObject`
+- `@EnvironmentObject`
+
+### Keep identity stable
+
+- use stable `.id(...)` values only when they represent real identity
+- prefer `@ViewBuilder` and enums over `AnyView`
+- keep scene ownership and dependency resolution stable so child tasks do not flap
+
+Do not use `AnyView` in core feature composition. It destroys structural identity and makes SwiftUI lifecycle bugs much harder to reason about.
+
+### Use `.task` for effectful work
+
+- use `.task` for lifecycle-bound async work
+- use `.task(id:)` when the work should restart from a stable dependency change
+- use `.onChange` only for lightweight synchronous synchronization
+
+Do not use `.onAppear` as the default place for async bootstrap logic.
+
+### Keep service injection separate from feature ownership
+
+Shared app services are fine in `@Environment(Type.self)`:
+
+- runtime registry
+- router
+- pricing service
+- usage registry
+
+But feature view models should still receive their real dependencies explicitly from the owning scene or parent feature.
+
+### Prefer native scene patterns
+
+For desktop flows:
+
+- use explicit selection-driven layouts
+- prefer `NavigationSplitView` or deliberate split layouts over touch-first push stacks
+- keep commands, toolbars, inspectors, and keyboard behavior first-class
+
+## Surface Ownership Map
+
+This is the intended ownership model.
+
+| Surface | Owner | HTTP authority | Realtime follow-up |
+| --- | --- | --- | --- |
+| Dashboard | dashboard scene/view model | `GET /api/dashboard` | dashboard replay or invalidation |
+| Library | library scene/view model | `GET /api/library` | dashboard or library invalidation |
+| Missions | mission control scene/view model | canonical missions snapshot | missions replay or invalidation |
+| Session detail shell | session detail scene/view model | selected-session detail snapshot | detail-specific invalidation |
+| Conversation | conversation view model | conversation bootstrap + pagination | conversation row deltas + explicit conversation resync |
+| Control deck | control-deck view model | control-deck snapshot | control-deck-specific invalidation |
+| Review canvas | review view model | review/diff snapshot | review-specific invalidation |
+| Skills | skills view model | skills snapshot | skills-specific invalidation |
+| MCP servers | MCP view model | MCP snapshot | MCP-specific invalidation |
+
+Two important notes:
+
+- The selected session bootstrap may intentionally hydrate multiple related surfaces once. That is fine when one owner does it on purpose.
+- What is not fine is each child surface independently inventing another bootstrap path for the same session state.
+
+## Transport Follow-Up Model
+
+By default:
+
+- HTTP loads authoritative state
+- WebSocket tells the client what changed
+- the owning surface decides whether to apply a delta directly or refresh from HTTP
+
+### The only normal data-carrying exception
+
+Conversation rows are allowed to arrive incrementally over WebSocket because the server owns their IDs, ordering, and replay semantics.
+
+That means conversation may:
+
+- bootstrap from HTTP
+- append or update rows from WS deltas
+- refetch from HTTP only on explicit conversation resync or pagination
+
+### Everything else should be refresh-driven
+
+For approvals, config, session status, review data, skills, and MCP capability changes:
+
+- treat WS as a signal
+- refresh the owning HTTP snapshot
+- replace the local surface state with the new authoritative snapshot
+
+Do not build a parallel client-side state machine out of websocket payloads.
+
+## What The Native App Should Not Do
+
+Do not add:
+
+- shared mutable session objects
+- placeholder production stores like `SessionStore.preview()` as real runtime ownership
+- broad per-session refresh loops for unrelated surfaces
+- giant scene roots that own routing, composition, dependency lookup, and feature logic all at once
+- `AnyView` in core composition paths
+- async work primarily driven by `.onAppear`
+- feature services whose main job is mutating a shared observable blob
+
+## Recommended File Shape
+
+For non-trivial SwiftUI features:
+
+- scene shell file: composition and lifecycle wiring only
+- feature view model file: one surface, one snapshot model
+- section/chrome files: visual decomposition
+- planner/mapper files: pure shaping logic
+- service files: transport or platform integration
+
+If a file starts collecting unrelated views, models, stores, networking code, and helpers, split it.
+
+## Part 2: Server Architecture
+
+The Rust server owns all durable session state. Every mutation follows one path:
+
+1. validate
+2. transition
+3. persist
+4. broadcast
+
+The database is always the source of truth.
+
+## The Transition System
 
 All session state mutations flow through a pure transition function:
 
@@ -150,166 +279,98 @@ All session state mutations flow through a pure transition function:
 fn transition(state: TransitionState, input: Input, now: DateTime) -> (TransitionState, Vec<Effect>)
 ```
 
-This function is pure and synchronous — no IO, no side effects. It takes the current state and an input event, and returns the new state plus a list of effects to execute. The effects are:
+This function is pure and synchronous.
 
-- `Effect::Persist(PersistOp)` — write to the database
-- `Effect::Emit(ServerMessage)` — broadcast to WebSocket subscribers
+It decides:
 
-The session actor executes these effects after the transition completes. Persist and broadcast always happen together — if the transition says to persist, it also says to broadcast, so clients never see stale state and the database never misses a mutation.
+- the next state
+- what to persist
+- what to broadcast
 
-**Location:** `connector-core/src/transition.rs`
+Effects are executed by the session actor after the transition completes.
 
-### How Events Flow
+## Session Actor Model
 
-```
-Connector event (hook, transcript line, API response)
-    ↓
-SessionCommand::ProcessEvent { event: Input }
-    ↓
-Session actor receives command
-    ↓
-extract_state() — pull current TransitionState from SessionHandle
-    ↓
-transition(state, input, now) — pure function, returns (new_state, effects)
-    ↓
-apply_state() — write new TransitionState back to SessionHandle
-    ↓
-Execute effects:
-  - Persist → send to persistence actor via mpsc
-  - Emit → broadcast to WebSocket subscribers via tokio::broadcast
-```
+Each session gets its own actor task.
 
-Every connector (Claude hooks, Codex hooks, direct sessions) feeds events into `ProcessEvent`. The transition function decides what changes, what persists, and what broadcasts. No connector code should persist or broadcast directly.
+That gives us:
 
-### Session Actor Model
+- no lock-based mutation races
+- sequential command handling
+- lock-free snapshot reads through `ArcSwap<SessionSnapshot>`
 
-Each session gets its own actor task. External callers interact through `SessionActorHandle`, which sends commands over an mpsc channel. This means:
+Connectors and handlers must not mutate session state directly. They feed inputs into the actor, and the actor runs the transition.
 
-- **No locks** — the actor processes commands sequentially
-- **Lock-free reads** — `ArcSwap<SessionSnapshot>` lets any thread read the latest snapshot without blocking the actor
-- **No shared mutable state** — the actor owns `SessionHandle`, nobody else touches it
+## Server Rule
 
-The actor loop:
+Every durable session mutation must go through the transition system.
 
-```
-loop {
-  select! {
-    cmd = command_rx.recv() => handle_session_command(cmd, &mut handle, &persist_tx),
-    event = connector_rx.recv() => dispatch_transition_input(event, &mut handle, &persist_tx),
-  }
-}
-```
+Do not bypass it for:
 
-### Input Variants
+- simple field updates
+- convenience broadcasts
+- approval flow shortcuts
+- connector-specific mutations
 
-The `Input` enum covers every kind of state change:
+If a mutation needs to exist, it needs:
 
-| Category | Examples |
-|----------|---------|
-| Lifecycle | `Started`, `Ended`, `Paused`, `Resumed` |
-| Work progress | `WorkingOnTool`, `ToolCompleted`, `ThinkingStarted` |
-| Approvals | `ApprovalRequested`, `AttentionUpdated` |
-| Config | `ModelUpdated`, `EffortUpdated`, `PermissionModeChanged` |
-| Environment | `EnvironmentChanged`, `TranscriptPathUpdated` |
-| Content | `SummaryUpdated`, `FirstPromptCaptured`, `PlanUpdated` |
-| Subagents | `SubagentStarted`, `SubagentStopped` |
+- an input variant
+- transition logic
+- persist effects
+- broadcast effects
 
-When adding a new state mutation, add a new `Input` variant and handle it in the transition function. Do not bypass the transition system.
+## Server Anti-Patterns
 
-### The One Rule
+Do not reintroduce:
 
-**Every state mutation must go through `ProcessEvent`.** No exceptions for "simple" fields or "just a broadcast."
+- fire-and-forget in-memory mutations
+- split persist and broadcast paths
+- connector-owned direct state mutation
+- caller-side duplicate persistence after a handler already owns the update
 
-The transition function is the only place that decides:
-- What the new state looks like
-- What gets persisted
-- What gets broadcast to clients
+## Part 3: Cross-Layer Guardrails
 
-This guarantees:
-- The database is always consistent with in-memory state
-- Every client sees every change
-- Server restart recovers the exact state that was last persisted
-- Business logic is testable in isolation (the transition function is pure)
+### Typed boundaries
 
-### Approved Exceptions
+Keep the Swift side strongly typed to match server contracts.
 
-A small number of `ApplyDelta { persist_op: None }` calls remain. These are intentional and documented:
+- avoid schema-free payload bags where a real type exists
+- keep protocol boundaries explicit
+- keep forward-compatible decoding resilient
 
-| Location | Reason |
-|----------|--------|
-| `handler.rs` (2 sites) | Ephemeral UI broadcasts (tool_result/tool_error working status) — the real persist happens through the transition that follows |
-| `session_resume.rs` | Timing-sensitive init — permission_mode must broadcast before the connector loop starts |
-| `session_direct_start.rs` | Same timing-sensitive init pattern as resume |
-| `git_refresh.rs` | Filesystem-derived state (git status), not business truth |
-| Test-only sites | Test helpers that need lightweight state setup |
+### SQLite ownership
 
-If you're adding a new `ApplyDelta { persist_op: None }`, stop and route through `ProcessEvent` instead.
+Only the Rust server reads and writes SQLite directly.
 
-### Approval Flow
+The app and CLI should go through server APIs.
 
-Approvals follow the same transition path:
+### Endpoint scoping
 
-**Request:** Connector detects a tool needing approval → `ProcessEvent(Input::ApprovalRequested { ... })` → transition atomically sets pending_approval, work_status, persists the approval row AND the session update, and broadcasts to all subscribers.
+All client state must be scoped by endpoint plus session identity.
 
-**Resolve:** HTTP handler calls `SessionCommand::ResolvePendingApproval` → the handler resolves in-memory, persists the updated work_status, broadcasts the delta, and returns the result. Callers do not need to separately persist — the handler owns the full persist + broadcast cycle.
+Always guard async callbacks against stale binding context before applying results.
 
-### Anti-Patterns
+### Runtime versus product truth
 
-These patterns were eliminated during the refactor. Do not reintroduce them:
+Connector runtime is operational plumbing.
 
-**Fire-and-forget commands** — Commands like `SetModel`, `SetLastTool`, `SetPendingApproval` that mutated in-memory state without persisting or broadcasting. State was lost on restart and clients saw stale data.
+It may help the server produce product truth, but it is not product truth by itself. The client should not treat runtime artifacts as durable UI authority.
 
-**Split persist + broadcast** — Sending `ApplyDelta { persist_op: None }` for the broadcast, then a separate `PersistCommand` for the persist. If either failed, the database and in-memory state would diverge.
+## Practical Summary
 
-**Caller-side persist after resolve** — Callers of `ResolvePendingApproval` separately sending `PersistCommand::SessionUpdate` for work_status. The handler now owns this, so callers should not persist work_status themselves.
+If you're touching the Swift app:
 
-**Direct state mutation from connectors** — Connector code reaching into `SessionHandle` to mutate fields directly instead of routing through the transition system.
+- start from the owning scene
+- keep dependencies stable before mounting children
+- give each feature one owner and one contract
+- use HTTP for authority and WS for follow-up
+- keep `SessionStore` narrow
+- write SwiftUI the native way, not the web-app way
 
----
+If you're touching the server:
 
-## Part 3: Engineering Guardrails
+- put durable state changes through the transition system
+- persist and broadcast together
+- keep the database authoritative
 
-### Server-Authoritative State
-
-The Rust server owns durable session and approval truth. The Swift client should render server state, not reconstruct business logic by scanning history or guessing queue state. If the client needs new durable truth, change the server contract.
-
-### Typed Protocol Boundaries
-
-Keep the Swift side strongly typed to match Rust serde models.
-
-- do not introduce `AnyCodable` for payloads that have a real schema
-- keep unknown server message variants resilient so the connection does not crash on forward-compatible changes
-- prefer explicit typed payloads over generic bags of fields
-
-For detailed protocol contracts, see [data-flow.md](data-flow.md).
-
-### SQLite Ownership
-
-Only the Rust server reads from and writes to SQLite directly.
-
-The app and CLI should go through server APIs. If a workflow needs direct DB access to function, that is usually a design smell.
-
-### Conversation Row Persistence
-
-Conversation row writes must follow the server's single-writer path.
-
-Do not introduce side paths that write rows directly and race sequence assignment. This is one of the easiest ways to create subtle ordering bugs.
-
-For the persistence model and database operations, see [OPERATIONS.md](OPERATIONS.md).
-
-### State Scoping
-
-Keep state endpoint-scoped. Cache values by scoped session identity (endpoint + session ID) to prevent cross-server bleeding. Always guard async callbacks with a current scoped-id check.
-
-Per-session observation uses per-session `@Observable` classes. Access via `serverState.session(scopedId)`. Views observe only the session they display.
-
-### Shared Mutable State Anti-Pattern
-
-Do not create:
-
-- shared mutable session objects (no god objects)
-- `withObservationTracking` on shared state stores
-- feature services that wrap HTTP clients just to mutate a shared observable
-- global event processing for surfaces that aren't on screen
-
-View models call HTTP clients directly.
+For transport details, read [data-flow.md](data-flow.md).

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -132,9 +132,15 @@ make lint         # Lint Swift + Rust
 
 ### Swift App
 
-**State management** — Keep state endpoint-scoped. Cache values by scoped session identity (endpoint + session ID) to prevent cross-server bleeding. Always guard async callbacks with a current scoped-id check.
+**Scene ownership** — Resolve the real endpoint-scoped `SessionStore` in the owning scene before mounting child features. Do not build runtime ownership around placeholder stores or late child-level dependency lookup.
 
-**Per-session observation** — Scope views to single sessions. Access via `serverState.session(scopedId)`. Never share session observables across screens.
+**Surface ownership** — Give each rendered surface one owner, one HTTP bootstrap path, and one realtime follow-up path. `SessionStore` is transport only, not a shared product-state blob.
+
+**State scoping** — Keep state endpoint-scoped and session-scoped where appropriate. Cache by scoped identity and always guard async callbacks with a current scoped-id check before applying results.
+
+**SwiftUI structure** — Prefer small dedicated subviews over giant computed `some View` helpers, keep the view tree structurally stable, and move non-trivial actions or async work out of `body`.
+
+**Observation** — Own root `@Observable` models with `@State`, pass them explicitly to children, and prefer `.task` / `.task(id:)` for lifecycle-bound async work.
 
 **Theme colors** — Always use the cosmic palette from `Theme.swift`. Never use system colors (`.blue`, `.green`, `.purple`). Never use `.foregroundStyle(.tertiary)` — use `Color.textTertiary` instead.
 

--- a/docs/data-flow.md
+++ b/docs/data-flow.md
@@ -1,40 +1,119 @@
 # OrbitDock Data Flow Contract
 
-This is the current server-authoritative contract for OrbitDock.
+This is the transport source of truth for OrbitDock.
+
+If a client-side implementation fights this document, treat the code as the thing that needs to move.
 
 The short version:
 
-- HTTP owns initial and heavy reads.
-- WebSocket owns realtime updates and replay.
+- HTTP owns bootstrap, pagination, and mutation responses.
+- WebSocket owns realtime follow-up, replay, heartbeats, and explicit refetch hints.
 - The Rust server owns durable business truth.
-- The client renders server state. It does not reconstruct business state from connector internals.
-- WebSocket begins with a lightweight `hello` handshake that advertises server metadata and surface capabilities.
+- The native app renders server state through explicit scene and surface owners.
+- `SessionStore` is transport infrastructure, not product state.
 
-Today’s important nuance:
+## Core Contract
 
-- HTTP is the only bootstrap path.
-- WebSocket carries deltas, replay, heartbeats, and explicit resync/refetch hints only.
-- If replay cannot satisfy a revision gap, the client refetches the matching HTTP surface.
-- Transport failures should surface directly. OrbitDock should not try to infer protocol compatibility from unrelated decode or bootstrap errors.
+OrbitDock uses a surface-based transport model.
+
+Each rendered surface should have:
+
+- one owner
+- one HTTP authority
+- one realtime follow-up path
+
+Examples:
+
+- dashboard
+- missions
+- session detail
+- conversation
+- control deck
+- review canvas
+- skills
+- MCP servers
+
+The client should not rebuild all session UI from one giant mutable session blob.
+
+## Transport Roles
+
+### HTTP
+
+HTTP is authoritative for:
+
+- initial snapshot loads
+- pagination
+- heavy payloads
+- mutation responses
+- targeted refetch after invalidation or replay failure
+
+HTTP is the only normal bootstrap path.
+
+### WebSocket
+
+WebSocket is authoritative for:
+
+- connection metadata
+- replay from a known revision
+- lightweight realtime deltas
+- explicit refetch or resync hints
+
+WebSocket should not become a second bootstrap channel for large surface snapshots.
+
+## Client Ownership Model
+
+The native app should follow this shape:
+
+1. scene owners resolve stable dependencies
+2. feature owners bootstrap and render one surface
+3. `SessionStore` provides transport APIs and async streams
+
+That means:
+
+- scene owners resolve the endpoint-scoped `SessionStore` before mounting child features
+- feature owners decide which HTTP snapshot to load and which realtime feed to observe
+- child views render state passed to them explicitly
+
+The client should not:
+
+- mount against placeholder production stores
+- let multiple child features independently bootstrap the same surface
+- treat websocket events as the primary business-state model
+
+## SessionStore Contract
+
+`SessionStore` is a narrow transport shell.
+
+It may:
+
+- manage websocket connection lifecycle
+- expose typed HTTP clients
+- expose targeted async streams
+- handle replay and reconnect recovery
+
+It should not:
+
+- become a shared session view model
+- own feature presentation state
+- synthesize every screen from one mixed state object
 
 ## Architecture Diagram
 
 ```mermaid
 flowchart TD
-    UI[SwiftUI / CLI surfaces]
-    VM[View Models]
-    SS[SessionStore — transport shell]
-    WS[WebSocket realtime + replay]
-    HTTP[HTTP snapshots + pagination + mutations]
+    UI[SwiftUI scenes and feature views]
+    OWNERS[Scene owners and surface owners]
+    SS[SessionStore transport shell]
+    WS[WebSocket replay and deltas]
+    HTTP[HTTP snapshots and mutations]
     API[Rust transport layer]
-    DOMAIN[Session actor + transition system]
+    DOMAIN[Session actors and transitions]
     DB[(SQLite durable truth)]
-    RT[Connector runtime / harnesses]
+    RT[Connector runtime]
 
-    UI --> VM
-    VM --> SS
-
-    VM --> HTTP
+    UI --> OWNERS
+    OWNERS --> SS
+    OWNERS --> HTTP
     SS --> WS
 
     HTTP --> API
@@ -45,182 +124,151 @@ flowchart TD
     RT --> DOMAIN
 ```
 
-The rule of thumb:
-
-- HTTP loads authoritative surface state.
-- WebSocket only delivers incremental realtime change or replay from a known revision.
-- The domain layer decides business state.
-- SQLite stores that business state durably.
-- Connector runtime is operational plumbing, not product truth.
-
-## Session Authority Diagram
-
-```mermaid
-stateDiagram-v2
-    [*] --> PassiveOpen: create passive
-    [*] --> DirectOpen: create direct
-
-    PassiveOpen --> DirectOpen: takeover
-    DirectOpen --> DirectResumable: connector detached / resume required
-    DirectResumable --> DirectOpen: explicit resume + harness attached
-
-    PassiveOpen --> Ended: end
-    DirectOpen --> Ended: end
-    DirectResumable --> Ended: end
-```
-
-## Principles
-
-1. HTTP is the bootstrap path.
-   Dashboard, session bootstrap, and pagination all start from HTTP.
-2. WebSocket is the follow-up path.
-   After the client has a snapshot revision, it subscribes for realtime updates and replay from that revision.
-3. Session authority lives on the server.
-   `control_mode`, `lifecycle_state`, and `accepts_user_input` are server-owned fields.
-4. Mutation responses are authoritative.
-   Successful `POST`/`PATCH`/`PUT` responses are applied immediately by the client. WS reconciles afterward.
-5. WebSocket events are signals, not state.
-   A WS event tells the client **something changed**. The client should re-fetch the relevant HTTP snapshot to get the authoritative state. Never bridge WS event payloads directly into view model state as the primary data path — that creates a second source of truth that drifts from the server.
-   - Conversation row deltas are the one exception: they carry server-assigned sequence numbers and are applied incrementally by design.
-   - For everything else (approvals, config changes, session status), the WS event is a trigger to refresh, not a replacement for the HTTP snapshot.
-
-## Boundary Rules
-
-- The client may derive presentation, never business truth.
-- The Rust domain layer owns `control_mode`, `lifecycle_state`, and `accepts_user_input`.
-- Runtime connector maps may support those fields, but they do not define them.
-- Large payloads move over HTTP. WebSocket should carry deltas, replay, heartbeats, and refetch hints.
-- Replay gaps are handled by refetching the exact affected HTTP surface, not by rebuilding unrelated state.
-- Each surface has one bootstrap path and one realtime path.
-
-## Surface Model
-
-OrbitDock now treats UI data as named surfaces instead of one catch-all session blob.
+## Surface Bootstrap Rules
 
 ### Dashboard
 
 - HTTP: `GET /api/dashboard`
-- WS subscribe: `subscribe_dashboard { since_revision }`
-- Purpose:
-  - root session list
-  - dashboard conversations
-  - dashboard counts
+- WS follow-up: dashboard replay or invalidation
+- Owner: dashboard scene or dashboard view model
 
 ### Missions
 
 - HTTP: canonical missions snapshot endpoint
-- WS subscribe: `subscribe_missions { since_revision }`
-- Purpose:
-  - mission summaries
-  - mission realtime deltas
+- WS follow-up: missions replay or invalidation
+- Owner: mission control scene or mission control view model
 
-### Session Detail
+### Session Detail Shell
 
-- HTTP state source: session bootstrap payload
-- WS subscribe: `subscribe_session_surface { session_id, surface: detail, since_revision }`
-
-### Session Composer
-
-- HTTP state source: session bootstrap payload
-- WS subscribe: `subscribe_session_surface { session_id, surface: composer, since_revision }`
+- HTTP: selected-session bootstrap snapshot
+- WS follow-up: detail-specific invalidation or replay
+- Owner: session detail scene
 
 ### Conversation
 
 - HTTP bootstrap: `GET /api/sessions/{id}/conversation?limit=...`
 - HTTP pagination: `GET /api/sessions/{id}/messages?before_sequence=...&limit=...`
-- WS subscribe: `subscribe_session_surface { session_id, surface: conversation, since_revision }`
+- WS follow-up: conversation row replay, row deltas, or explicit conversation resync
+- Owner: conversation view model
+
+### Other Session Surfaces
+
+This includes control deck, review canvas, skills, and MCP servers.
+
+- HTTP: surface-specific authoritative snapshot
+- WS follow-up: surface-specific invalidation or replay hint
+- Owner: the matching feature owner for that surface
+
+These surfaces should not refresh because of a broad unrelated per-session event.
 
 ## Boot Sequences
 
 ### Dashboard Boot
 
 1. WebSocket connects and receives `hello`.
-2. Client fetches `GET /api/dashboard`.
-3. Client applies the snapshot and stores its revision.
-4. Client subscribes to dashboard updates with `since_revision = snapshot.revision`.
+2. The dashboard owner fetches `GET /api/dashboard`.
+3. The owner applies the snapshot and stores its revision.
+4. The owner subscribes to dashboard follow-up from that revision.
 
-There should not be a second eager dashboard bootstrap path in parallel.
+There should not be parallel eager dashboard bootstraps from sibling views.
 
-### Session Boot
+### Session Detail Boot
 
-1. Client fetches `GET /api/sessions/{id}/conversation?limit=...`.
-2. Client applies the returned `session` to detail and composer state.
-3. Client applies the returned rows to conversation state and stores `session.revision`.
-4. Client subscribes to the WS surfaces it renders with `since_revision = session.revision`.
+1. The session detail scene resolves the real endpoint-scoped `SessionStore`.
+2. The scene decides which surfaces are visible.
+3. Each visible surface owner performs exactly one HTTP bootstrap.
+4. Each surface owner subscribes to its own follow-up stream from the returned revision.
 
-Conversation screens usually need:
+If one intentional selected-session bootstrap hydrates multiple closely related surfaces, that is fine.
 
-1. session bootstrap HTTP
-2. conversation WS replay/deltas
-3. detail WS replay/deltas
+What is not fine:
 
-Composer screens usually need:
+- conversation bootstrapping itself one way
+- session detail bootstrapping it another way
+- a shared session observer bootstrapping it a third way
 
-1. session bootstrap HTTP
-2. composer WS replay/deltas
-3. conversation HTTP/WS only if the composer screen also renders history
+## Mutation Rules
 
-## Replay Rules
+Successful mutation responses are authoritative.
 
-- Every replayable WS subscription accepts `since_revision`.
+For a user action:
+
+1. send the HTTP request
+2. apply the successful response immediately
+3. let websocket follow-up reconcile afterward
+
+Do not wait for a later websocket event when the HTTP response already contains the accepted state.
+
+## Replay And Resync Rules
+
+- Every replayable realtime feed should accept a revision or equivalent cursor.
 - If the server can replay from that revision, it sends only the missing events.
-- If the replay window is too old or unavailable, the server tells the client to refetch that surface over HTTP.
-- The client must treat HTTP refetch as the fallback, not try to synthesize missing state locally.
+- If replay cannot satisfy the gap, the server tells the client to refetch the matching HTTP surface.
+- The client refetches the exact affected surface, not unrelated state.
+
+This is especially important for reconnects. Replay gaps should trigger targeted recovery, not full-screen rebuilds.
+
+## Conversation Exception
+
+Conversation is the one normal surface that may apply realtime payloads directly.
+
+That works because conversation rows are:
+
+- server-assigned
+- sequence-based
+- replayable
+- append/update oriented
+
+So conversation may:
+
+- bootstrap from HTTP
+- append or update rows from websocket
+- refetch from HTTP only for pagination or explicit conversation resync
+
+For most other surfaces, websocket should be treated as a signal to refresh authoritative HTTP state.
 
 ## Durable Session Authority
 
-The server is responsible for these fields:
+The server owns durable session truth such as:
 
 - `control_mode`
-  - `direct`
-  - `passive`
 - `lifecycle_state`
-  - `open`
-  - `resumable`
-  - `ended`
 - `accepts_user_input`
 
-The intended model is:
+The client may derive presentation from those fields, but it must not infer them from:
 
-- `direct + open` means OrbitDock owns the live control path.
-- `passive + open` means the underlying provider session is live, but OrbitDock does not own direct control.
-- `direct + resumable` means this is still a direct session, but it needs a resume path rather than immediate input.
-- `ended` means historical only.
+- connector runtime maps
+- missing channels
+- transcript content
+- partial websocket payloads
 
-The client should never infer these from connector maps, missing channels, or transcript patterns.
+If the client needs a durable fact, add it to the server contract.
 
-## Conversation Row Rules
+## Anti-Patterns
 
-- Conversation rows remain single-writer, server-assigned, and sequence-based.
-- HTTP bootstrap and pagination return server-owned ordering metadata:
-  - `total_row_count`
-  - `has_more_before`
-  - `oldest_sequence`
-  - `newest_sequence`
-- WS conversation updates carry row changes and replay events, not full raw tool payloads.
-- Expanded tool content is still fetched on demand via HTTP.
+Do not introduce:
 
-## Send Semantics
+- dual bootstrap paths for the same surface
+- websocket-only large surface loads
+- broad per-session refresh loops for unrelated surfaces
+- client-side business-state inference
+- a god-object session store
+- send flows that wait for websocket before showing the accepted response
+- replay recovery that rebuilds unrelated UI
 
-`POST /api/sessions/{id}/messages` must obey this contract:
+## Practical Summary
 
-1. connector enqueue succeeds
-2. server persists and broadcasts the accepted row
-3. HTTP response returns the authoritative accepted row
-4. client applies the response immediately
+When you touch the native client:
 
-If connector enqueue fails:
+- start from the owning scene
+- give each rendered surface one owner
+- use HTTP for authority
+- use websocket for follow-up
+- keep `SessionStore` narrow
+- refresh only the surface that actually changed
 
-- the server returns an error such as `connector_unavailable`
-- no accepted conversation row is created
-- the client keeps the draft locally and shows the failure
+When you touch the server:
 
-## What We Intentionally Avoid
-
-- No dual bootstrap for the same surface.
-- No client-owned business-state inference.
-- No “accept first, fail later” send path that leaves ghost rows behind.
-- No using WebSocket as the only source for large initial payloads.
-- No broad god-object session store that synthesizes every UI surface from one mixed state blob.
-- No durable state transitions driven implicitly by runtime channel presence alone.
-- No heavy all-rows websocket resync when a targeted HTTP refetch hint would do.
+- keep durable state in the transition system
+- persist and broadcast together
+- use websocket for deltas and refetch hints, not heavy bootstrap payloads

--- a/orbitdock-server/crates/cli/src/commands/session.rs
+++ b/orbitdock-server/crates/cli/src/commands/session.rs
@@ -729,6 +729,7 @@ fn conversation_snapshot_from_session(session: &SessionState) -> Option<Conversa
 
   Some(ConversationSnapshotPage {
     revision: session.revision.unwrap_or_default(),
+    replay_cursor: session.revision.unwrap_or_default(),
     session_id: session.id.clone(),
     session: session.clone(),
     rows: session.rows.iter().map(|row| row.to_summary()).collect(),

--- a/orbitdock-server/crates/connector-codex/src/config.rs
+++ b/orbitdock-server/crates/connector-codex/src/config.rs
@@ -18,7 +18,7 @@ use codex_protocol::openai_models::{
   TruncationPolicyConfig, WebSearchToolType,
 };
 use codex_protocol::protocol::{Op, SessionSource};
-use tracing::{info, warn};
+use tracing::warn;
 
 use super::{CodexConfigOverrides, CodexConnector, CodexControlPlane};
 use orbitdock_connector_core::ConnectorError;
@@ -49,18 +49,6 @@ Plan mode guidance:
 
 When a plan is ready to persist, call `plan_write` and save Markdown under `plans/`.
 "#;
-
-struct ProviderRouteDebugInfo {
-  provider_id: String,
-  provider_name: Option<String>,
-  base_url: Option<String>,
-  wire_api: String,
-  query_param_keys: Vec<String>,
-  http_header_names: Vec<String>,
-  env_http_header_names: Vec<String>,
-  has_orbitdock_openrouter_referer: bool,
-  has_orbitdock_openrouter_title: bool,
-}
 
 pub struct ResumeConnectorWithToolsConfig<'a> {
   pub cwd: &'a str,
@@ -176,8 +164,6 @@ impl CodexConnector {
     control_plane: CodexControlPlane,
     dynamic_tools: Vec<codex_protocol::dynamic_tools::DynamicToolSpec>,
   ) -> Result<Self, ConnectorError> {
-    info!("Creating codex-core connector for {}", cwd);
-
     let codex_home = find_codex_home()
       .map_err(|e| ConnectorError::ProviderError(format!("Failed to find codex home: {}", e)))?;
 
@@ -205,8 +191,6 @@ impl CodexConnector {
       Arc::new(EnvironmentManager::new(None)),
     ));
     Self::finalize_reasoning_summary(&mut config, thread_manager.as_ref()).await;
-    log_provider_route("start", cwd, &config);
-
     let configured_model = config.model.clone();
     let new_thread = thread_manager
       .start_thread_with_tools(config, dynamic_tools, false)
@@ -320,11 +304,6 @@ impl CodexConnector {
       dynamic_tools,
     } = params;
 
-    info!(
-      "Resuming codex-core connector for {} with thread {}",
-      cwd, thread_id
-    );
-
     let codex_home = find_codex_home()
       .map_err(|e| ConnectorError::ProviderError(format!("Failed to find codex home: {}", e)))?;
 
@@ -336,8 +315,6 @@ impl CodexConnector {
       .ok_or_else(|| {
         ConnectorError::ProviderError(format!("No rollout file found for thread {}", thread_id))
       })?;
-
-    info!("Found rollout at {:?}", rollout_path);
 
     let auth_manager = Arc::new(AuthManager::new(
       codex_home.clone(),
@@ -363,8 +340,6 @@ impl CodexConnector {
       Arc::new(EnvironmentManager::new(None)),
     ));
     Self::finalize_reasoning_summary(&mut config, thread_manager.as_ref()).await;
-    log_provider_route("resume", cwd, &config);
-
     let configured_model = config.model.clone();
     if !dynamic_tools.is_empty() {
       match codex_protocol::ThreadId::try_from(thread_id) {
@@ -533,7 +508,7 @@ impl CodexConnector {
     apply_orbitdock_provider_defaults(&mut config);
     apply_orbitdock_external_model_defaults(&mut config);
     let forced_apply_patch_feature = ensure_apply_patch_feature_for_custom_models(&mut config);
-    log_apply_patch_tool_resolution(cwd, &config, forced_apply_patch_feature);
+    let _ = (cwd, forced_apply_patch_feature);
 
     Ok(config)
   }
@@ -643,7 +618,6 @@ pub async fn discover_models_for_context(
         ConnectorError::ProviderError(format!("Failed to load config for model discovery: {}", e))
       })?;
   apply_orbitdock_provider_defaults(&mut base_config);
-  log_provider_route("discover_models", cwd.unwrap_or(""), &base_config);
   let thread_manager = Arc::new(ThreadManager::new(
     &base_config,
     auth_manager,
@@ -909,88 +883,6 @@ pub(crate) fn ensure_apply_patch_feature_for_custom_models(config: &mut Config) 
       );
       false
     }
-  }
-}
-
-fn log_apply_patch_tool_resolution(cwd: &str, config: &Config, forced_by_orbitdock: bool) {
-  info!(
-    event = "codex.connector.apply_patch_tool_resolved",
-    cwd,
-    model = ?config.model,
-    model_provider_id = %config.model_provider_id,
-    include_apply_patch_tool = config.include_apply_patch_tool,
-    feature_apply_patch_freeform = config.features.enabled(Feature::ApplyPatchFreeform),
-    feature_js_repl = config.features.enabled(Feature::JsRepl),
-    feature_unified_exec = config.features.enabled(Feature::UnifiedExec),
-    forced_by_orbitdock,
-  );
-}
-
-fn log_provider_route(phase: &str, cwd: &str, config: &Config) {
-  let info = provider_route_debug_info(config);
-  info!(
-    event = "codex.connector.route_resolved",
-    phase,
-    cwd,
-    model = ?config.model,
-    model_provider_id = %info.provider_id,
-    provider_name = ?info.provider_name,
-    provider_base_url = ?info.base_url,
-    wire_api = %info.wire_api,
-    query_param_keys = ?info.query_param_keys,
-    http_header_names = ?info.http_header_names,
-    env_http_header_names = ?info.env_http_header_names,
-    has_orbitdock_openrouter_referer = info.has_orbitdock_openrouter_referer,
-    has_orbitdock_openrouter_title = info.has_orbitdock_openrouter_title,
-  );
-}
-
-fn provider_route_debug_info(config: &Config) -> ProviderRouteDebugInfo {
-  let provider_id = config.model_provider_id.clone();
-  let provider = config.model_providers.get(&provider_id);
-
-  let mut query_param_keys = provider
-    .and_then(|value| value.query_params.as_ref())
-    .map(|value| value.keys().cloned().collect::<Vec<_>>())
-    .unwrap_or_default();
-  query_param_keys.sort();
-
-  let mut http_header_names = provider
-    .and_then(|value| value.http_headers.as_ref())
-    .map(|value| value.keys().cloned().collect::<Vec<_>>())
-    .unwrap_or_default();
-  http_header_names.sort();
-
-  let mut env_http_header_names = provider
-    .and_then(|value| value.env_http_headers.as_ref())
-    .map(|value| value.keys().cloned().collect::<Vec<_>>())
-    .unwrap_or_default();
-  env_http_header_names.sort();
-
-  let has_orbitdock_openrouter_referer = provider
-    .and_then(|value| value.http_headers.as_ref())
-    .and_then(|value| value.get("HTTP-Referer"))
-    .map(|value| value == ORBITDOCK_OPENROUTER_SITE_URL)
-    .unwrap_or(false);
-
-  let has_orbitdock_openrouter_title = provider
-    .and_then(|value| value.http_headers.as_ref())
-    .and_then(|value| value.get("X-OpenRouter-Title"))
-    .map(|value| value == ORBITDOCK_OPENROUTER_TITLE)
-    .unwrap_or(false);
-
-  ProviderRouteDebugInfo {
-    provider_id,
-    provider_name: provider.map(|value| value.name.clone()),
-    base_url: provider.and_then(|value| value.base_url.clone()),
-    wire_api: provider
-      .map(|value| format!("{:?}", value.wire_api))
-      .unwrap_or_else(|| "unknown".to_string()),
-    query_param_keys,
-    http_header_names,
-    env_http_header_names,
-    has_orbitdock_openrouter_referer,
-    has_orbitdock_openrouter_title,
   }
 }
 

--- a/orbitdock-server/crates/protocol/src/control_deck.rs
+++ b/orbitdock-server/crates/protocol/src/control_deck.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 use crate::{
+  conversation_contracts::ConversationRowEntry,
   ApprovalRequest, CodexApprovalPolicy, CodexApprovalsReviewer, CodexConfigMode,
   CodexSandboxPolicy, Provider, SessionControlMode, SessionLifecycleState, TokenUsage,
   TokenUsageSnapshotKind,
@@ -255,4 +256,12 @@ pub struct ControlDeckSubmitTurnRequest {
   pub skills: Vec<ControlDeckSkillRef>,
   #[serde(default, skip_serializing_if = "Option::is_none")]
   pub overrides: Option<ControlDeckTurnOverrides>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ControlDeckSubmitResponse {
+  pub accepted: bool,
+  pub row: ConversationRowEntry,
+  #[serde(default, skip_serializing_if = "Option::is_none")]
+  pub snapshot: Option<ControlDeckSnapshot>,
 }

--- a/orbitdock-server/crates/protocol/src/control_deck.rs
+++ b/orbitdock-server/crates/protocol/src/control_deck.rs
@@ -1,10 +1,9 @@
 use serde::{Deserialize, Serialize};
 
 use crate::{
-  conversation_contracts::ConversationRowEntry,
-  ApprovalRequest, CodexApprovalPolicy, CodexApprovalsReviewer, CodexConfigMode,
-  CodexSandboxPolicy, Provider, SessionControlMode, SessionLifecycleState, TokenUsage,
-  TokenUsageSnapshotKind,
+  conversation_contracts::ConversationRowEntry, ApprovalRequest, CodexApprovalPolicy,
+  CodexApprovalsReviewer, CodexConfigMode, CodexSandboxPolicy, Provider, SessionControlMode,
+  SessionLifecycleState, TokenUsage, TokenUsageSnapshotKind,
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]

--- a/orbitdock-server/crates/protocol/src/types.rs
+++ b/orbitdock-server/crates/protocol/src/types.rs
@@ -2025,6 +2025,7 @@ pub struct SessionComposerSnapshot {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ConversationSnapshotPage {
   pub revision: u64,
+  pub replay_cursor: u64,
   pub session_id: String,
   pub session: SessionState,
   pub rows: Vec<crate::conversation_contracts::RowEntrySummary>,

--- a/orbitdock-server/crates/server/src/domain/sessions/session.rs
+++ b/orbitdock-server/crates/server/src/domain/sessions/session.rs
@@ -881,7 +881,9 @@ impl SessionHandle {
   /// Replay events since a given revision.
   /// Returns `None` if the gap is too large (caller should send a retained snapshot fallback).
   pub fn replay_since(&self, since_revision: u64) -> Option<Vec<String>> {
-    let oldest = self.event_log.front().map(|(rev, _)| *rev)?;
+    let Some(oldest) = self.event_log.front().map(|(rev, _)| *rev) else {
+      return (since_revision == self.revision).then(Vec::new);
+    };
     if oldest > since_revision + 1 {
       return None; // Gap too large, need a retained snapshot fallback.
     }
@@ -1063,6 +1065,17 @@ mod tests {
     assert!(!payload.contains("\"aggregated_output\""));
     assert!(!payload.contains("\"terminal_snapshot\""));
     assert!(payload.contains("\"live_output_preview\""));
+  }
+
+  #[test]
+  fn replay_since_current_revision_without_event_log_returns_empty_replay() {
+    let session = session_handle(Provider::Codex);
+
+    let replay = session
+      .replay_since(0)
+      .expect("empty replay at current revision");
+
+    assert!(replay.is_empty());
   }
 
   #[test]

--- a/orbitdock-server/crates/server/src/infrastructure/logging.rs
+++ b/orbitdock-server/crates/server/src/infrastructure/logging.rs
@@ -19,6 +19,9 @@ const QUIET_TARGET_DIRECTIVES: &[(&str, &str)] = &[
   ("codex_otel.log_only", "warn"),
   ("codex_client::custom_ca", "warn"),
   ("codex_api::endpoint::responses_websocket", "warn"),
+  ("codex_core::config", "warn"),
+  ("codex_core::models_manager", "warn"),
+  ("connector_codex::config", "warn"),
   ("codex_core::features", "error"),
   ("feedback_tags", "warn"),
   ("rmcp::transport::worker", "off"),
@@ -374,6 +377,9 @@ mod tests {
     assert!(resolved.contains("codex_otel.log_only=warn"));
     assert!(resolved.contains("codex_client::custom_ca=warn"));
     assert!(resolved.contains("codex_api::endpoint::responses_websocket=warn"));
+    assert!(resolved.contains("codex_core::config=warn"));
+    assert!(resolved.contains("codex_core::models_manager=warn"));
+    assert!(resolved.contains("connector_codex::config=warn"));
     assert!(resolved.contains("codex_core::features=error"));
     assert!(resolved.contains("feedback_tags=warn"));
     assert!(resolved.contains("rmcp::transport::worker=off"));
@@ -384,8 +390,8 @@ mod tests {
     let resolved = resolve_filter_directives(Some("debug".to_string()));
 
     assert_eq!(
-            resolved,
-            "debug,codex_otel.trace_safe=warn,codex_otel.log_only=warn,codex_client::custom_ca=warn,codex_api::endpoint::responses_websocket=warn,codex_core::features=error,feedback_tags=warn,rmcp::transport::worker=off"
+      resolved,
+            "debug,codex_otel.trace_safe=warn,codex_otel.log_only=warn,codex_client::custom_ca=warn,codex_api::endpoint::responses_websocket=warn,codex_core::config=warn,codex_core::models_manager=warn,connector_codex::config=warn,codex_core::features=error,feedback_tags=warn,rmcp::transport::worker=off"
         );
   }
 

--- a/orbitdock-server/crates/server/src/runtime/control_deck.rs
+++ b/orbitdock-server/crates/server/src/runtime/control_deck.rs
@@ -743,12 +743,17 @@ mod tests {
       "expected a standard accepted user row id, got {}",
       result.row.id()
     );
-    let snapshot = result.snapshot.expect("submit response should include snapshot");
+    let snapshot = result
+      .snapshot
+      .expect("submit response should include snapshot");
     assert_eq!(snapshot.session_id, session_id);
 
     let action = action_rx.recv().await.expect("connector action");
     assert!(
-      matches!(action, crate::connectors::codex_session::CodexAction::SendMessage { .. }),
+      matches!(
+        action,
+        crate::connectors::codex_session::CodexAction::SendMessage { .. }
+      ),
       "expected control deck submit to dispatch a send message action"
     );
   }

--- a/orbitdock-server/crates/server/src/runtime/control_deck.rs
+++ b/orbitdock-server/crates/server/src/runtime/control_deck.rs
@@ -66,6 +66,7 @@ pub(crate) enum ControlDeckAttachmentUploadError {
 #[derive(Debug, Clone)]
 pub(crate) struct ControlDeckSubmitResult {
   pub row: orbitdock_protocol::conversation_contracts::ConversationRowEntry,
+  pub snapshot: Option<ControlDeckSnapshot>,
 }
 
 #[derive(Debug, Clone)]
@@ -78,6 +79,13 @@ struct ControlDeckDispatchRequest {
   images: Vec<ImageInput>,
   mentions: Vec<MentionInput>,
   message_id: String,
+}
+
+fn next_control_deck_submit_message_id() -> String {
+  // Control deck compose is still a normal user-turn mutation. Keep its accepted
+  // HTTP row identity aligned with `POST /messages` so the client can render the
+  // returned row immediately without special cases.
+  format!("user-http-{}", orbitdock_protocol::new_id())
 }
 
 pub(crate) fn load_control_deck_preferences() -> ControlDeckPreferences {
@@ -119,6 +127,28 @@ pub(crate) async fn load_control_deck_snapshot(
     Err(SessionLoadError::Db(err)) => Err(ControlDeckSnapshotLoadError::Db(err)),
     Err(SessionLoadError::Runtime(err)) => Err(ControlDeckSnapshotLoadError::Runtime(err)),
   }
+}
+
+async fn load_live_control_deck_submit_snapshot(
+  state: &Arc<SessionRegistry>,
+  session_id: &str,
+) -> Result<ControlDeckSnapshot, ControlDeckSnapshotLoadError> {
+  if let Some(actor) = state.get_session(session_id) {
+    let session = actor
+      .retained_state()
+      .await
+      .map_err(ControlDeckSnapshotLoadError::Runtime)?;
+    let effort_options = resolve_control_deck_effort_options(session_id, &session).await;
+    let connector_attached = state.has_active_connector_action_tx(session_id);
+    return Ok(build_control_deck_snapshot(
+      &session,
+      load_control_deck_preferences(),
+      effort_options,
+      connector_attached,
+    ));
+  }
+
+  load_control_deck_snapshot(state, session_id).await
 }
 
 async fn resolve_control_deck_effort_options(
@@ -329,7 +359,7 @@ pub(crate) async fn submit_control_deck_turn(
     skills: plan.skills,
     images: plan.images,
     mentions: plan.mentions,
-    message_id: format!("control-deck-http-{}", orbitdock_protocol::new_id()),
+    message_id: next_control_deck_submit_message_id(),
   };
 
   let result = dispatch_control_deck_turn(state, dispatch_request.clone()).await;
@@ -351,7 +381,24 @@ pub(crate) async fn submit_control_deck_turn(
     Err(other) => return Err(map_dispatch_error(other)),
   };
 
-  Ok(ControlDeckSubmitResult { row: user_row })
+  let snapshot = match load_live_control_deck_submit_snapshot(state, session_id).await {
+    Ok(snapshot) => Some(snapshot),
+    Err(error) => {
+      warn!(
+        component = "control_deck",
+        event = "submit.snapshot_unavailable",
+        session_id = %session_id,
+        error = ?error,
+        "Control deck submit succeeded but snapshot reload was unavailable"
+      );
+      None
+    }
+  };
+
+  Ok(ControlDeckSubmitResult {
+    row: user_row,
+    snapshot,
+  })
 }
 
 /// Attempt to transparently resume a session whose connector has died.
@@ -512,13 +559,16 @@ fn map_dispatch_error(error: DispatchMessageError) -> ControlDeckSubmitError {
 
 #[cfg(test)]
 mod tests {
-  use super::{auto_resume_session_with, ControlDeckSubmitError};
+  use super::{auto_resume_session_with, submit_control_deck_turn, ControlDeckSubmitError};
   use crate::domain::sessions::session::SessionHandle;
   use crate::runtime::restored_sessions::PreparedResumeSession;
   use crate::runtime::session_registry::SessionRegistry;
   use crate::runtime::session_resume::ResumeSessionLaunch;
-  use crate::support::test_support::ensure_server_test_data_dir;
-  use orbitdock_protocol::Provider;
+  use crate::support::test_support::{ensure_server_test_data_dir, new_test_session_registry};
+  use orbitdock_protocol::{
+    CodexIntegrationMode, ControlDeckSubmitTurnRequest, Provider, SessionLifecycleState,
+    SessionStatus, StateChanges, WorkStatus,
+  };
   use std::sync::atomic::{AtomicUsize, Ordering};
   use std::sync::Arc;
   use tokio::sync::{mpsc, oneshot};
@@ -652,5 +702,54 @@ mod tests {
     assert!(second_result.expect("second task join").is_ok());
     assert_eq!(load_count_assert.load(Ordering::SeqCst), 1);
     assert_eq!(launch_count.load(Ordering::SeqCst), 1);
+  }
+
+  #[tokio::test]
+  async fn submit_control_deck_turn_returns_standard_user_http_row_id() {
+    let state = new_test_session_registry(true);
+    let session_id = "control-deck-submit-user-row";
+    let mut handle = SessionHandle::new(
+      session_id.to_string(),
+      Provider::Codex,
+      "/tmp/orbitdock-test".to_string(),
+    );
+    handle.apply_changes(&StateChanges {
+      status: Some(SessionStatus::Active),
+      work_status: Some(WorkStatus::Waiting),
+      lifecycle_state: Some(SessionLifecycleState::Open),
+      codex_integration_mode: Some(Some(CodexIntegrationMode::Direct)),
+      ..Default::default()
+    });
+    state.add_session(handle);
+
+    let (action_tx, mut action_rx) = mpsc::channel(1);
+    state.set_codex_action_tx(session_id, action_tx);
+
+    let result = submit_control_deck_turn(
+      &state,
+      session_id,
+      ControlDeckSubmitTurnRequest {
+        text: "Ship the fix".to_string(),
+        attachments: vec![],
+        skills: vec![],
+        overrides: None,
+      },
+    )
+    .await
+    .expect("control deck submit should succeed");
+
+    assert!(
+      result.row.id().starts_with("user-http-"),
+      "expected a standard accepted user row id, got {}",
+      result.row.id()
+    );
+    let snapshot = result.snapshot.expect("submit response should include snapshot");
+    assert_eq!(snapshot.session_id, session_id);
+
+    let action = action_rx.recv().await.expect("connector action");
+    assert!(
+      matches!(action, crate::connectors::codex_session::CodexAction::SendMessage { .. }),
+      "expected control deck submit to dispatch a send message action"
+    );
   }
 }

--- a/orbitdock-server/crates/server/src/runtime/session_actor.rs
+++ b/orbitdock-server/crates/server/src/runtime/session_actor.rs
@@ -269,7 +269,7 @@ mod tests {
   }
 
   #[tokio::test]
-  async fn actor_subscribe_with_revision_returns_resync_required() {
+  async fn actor_subscribe_with_current_revision_returns_empty_replay() {
     let (persist_tx, _persist_rx) = mpsc::channel(64);
     let actor_handle = SessionActorHandle::spawn(test_handle(), persist_tx);
 
@@ -283,9 +283,11 @@ mod tests {
 
     let result = rx.await.unwrap();
     match result {
-      crate::runtime::session_commands::SubscribeResult::ResyncRequired { .. } => {}
-      crate::runtime::session_commands::SubscribeResult::Replay { .. } => {
-        panic!("expected resync-required, got replay")
+      crate::runtime::session_commands::SubscribeResult::Replay { events, .. } => {
+        assert!(events.is_empty());
+      }
+      crate::runtime::session_commands::SubscribeResult::ResyncRequired { .. } => {
+        panic!("expected empty replay, got resync-required")
       }
     }
   }

--- a/orbitdock-server/crates/server/src/runtime/session_actor.rs
+++ b/orbitdock-server/crates/server/src/runtime/session_actor.rs
@@ -245,7 +245,7 @@ mod tests {
   }
 
   #[tokio::test]
-  async fn actor_subscribe_returns_state_and_receiver() {
+  async fn actor_subscribe_without_revision_returns_replay() {
     let (persist_tx, _persist_rx) = mpsc::channel(64);
     let actor_handle = SessionActorHandle::spawn(test_handle(), persist_tx);
 
@@ -259,10 +259,12 @@ mod tests {
 
     let result = rx.await.unwrap();
     match result {
-      crate::runtime::session_commands::SubscribeResult::Replay { .. } => {
-        panic!("expected resync-required, got replay")
+      crate::runtime::session_commands::SubscribeResult::Replay { events, .. } => {
+        assert!(events.is_empty());
       }
-      crate::runtime::session_commands::SubscribeResult::ResyncRequired { .. } => {}
+      crate::runtime::session_commands::SubscribeResult::ResyncRequired { .. } => {
+        panic!("expected replay, got resync-required")
+      }
     }
   }
 

--- a/orbitdock-server/crates/server/src/runtime/session_command_handler.rs
+++ b/orbitdock-server/crates/server/src/runtime/session_command_handler.rs
@@ -273,14 +273,18 @@ pub async fn handle_session_command(
       since_revision,
       reply,
     } => {
-      if let Some(since_rev) = since_revision {
-        if let Some(events) = handle.replay_since(since_rev) {
-          let rx = handle.subscribe();
-          persist_and_broadcast_mark_read(handle, persist_tx).await;
-          let _ = reply.send(SubscribeResult::Replay { events, rx });
-          return;
-        }
+      let replay_events = match since_revision {
+        None => Some(vec![]),
+        Some(since_rev) => handle.replay_since(since_rev),
+      };
+
+      if let Some(events) = replay_events {
+        let rx = handle.subscribe();
+        persist_and_broadcast_mark_read(handle, persist_tx).await;
+        let _ = reply.send(SubscribeResult::Replay { events, rx });
+        return;
       }
+
       let rx = handle.subscribe();
       persist_and_broadcast_mark_read(handle, persist_tx).await;
       let _ = reply.send(SubscribeResult::ResyncRequired { rx });
@@ -1083,6 +1087,35 @@ mod tests {
       Some("2026-03-20T12:34:56Z")
     );
     assert!(persist_rx.try_recv().is_err());
+  }
+
+  #[tokio::test]
+  async fn subscribe_without_cursor_attaches_live_stream_without_resync() {
+    let (persist_tx, _persist_rx) = mpsc::channel(8);
+    let mut handle = SessionHandle::new(
+      "session-1".to_string(),
+      Provider::Codex,
+      "/repo".to_string(),
+    );
+    let (reply_tx, reply_rx) = tokio::sync::oneshot::channel();
+
+    handle_session_command(
+      SessionCommand::Subscribe {
+        since_revision: None,
+        reply: reply_tx,
+      },
+      &mut handle,
+      &persist_tx,
+    )
+    .await;
+
+    let result = reply_rx.await.expect("subscribe result");
+    match result {
+      SubscribeResult::Replay { events, .. } => assert!(events.is_empty()),
+      SubscribeResult::ResyncRequired { .. } => {
+        panic!("fresh subscribe without cursor should not require resync")
+      }
+    }
   }
 
   #[tokio::test]

--- a/orbitdock-server/crates/server/src/transport/http/control_deck.rs
+++ b/orbitdock-server/crates/server/src/transport/http/control_deck.rs
@@ -8,7 +8,7 @@ use axum::{
 };
 use orbitdock_protocol::{
   ControlDeckConfigUpdate, ControlDeckImageAttachmentRef, ControlDeckPreferences,
-  ControlDeckSnapshot, ControlDeckSubmitTurnRequest,
+  ControlDeckSnapshot, ControlDeckSubmitResponse, ControlDeckSubmitTurnRequest,
 };
 use serde::{Deserialize, Serialize};
 use tracing::{info, warn};
@@ -27,12 +27,6 @@ use crate::runtime::control_deck::{
   ControlDeckPreferencesUpdateError, ControlDeckSnapshotLoadError, ControlDeckSubmitError,
 };
 use crate::runtime::session_registry::SessionRegistry;
-
-#[derive(Debug, Serialize)]
-pub struct ControlDeckSubmitResponse {
-  pub accepted: bool,
-  pub row: orbitdock_protocol::conversation_contracts::ConversationRowEntry,
-}
 
 #[derive(Debug, Serialize)]
 pub struct ControlDeckImageAttachmentResponse {
@@ -137,6 +131,7 @@ pub async fn submit_control_deck_turn(
         Json(ControlDeckSubmitResponse {
           accepted: true,
           row: result.row,
+          snapshot: result.snapshot,
         }),
       )
     })

--- a/orbitdock-server/crates/server/src/transport/http/sessions.rs
+++ b/orbitdock-server/crates/server/src/transport/http/sessions.rs
@@ -302,6 +302,7 @@ pub async fn get_conversation_snapshot(
         .collect();
       Ok(Json(ConversationSnapshotPage {
         revision: bootstrap.session.revision.unwrap_or_default(),
+        replay_cursor: bootstrap.session.revision.unwrap_or_default(),
         session_id,
         session: bootstrap.session,
         rows,

--- a/orbitdock-server/crates/server/src/transport/websocket/connection.rs
+++ b/orbitdock-server/crates/server/src/transport/websocket/connection.rs
@@ -13,7 +13,7 @@ use axum::{
 use futures::{SinkExt, StreamExt};
 use tokio::sync::mpsc;
 use tokio::task::JoinHandle;
-use tracing::{debug, error, info, warn};
+use tracing::{debug, error, warn};
 
 use orbitdock_protocol::SessionSurface;
 use orbitdock_protocol::{ClientMessage, ServerMessage};
@@ -100,18 +100,9 @@ impl ConnectionSubscriptions {
 /// WebSocket upgrade handler
 pub async fn ws_handler(
   ws: WebSocketUpgrade,
-  headers: HeaderMap,
+  _headers: HeaderMap,
   State(state): State<Arc<SessionRegistry>>,
 ) -> impl IntoResponse {
-  info!(
-      component = "websocket",
-      event = "ws.upgrade.request",
-      client_version = ?headers
-          .get(orbitdock_protocol::HTTP_HEADER_CLIENT_VERSION)
-          .and_then(|value| value.to_str().ok()),
-      has_authorization = headers.contains_key("authorization"),
-      "Received WebSocket upgrade request"
-  );
   ws.on_upgrade(move |socket| handle_socket(socket, state))
 }
 
@@ -119,12 +110,6 @@ pub async fn ws_handler(
 async fn handle_socket(socket: WebSocket, state: Arc<SessionRegistry>) {
   let conn_id = NEXT_CONNECTION_ID.fetch_add(1, Ordering::Relaxed);
   state.ws_connect();
-  info!(
-    component = "websocket",
-    event = "ws.connection.opened",
-    connection_id = conn_id,
-    "WebSocket connection opened"
-  );
 
   let (mut ws_tx, mut ws_rx) = socket.split();
 
@@ -257,12 +242,6 @@ async fn handle_socket(socket: WebSocket, state: Arc<SessionRegistry>) {
         continue;
       }
       Ok(Message::Close(_)) => {
-        info!(
-          component = "websocket",
-          event = "ws.connection.close_frame",
-          connection_id = conn_id,
-          "Client sent close frame"
-        );
         break;
       }
       Ok(_) => continue,
@@ -308,12 +287,6 @@ async fn handle_socket(socket: WebSocket, state: Arc<SessionRegistry>) {
   }
 
   state.ws_disconnect();
-  info!(
-    component = "websocket",
-    event = "ws.connection.closed",
-    connection_id = conn_id,
-    "WebSocket connection closed"
-  );
   if state.clear_client_primary_claim(conn_id) {
     state.broadcast_to_list(server_info_message(&state));
   }

--- a/plans/direct-session-token-tracking-plan-2026-04-11.md
+++ b/plans/direct-session-token-tracking-plan-2026-04-11.md
@@ -1,0 +1,199 @@
+# Direct Session Token Tracking Plan
+
+Date: 2026-04-11
+Status: Active
+Supersedes: `plans/usage-reconciliation-plan-2026-04-04.md`
+
+## Context
+- OrbitDock already has a durable usage stack: `usage_events`, `usage_session_state`, `usage_turns`, and `usage_ledger_entries`.
+- The server now writes completed-turn usage independently of diff presence through `PersistCommand::TurnDiffInsert`, and persistence always upserts `usage_turns` and `usage_ledger_entries` even when `diff` is `None`.
+- The client now understands `snapshot_kind` semantics (`context_turn`, `mixed_legacy`, etc.) for live token display and turn-diff decoding.
+- We only care about OrbitDock direct sessions for this work.
+- We want token tracking that is correct per turn, durable, restart-safe, and ready for eventual conversation-view usage UI.
+
+## Why This Change
+- Problem:
+  - Codex direct sessions still use `ContextTurn` snapshots for live token updates, but the completed-turn persistence path still writes per-turn usage from accumulators that are only updated for `MixedLegacy` snapshots.
+  - `/api/usage/summary` still aggregates all sessions instead of only direct sessions.
+  - Conversation APIs still expose per-turn token data only through `turn_diffs`, which means usage-only turns without diffs are not a first-class surface.
+- Why now:
+  - The current API/client refactors give us clean HTTP surfaces and clearer token semantics, so this is the right moment to finish the accounting model instead of layering more UI on top of incorrect data.
+- Cost of leaving it as-is:
+  - Codex-heavy direct sessions can still persist zero or incorrect per-turn usage.
+  - Usage summary can still over-count scope by including non-direct sessions.
+  - We cannot confidently build per-turn usage into conversation UI without a dedicated contract.
+- Success looks like:
+- [ ] Every completed direct-session turn produces correct billable usage regardless of provider.
+- [ ] `/api/usage/summary` reports direct-session-only totals.
+- [ ] A dedicated HTTP contract exists for per-turn usage history, independent of diffs.
+- [ ] Live token UI and authoritative billing data are explicitly separated in the design.
+
+## Target Design
+
+### Current Gap
+- `Input::TokensUpdated` in `connector-core` treats `MixedLegacy` as special and updates per-turn accumulators, but all other snapshot kinds overwrite only `state.token_usage`.
+- Codex direct sessions emit `ContextTurn` from `last_token_usage`, which is appropriate for live context display, but not sufficient as the only source of authoritative completed-turn accounting.
+- Summary SQL in `server_meta.rs` does not scope to direct sessions.
+- Session/conversation hydration builds turn token data from `turn_diffs` joins, not from a usage-first turn history surface.
+
+### Proposed Shape
+- Separate the system into two server-owned flows:
+  - Live token snapshots: provider-semantic `TokensUpdated` values used for session/control-deck display.
+  - Completed-turn accounting: provider-normalized per-turn usage facts written once per completed turn and used by summary/history APIs.
+- For provider accounting:
+  - Claude direct continues using accumulated per-turn values derived from `MixedLegacy` snapshots.
+  - Codex direct should finalize turn usage from a provider-appropriate completed-turn source, not from the current `ContextTurn` accumulator path.
+- HTTP remains the source of truth for usage surfaces:
+  - `/api/usage/summary` becomes direct-session scoped.
+  - Add a dedicated per-turn usage endpoint for session history / eventual conversation usage UI.
+- WebSocket remains lightweight:
+  - Existing `tokens_updated` remains live UI state.
+  - If needed later, WS should emit a refetch hint for per-turn usage instead of streaming large history payloads.
+
+### Decision Log
+- 2026-04-11: Treat live token snapshots and authoritative completed-turn accounting as separate concerns. Status: decided.
+- 2026-04-11: Use HTTP, not WebSocket, for per-turn usage history. Status: decided.
+- 2026-04-11: Scope usage summary to direct sessions only. Status: decided.
+- 2026-04-11: Supersede the 2026-04-04 plan because the repo has already completed the earlier diff-decoupling work. Status: decided.
+
+### Risks And Mitigations
+| Risk | Why it matters | Mitigation |
+|---|---|---|
+| We patch Codex by reusing live `ContextTurn` values for billing | Could preserve wrong per-turn accounting under a cleaner API | Define a dedicated Codex turn-final accounting path and test it against provider semantics |
+| We overload `turn_diffs` again instead of creating a usage-first API | Conversation usage UI remains sparse/incomplete for no-diff turns | Add a dedicated `/usage/turns` style endpoint and keep diff history separate |
+| Direct-session filtering is applied inconsistently across SQL paths | Summary and future history endpoints drift in scope | Centralize and reuse the existing direct-session predicate pattern |
+| Client starts using billing data for live context UI | UI becomes less responsive or semantically wrong | Keep `tokens_updated` for live display and use ledger/history only for completed turns |
+
+## Phase 1: Re-baseline Current Semantics In Code And Tests
+Goal: Lock the current design assumptions into tests before changing accounting behavior.
+Why this phase first: We already have a partially-refactored system, and we need guardrails that reflect the current architecture before altering provider logic.
+Files:
+- `orbitdock-server/crates/connector-core/src/transition.rs` - add/adjust transition tests around `ContextTurn`, `MixedLegacy`, and completed-turn persistence.
+- `orbitdock-server/crates/server/src/infrastructure/persistence/usage.rs` - add normalization tests that encode direct-session accounting expectations.
+- `OrbitDockNative/OrbitDockTests/Server/Sessions/ServerTokenUsageSemanticsTests.swift` - preserve client-side semantic expectations for live display decoding.
+
+Changes:
+- [ ] Add a server test proving Codex `ContextTurn` live updates do not yet produce correct completed-turn accounting.
+- [ ] Add a server test proving Claude `MixedLegacy` completed-turn accounting still works as expected.
+- [ ] Add a test proving turns without diffs still persist usage rows, so we do not regress already-completed work.
+- [ ] Document in-test language that live snapshot semantics and authoritative turn accounting are intentionally different.
+
+Done when:
+- [ ] The failing/coverage tests identify the remaining Codex correctness gap without reintroducing outdated assumptions from the April 4 plan.
+- [ ] Tests clearly encode what is already solved versus what still needs implementation.
+
+## Phase 2: Fix Provider-Specific Completed-Turn Accounting
+Goal: Make completed-turn usage correct for direct sessions across Claude and Codex.
+Why this phase next: Summary accuracy and any future per-turn history API depend on writing correct turn facts first.
+Files:
+- `orbitdock-server/crates/connector-core/src/transition.rs` - stop relying on `MixedLegacy`-only accumulators as the only completed-turn accounting mechanism.
+- `orbitdock-server/crates/connector-codex/src/event_mapping/runtime_signals.rs` - keep or refine live token mapping with clear separation from accounting needs.
+- `orbitdock-server/crates/server/src/runtime/transcript_sync_policy.rs` - ensure transcript-driven usage updates remain live-display semantics only.
+- `orbitdock-server/crates/server/src/infrastructure/persistence/usage.rs` - preserve normalized ledger-writing behavior once the right turn facts are provided.
+- `orbitdock-server/crates/server/src/infrastructure/persistence/session_writes.rs` - continue writing completed-turn usage through the authoritative persistence path.
+
+Changes:
+- [ ] Introduce a provider-aware completed-turn accounting path for Codex direct sessions.
+- [ ] Preserve `TokensUpdated` as a live snapshot path for current session/control-deck UI.
+- [ ] Ensure Claude direct sessions continue to finalize accurate turn usage from accumulated `MixedLegacy` data.
+- [ ] Add regression tests covering multi-turn Codex sessions and restart-safe completed-turn persistence.
+
+Done when:
+- [ ] Codex completed turns persist non-zero, provider-correct usage when the provider reports token activity.
+- [ ] Claude completed-turn accounting still passes existing semantics/regression tests.
+- [ ] The persistence layer receives correct turn facts without needing to infer provider behavior from sparse SQL later.
+
+## Phase 3: Scope Summary API To Direct Sessions
+Goal: Ensure the summary endpoint reports only the sessions we care about.
+Why this phase next: Once turn facts are correct, summary scope becomes the next biggest source of user-visible mismatch.
+Files:
+- `orbitdock-server/crates/server/src/transport/http/server_meta.rs` - filter sessions and ledger rows to direct sessions only.
+- `OrbitDockNative/OrbitDock/Services/Server/API/UsageClient.swift` - no contract change expected unless we add explicit scope params.
+- `OrbitDockNative/OrbitDock/Services/UsageServiceRegistry.swift` - validate that merged runtime summaries still behave correctly under the narrowed scope.
+
+Changes:
+- [ ] Apply the existing direct-session predicate pattern to `load_usage_summary` session counting.
+- [ ] Apply the same predicate to ledger-row and legacy-fallback row loading.
+- [ ] Add summary tests covering direct vs non-direct sessions.
+- [ ] Decide whether the endpoint should remain implicitly direct-scoped or expose an explicit query parameter for future expansion.
+
+Done when:
+- [ ] `/api/usage/summary` excludes passive/non-direct sessions.
+- [ ] Summary tests prove direct-session scope across both ledger and legacy-fallback paths.
+- [ ] Native summary UI continues to decode and render without contract regressions.
+
+## Phase 4: Add A Dedicated Per-Turn Usage History API
+Goal: Provide a usage-first HTTP surface for eventual conversation/session UI.
+Why this phase next: Once correctness and summary scope are fixed, we can safely expose historical turn usage without teaching the client to reverse-engineer it from diffs.
+Files:
+- `orbitdock-server/crates/server/src/transport/http/router.rs` - add route for per-turn usage history.
+- `orbitdock-server/crates/server/src/transport/http/sessions.rs` or a new focused usage transport file - implement the endpoint.
+- `orbitdock-server/crates/protocol/src/types.rs` - add shared payload types if we want protocol-level reuse.
+- `orbitdock-server/crates/server/src/infrastructure/persistence/session_reads/session_hydration.rs` - leave diff hydration focused on diffs; avoid overloading it with usage-history responsibilities.
+- `OrbitDockNative/OrbitDock/Services/Server/API/ConversationClient.swift` or `UsageClient.swift` - add client fetcher for per-turn usage history.
+- `OrbitDockNative/OrbitDock/Services/Server/Protocol/ServerSessionContracts.swift` - add payload decoding for turn-usage history rows.
+
+Changes:
+- [ ] Design a direct-session per-turn usage payload with turn id, turn seq, provider/model context, billable token facts, context-window facts, observed time, and snapshot kind.
+- [ ] Implement an HTTP endpoint that pages/sorts completed-turn usage independently of diff history.
+- [ ] Keep `turn_diffs` unchanged so review/diff UI does not take on usage-history responsibilities.
+- [ ] Add API and client decoding tests.
+
+Done when:
+- [ ] We can fetch per-turn usage for a session even when some turns have no diffs.
+- [ ] The endpoint is HTTP bootstrap/history only, with no heavy WS payload addition.
+- [ ] The payload is sufficient for future conversation-view token UI without another server redesign.
+
+## Files To Modify
+| File | Planned change |
+|---|---|
+| `plans/direct-session-token-tracking-plan-2026-04-11.md` | Source-of-truth implementation plan; update status as work progresses |
+| `orbitdock-server/crates/connector-core/src/transition.rs` | Separate live token snapshots from authoritative completed-turn accounting |
+| `orbitdock-server/crates/connector-codex/src/event_mapping/runtime_signals.rs` | Keep Codex live snapshot mapping explicit and aligned with provider semantics |
+| `orbitdock-server/crates/server/src/runtime/transcript_sync_policy.rs` | Preserve transcript usage as live-display sync, not billing truth |
+| `orbitdock-server/crates/server/src/infrastructure/persistence/usage.rs` | Continue normalized ledger writes and add targeted regression tests |
+| `orbitdock-server/crates/server/src/infrastructure/persistence/session_writes.rs` | Keep completed-turn persistence authoritative once correct turn facts are provided |
+| `orbitdock-server/crates/server/src/transport/http/server_meta.rs` | Direct-session summary filtering and tests |
+| `orbitdock-server/crates/server/src/transport/http/router.rs` | Route dedicated per-turn usage endpoint |
+| `orbitdock-server/crates/server/src/transport/http/sessions.rs` or a new transport file | Implement per-turn usage HTTP API |
+| `orbitdock-server/crates/server/src/infrastructure/persistence/session_reads/session_hydration.rs` | Keep diff hydration scoped correctly; avoid mixing in usage-history responsibilities |
+| `orbitdock-server/crates/protocol/src/types.rs` | Shared per-turn usage payload types if needed |
+| `OrbitDockNative/OrbitDock/Services/Server/API/UsageClient.swift` | Summary contract call path, plus optional per-turn usage fetches |
+| `OrbitDockNative/OrbitDock/Services/Server/API/ConversationClient.swift` | Optional home for per-turn usage history fetch depending on surface ownership |
+| `OrbitDockNative/OrbitDock/Services/Server/Protocol/ServerSessionContracts.swift` | Decode new per-turn usage payloads |
+| `OrbitDockNative/OrbitDock/Services/UsageServiceRegistry.swift` | Validate summary behavior after direct-session scoping |
+| `OrbitDockNative/OrbitDockTests/Server/Sessions/ServerTokenUsageSemanticsTests.swift` | Preserve live token semantic expectations |
+
+## Implementation Order
+1. Re-baseline tests around current semantics so the new work starts from the real codebase rather than the April 4 assumptions.
+2. Fix completed-turn provider accounting on the server, because every downstream surface depends on correct turn facts.
+3. Scope `/api/usage/summary` to direct sessions once ledger truth is correct.
+4. Add the dedicated per-turn usage HTTP surface for future conversation/session UI.
+5. Wire client decoding and keep this plan updated as tasks move from open to done.
+
+## Verification
+Build or test commands:
+- `cargo test -p orbitdock-server`
+- `cargo test -p orbitdock-server usage_summary`
+- `cargo test -p orbitdock-server transition`
+- `xcodebuild -project OrbitDockNative/OrbitDock/OrbitDock.xcodeproj -scheme OrbitDock -destination 'platform=macOS' test`
+
+Checks:
+- [ ] Codex direct-session turns persist correct completed-turn usage across multiple turns.
+- [ ] Claude direct-session turns still persist correct completed-turn usage.
+- [ ] Usage summary excludes passive/non-direct sessions.
+- [ ] Per-turn usage history can be fetched for a session even when no diff exists for some turns.
+- [ ] Native client decodes the updated contracts without semantic regressions for live token display.
+
+## Open Questions
+- [ ] For Codex direct sessions, should authoritative completed-turn accounting come from total-usage deltas captured at turn boundaries, or from a new provider-emitted finalized turn usage event if we add one?
+- [ ] Should `/api/usage/summary` become implicitly direct-only now, or should we add an explicit `scope=direct` query parameter for future-proofing?
+- [ ] Should per-turn usage history live under `UsageClient` or `ConversationClient` on the native side?
+
+## Definition Of Done
+- [ ] This plan file is the active source of truth and is updated as phases/tasks complete.
+- [ ] Direct-session completed-turn accounting is correct for both Claude and Codex.
+- [ ] Summary totals are direct-session scoped.
+- [ ] A dedicated per-turn usage HTTP contract exists and is tested.
+- [ ] Live token UI semantics remain correct and distinct from billing/accounting semantics.
+- [ ] Server and native regression coverage is in place for the changed contracts.

--- a/plans/native-app-architecture-cleanup.md
+++ b/plans/native-app-architecture-cleanup.md
@@ -1,0 +1,183 @@
+# Native App Architecture Cleanup
+
+Date: 2026-04-11
+Status: Active
+
+## Context
+
+- OrbitDock's native app still has architecture drift that shows up as duplicate bootstrap work, stale live updates, and feature surfaces that refresh for the wrong reasons.
+- The docs are now aligned around the target model in [docs/ARCHITECTURE.md](/Users/robertdeluca/Developer/OrbitDock/docs/ARCHITECTURE.md:1), [docs/data-flow.md](/Users/robertdeluca/Developer/OrbitDock/docs/data-flow.md:1), and [docs/GETTING_STARTED.md](/Users/robertdeluca/Developer/OrbitDock/docs/GETTING_STARTED.md:1).
+- The next step is to make the code match that model instead of continuing to patch symptoms one view at a time.
+
+## Target Model
+
+The cleanup is converging on four rules:
+
+1. Scene owners resolve stable dependencies before mounting child features.
+2. Each rendered surface has one owner, one HTTP bootstrap path, and one realtime follow-up path.
+3. `SessionStore` stays transport-only: typed HTTP clients, reconnect/replay handling, and targeted async streams.
+4. SwiftUI stays structurally stable: small dedicated views, explicit dependency injection, no placeholder runtime stores, no broad fan-out as the default.
+
+This aligns with the plugin-native guidance we want to follow:
+
+- `build-ios-apps:swiftui-view-refactor`
+- `build-ios-apps:swiftui-ui-patterns`
+- `build-macos-apps:swiftui-patterns`
+- `build-macos-apps:view-refactor`
+
+## What We Already Finished
+
+- [x] Rewrote the architecture docs so they are the source of truth for native ownership and transport boundaries.
+- [x] Removed repo guidance that pointed at the deprecated local Swift skills.
+- [x] Removed the deprecated local Swift skills from `~/.codex/skills`.
+
+That means this plan starts from implementation, not from documentation cleanup.
+
+## Current Architectural Problems
+
+### 1. Session detail still owns too much
+
+- [SessionDetailView.swift](/Users/robertdeluca/Developer/OrbitDock/OrbitDockNative/OrbitDock/Views/SessionDetail/SessionDetailView.swift:1) is still doing too much composition and lifecycle wiring in one place.
+- [SessionDetailViewModel.swift](/Users/robertdeluca/Developer/OrbitDock/OrbitDockNative/OrbitDock/Views/SessionDetail/SessionDetailViewModel.swift:1) still carries ownership concerns that belong closer to the scene boundary.
+
+### 2. Feature view models still have unstable startup patterns
+
+- Several feature view models still begin life around placeholder store assumptions or delayed bind/bootstrap patterns.
+- That makes SwiftUI identity and lifecycle behavior harder to reason about, especially during selection changes and send/update flows.
+
+### 3. Broad per-session invalidation is still masking surface contracts
+
+- Review, control deck, skills, and MCP surfaces still rely too much on generic session-wide change streams.
+- That creates duplicate work, accidental refresh storms, and unclear ownership.
+
+### 4. The largest macOS files are still too monolithic
+
+- The session detail and control deck stack still carry too much view, effect, and composition logic in oversized files.
+- That fights the plugin-native pattern of small, explicit views with clear ownership.
+
+## Execution Strategy
+
+We should do this as a small number of high-leverage slices instead of a giant refactor.
+
+### Slice 1: Stabilize session-detail scene ownership
+
+Goal:
+
+- make the selected-session subtree mount once against stable dependencies
+- remove placeholder production-store behavior from the session-detail stack
+- make conversation, review, and other child surfaces receive explicit runtime dependencies
+
+Primary files:
+
+- [OrbitDockWindowRoot.swift](/Users/robertdeluca/Developer/OrbitDock/OrbitDockNative/OrbitDock/OrbitDockWindowRoot.swift:1)
+- [SessionDetailView.swift](/Users/robertdeluca/Developer/OrbitDock/OrbitDockNative/OrbitDock/Views/SessionDetail/SessionDetailView.swift:1)
+- [SessionDetailViewModel.swift](/Users/robertdeluca/Developer/OrbitDock/OrbitDockNative/OrbitDock/Views/SessionDetail/SessionDetailViewModel.swift:1)
+- [ConversationViewModel.swift](/Users/robertdeluca/Developer/OrbitDock/OrbitDockNative/OrbitDock/Views/Conversation/ConversationViewModel.swift:1)
+- [ReviewCanvasViewModel.swift](/Users/robertdeluca/Developer/OrbitDock/OrbitDockNative/OrbitDock/Views/Review/ReviewCanvasViewModel.swift:1)
+
+Done when:
+
+- [x] feature view models no longer rely on placeholder runtime stores in production paths for session detail, conversation, review, skills, and MCP
+- [x] the selected session subtree is resolved from the scene boundary before children bind
+- [ ] session switching no longer causes avoidable remount churn
+
+### Slice 2: Replace broad invalidation with surface-specific follow-up
+
+Goal:
+
+- move non-conversation surfaces off generic `sessionChanges(for:)` where a narrower contract exists
+- add targeted streams or explicit invalidation APIs where missing
+
+Primary files:
+
+- [SessionStore.swift](/Users/robertdeluca/Developer/OrbitDock/OrbitDockNative/OrbitDock/Services/Server/SessionStore.swift:1)
+- [SessionStore+Events.swift](/Users/robertdeluca/Developer/OrbitDock/OrbitDockNative/OrbitDock/Services/Server/SessionStore+Events.swift:1)
+- [ReviewCanvas.swift](/Users/robertdeluca/Developer/OrbitDock/OrbitDockNative/OrbitDock/Views/Review/ReviewCanvas.swift:1)
+- [ControlDeckScreen.swift](/Users/robertdeluca/Developer/OrbitDock/OrbitDockNative/OrbitDock/Views/Sessions/ControlDeck/ControlDeckScreen.swift:1)
+- [SkillsTab.swift](/Users/robertdeluca/Developer/OrbitDock/OrbitDockNative/OrbitDock/Views/Sessions/Capabilities/SkillsTab.swift:1)
+- [McpServersTab.swift](/Users/robertdeluca/Developer/OrbitDock/OrbitDockNative/OrbitDock/Views/Sessions/Capabilities/McpServersTab.swift:1)
+
+Done when:
+
+- [x] each surface listens to its own follow-up contract for control deck, review, skills, and MCP
+- [x] generic session-wide refresh is no longer the default for feature tabs
+- [ ] live updates do not require leaving and re-entering a view
+
+### Slice 3: Break up the largest scene and control-deck files
+
+Goal:
+
+- make the top-level macOS files read like composition, not like mixed composition plus controller logic
+- move toward the plugin-native small-view structure without changing behavior first
+
+Primary files:
+
+- [SessionDetailView.swift](/Users/robertdeluca/Developer/OrbitDock/OrbitDockNative/OrbitDock/Views/SessionDetail/SessionDetailView.swift:1)
+- [SessionDetailViewModel.swift](/Users/robertdeluca/Developer/OrbitDock/OrbitDockNative/OrbitDock/Views/SessionDetail/SessionDetailViewModel.swift:1)
+- [ControlDeckScreen.swift](/Users/robertdeluca/Developer/OrbitDock/OrbitDockNative/OrbitDock/Views/Sessions/ControlDeck/ControlDeckScreen.swift:1)
+- [ControlDeckViewModel.swift](/Users/robertdeluca/Developer/OrbitDock/OrbitDockNative/OrbitDock/Views/Sessions/ControlDeck/ControlDeckViewModel.swift:1)
+- [ControlDeckStatusBar.swift](/Users/robertdeluca/Developer/OrbitDock/OrbitDockNative/OrbitDock/Views/Sessions/ControlDeck/ControlDeckStatusBar.swift:1)
+
+Done when:
+
+- [ ] scene root files are materially smaller
+- [ ] the composition flow is readable from top to bottom
+- [ ] feature-specific sections and chrome live in focused files
+
+### Slice 4: Remove remaining SwiftUI lifecycle and identity traps
+
+Goal:
+
+- remove `AnyView`
+- replace effectful `.onAppear` flows in core surfaces with `.task` or scene-owned startup
+- clean up obvious UI-adjacent async/lifecycle patterns that still read like controller code
+
+Primary files:
+
+- [ControlDeckStatusBar.swift](/Users/robertdeluca/Developer/OrbitDock/OrbitDockNative/OrbitDock/Views/Sessions/ControlDeck/ControlDeckStatusBar.swift:1)
+- session-detail, conversation, review, and control-deck surfaces as identified during slices 1 to 3
+
+Done when:
+
+- [ ] core surfaces no longer rely on `AnyView`
+- [ ] lifecycle-bound async work is owned by `.task` or the scene boundary
+- [ ] view code reads like UI plus orchestration, not embedded controller logic
+
+## Immediate Work Order
+
+1. Finish Slice 1 first.
+2. While doing Slice 1, record every remaining generic invalidation consumer we hit naturally.
+3. Move into Slice 2 immediately after scene ownership stabilizes.
+4. Do decomposition only after ownership and invalidation are cleaner.
+
+## Verification
+
+Build and tests:
+
+- [ ] `xcodebuild -project OrbitDockNative/OrbitDock.xcodeproj -scheme 'OrbitDock Unit Tests' -destination 'platform=macOS' -derivedDataPath /tmp/OrbitDockDerivedData test`
+- [ ] `xcodebuild -project OrbitDockNative/OrbitDock.xcodeproj -scheme 'OrbitDock Unit Tests' -destination 'platform=macOS' -derivedDataPath /tmp/OrbitDockDerivedData test -only-testing:OrbitDockTests/SessionStoreReconnectRecoveryTests`
+
+Manual checks:
+
+- [ ] selecting a session produces one conversation bootstrap, not repeated GET fan-out
+- [ ] sending a message updates the conversation live without leaving and re-entering
+- [ ] review, control deck, skills, and MCP surfaces refresh only when their own surface changes
+- [ ] fast session switching does not leak stale state across sessions or endpoints
+- [ ] macOS split-view selection and keyboard navigation remain stable
+
+## Risks
+
+- [ ] We may uncover places where the existing transport contract is still too broad for a clean surface owner.
+  Mitigation: add the narrowest missing stream instead of pushing more product state into `SessionStore`.
+- [ ] Decomposition could accidentally mix cleanup work with behavior changes.
+  Mitigation: keep Slice 3 behavior-preserving and verify after each extraction.
+- [ ] Existing dirty worktree changes may overlap with some native files.
+  Mitigation: make focused commits and work carefully around unrelated edits.
+
+## Definition Of Done
+
+- [ ] Core session surfaces have explicit owners and stable dependency injection.
+- [ ] No production feature path starts from placeholder runtime-store ownership.
+- [ ] Surface refresh behavior matches the docs.
+- [ ] The duplicate bootstrap and stale live-update classes of bugs are covered by regression tests.
+- [ ] The native app is moving with plugin-native SwiftUI/macOS patterns instead of fighting them.


### PR DESCRIPTION
## Why

The session detail / conversation / control deck flow had drifted into a pretty awkward place.

The biggest problem was that the app was trying to present one user workflow through multiple disconnected state paths:

- `ControlDeck` had its own mutation contract and snapshot flow
- `ConversationView` had its own bootstrap and realtime follow-up path
- `SessionDetailViewModel` had become a scene-sized controller that owned too many unrelated concerns

That mismatch showed up as laggy sends, duplicate bootstraps, inconsistent pending state, and a control deck that felt more loosely coupled to the conversation than it should have been.

This PR fixes that in the right order:

1. make the API contract authoritative and predictable
2. simplify the transport/bootstrap model around that contract
3. replace the controller-shaped native scene structure with smaller explicit models

## What Changed

### 1. Made control deck mutations server-authoritative

`POST /control-deck/submit` now returns the authoritative accepted conversation row along with the updated control deck snapshot.

That lets the native app apply the same server response immediately across the deck and conversation surfaces instead of inventing client-local timeline state and waiting for later websocket reconciliation to make the UI feel correct.

### 2. Tightened the session bootstrap and recovery contract

The native app now treats HTTP as the authority for bootstrap and websocket as the follow-up channel.

That includes:

- removing duplicate conversation bootstrap/resync churn
- fixing the subscribe/recovery contract so fresh subscriptions attach live instead of immediately triggering unnecessary resync behavior
- keeping replay and reconnect logic scoped to the transport layer instead of leaking into feature state

The result is a much healthier transport shape for session-backed surfaces.

### 3. Replaced the old native scene/controller pattern

This branch does real structural replacement instead of more patching.

For `SessionDetail`:

- split scene-local concerns into dedicated models for conversation, review, terminal, worker state, and worktree cleanup
- moved pure snapshot types and snapshot building out of the observable scene model
- reduced the root scene and companion files so composition, lifecycle wiring, and UI chrome are easier to reason about

For `ControlDeck`:

- replaced the old `ControlDeckViewModel` shape with `ControlDeckSessionModel`
- kept transport-backed session state separate from local draft/composer state with `ControlDeckComposerModel`
- split the oversized screen into explicit sections, actions, and attachment/platform handling files

This gets the native app much closer to the architecture we actually want:

- scenes own composition and stable dependencies
- feature/session models own one surface worth of state
- `SessionStore` stays transport-focused
- the server owns durable truth

### 4. Refreshed the architecture docs

The docs now describe the target model more directly so future work has a clearer source of truth:

- server-authoritative mutation handling
- HTTP bootstrap + websocket follow-up
- scene ownership before feature mounting
- surface-local models instead of session-sized god objects

## Impact

User-facing impact:

- sending from the control deck now feels immediate and consistent with the conversation timeline
- session selection no longer triggers the same kind of duplicate conversation bootstrap churn
- the conversation / control deck / session detail flow feels much smoother and more predictable

Developer impact:

- the session detail workflow is now much easier to reason about
- the native architecture better matches the documented client model
- future work in this area should require fewer workaround patches because the authority boundaries are cleaner

## Validation

Validated during this branch with targeted checks:

- `cargo check -p orbitdock-server`
- `cargo test -p orbitdock-server submit_control_deck_turn_returns_standard_user_http_row_id -- --test-threads=1`
- `cargo test -p orbitdock-server subscribe_without_cursor_attaches_live_stream_without_resync -- --test-threads=1`
- `xcodebuild -project OrbitDockNative/OrbitDock.xcodeproj -scheme OrbitDock -destination 'platform=macOS' -derivedDataPath /tmp/OrbitDockDerivedData build`
- `xcodebuild -project OrbitDockNative/OrbitDock.xcodeproj -scheme 'OrbitDock Unit Tests' -destination 'platform=macOS' -derivedDataPath /tmp/OrbitDockDerivedData test -only-testing:OrbitDockTests/SessionStoreReconnectRecoveryTests`

I also rebuilt and exercised the macOS app against these changes while fixing the send / bootstrap / control-deck sync path.
