### PR TITLE
✨ Add agent thread conversations

### DIFF
--- a/OrbitDockNative/OrbitDock/Services/Server/API/SessionsClient.swift
+++ b/OrbitDockNative/OrbitDock/Services/Server/API/SessionsClient.swift
@@ -523,6 +523,10 @@ struct SessionsClient: Sendable {
     let worktreeId: String
   }
 
+  struct AgentThreadMessageRequest: Encodable {
+    let content: String
+  }
+
   private let http: ServerHTTPClient
   private let requestBuilder: HTTPRequestBuilder
 
@@ -537,6 +541,21 @@ struct SessionsClient: Sendable {
     suffix: String
   ) -> String {
     "/api/sessions/\(requestBuilder.encodePathComponent(sessionId))/subagents/\(requestBuilder.encodePathComponent(subagentId))/\(suffix)"
+  }
+
+  private func agentThreadPath(
+    sessionId: String,
+    threadId: String? = nil,
+    suffix: String? = nil
+  ) -> String {
+    var path = "/api/sessions/\(requestBuilder.encodePathComponent(sessionId))/agent-threads"
+    if let threadId {
+      path += "/\(requestBuilder.encodePathComponent(threadId))"
+    }
+    if let suffix {
+      path += "/\(suffix)"
+    }
+    return path
   }
 
   func createSession(_ request: CreateSessionRequest) async throws -> CreateSessionResponse {
@@ -679,6 +698,37 @@ struct SessionsClient: Sendable {
       subagentPath(sessionId: sessionId, subagentId: subagentId, suffix: "messages")
     )
     return response.rows
+  }
+
+  func listAgentThreads(sessionId: String) async throws -> ServerAgentThreadListResponse {
+    try await http.get(agentThreadPath(sessionId: sessionId))
+  }
+
+  func getAgentThreadConversation(
+    sessionId: String,
+    threadId: String,
+    beforeSequence: UInt64? = nil,
+    limit: Int = 50
+  ) async throws -> ServerAgentThreadConversationPage {
+    var query = [URLQueryItem(name: "limit", value: "\(limit)")]
+    if let beforeSequence {
+      query.append(URLQueryItem(name: "before_sequence", value: "\(beforeSequence)"))
+    }
+    return try await http.get(
+      agentThreadPath(sessionId: sessionId, threadId: threadId, suffix: "conversation"),
+      query: query
+    )
+  }
+
+  func sendAgentThreadMessage(
+    sessionId: String,
+    threadId: String,
+    content: String
+  ) async throws -> ServerAgentThreadMessageResponse {
+    try await http.post(
+      agentThreadPath(sessionId: sessionId, threadId: threadId, suffix: "message"),
+      body: AgentThreadMessageRequest(content: content)
+    )
   }
 
   func markSessionRead(_ sessionId: String) async throws -> UInt64 {

--- a/OrbitDockNative/OrbitDock/Services/Server/Protocol/ServerSessionContracts.swift
+++ b/OrbitDockNative/OrbitDock/Services/Server/Protocol/ServerSessionContracts.swift
@@ -973,6 +973,163 @@ struct ServerSubagentTool: Codable, Identifiable {
   }
 }
 
+enum ServerAgentThreadInterjectionMode: String, Codable {
+  case direct
+  case parentMediated = "parent_mediated"
+  case none
+}
+
+enum ServerAgentThreadTranscriptFreshness: String, Decodable {
+  case live
+  case pollable
+  case finalOnly = "final_only"
+  case unavailable
+}
+
+struct ServerAgentThreadCapabilities: Decodable {
+  let canViewTranscript: Bool
+  let hasLiveUpdates: Bool
+  let acceptsUserInput: Bool
+  let canInterrupt: Bool
+  let canResume: Bool
+  let canClose: Bool
+  let interjectionMode: ServerAgentThreadInterjectionMode
+
+  enum CodingKeys: String, CodingKey {
+    case canViewTranscript = "can_view_transcript"
+    case hasLiveUpdates = "has_live_updates"
+    case acceptsUserInput = "accepts_user_input"
+    case canInterrupt = "can_interrupt"
+    case canResume = "can_resume"
+    case canClose = "can_close"
+    case interjectionMode = "interjection_mode"
+  }
+}
+
+struct ServerAgentThreadConversationSummary: Decodable {
+  let freshness: ServerAgentThreadTranscriptFreshness
+  let hasTranscript: Bool
+  let totalRowCount: UInt64?
+  let oldestSequence: UInt64?
+  let newestSequence: UInt64?
+
+  enum CodingKeys: String, CodingKey {
+    case freshness
+    case hasTranscript = "has_transcript"
+    case totalRowCount = "total_row_count"
+    case oldestSequence = "oldest_sequence"
+    case newestSequence = "newest_sequence"
+  }
+}
+
+struct ServerAgentThreadSummary: Decodable, Identifiable {
+  let id: String
+  let provider: ServerProvider
+  let agentType: String
+  let label: String?
+  let status: ServerSubagentStatus
+  let taskSummary: String?
+  let resultSummary: String?
+  let errorSummary: String?
+  let parentThreadId: String?
+  let model: String?
+  let startedAt: String
+  let lastActivityAt: String?
+  let endedAt: String?
+  let capabilities: ServerAgentThreadCapabilities
+  let conversation: ServerAgentThreadConversationSummary
+  let limitations: [String]
+
+  enum CodingKeys: String, CodingKey {
+    case id
+    case provider
+    case agentType = "agent_type"
+    case label
+    case status
+    case taskSummary = "task_summary"
+    case resultSummary = "result_summary"
+    case errorSummary = "error_summary"
+    case parentThreadId = "parent_thread_id"
+    case model
+    case startedAt = "started_at"
+    case lastActivityAt = "last_activity_at"
+    case endedAt = "ended_at"
+    case capabilities
+    case conversation
+    case limitations
+  }
+
+  init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    id = try container.decode(String.self, forKey: .id)
+    provider = try container.decode(ServerProvider.self, forKey: .provider)
+    agentType = try container.decode(String.self, forKey: .agentType)
+    label = try container.decodeIfPresent(String.self, forKey: .label)
+    status = try container.decode(ServerSubagentStatus.self, forKey: .status)
+    taskSummary = try container.decodeIfPresent(String.self, forKey: .taskSummary)
+    resultSummary = try container.decodeIfPresent(String.self, forKey: .resultSummary)
+    errorSummary = try container.decodeIfPresent(String.self, forKey: .errorSummary)
+    parentThreadId = try container.decodeIfPresent(String.self, forKey: .parentThreadId)
+    model = try container.decodeIfPresent(String.self, forKey: .model)
+    startedAt = try container.decode(String.self, forKey: .startedAt)
+    lastActivityAt = try container.decodeIfPresent(String.self, forKey: .lastActivityAt)
+    endedAt = try container.decodeIfPresent(String.self, forKey: .endedAt)
+    capabilities = try container.decode(ServerAgentThreadCapabilities.self, forKey: .capabilities)
+    conversation = try container.decode(ServerAgentThreadConversationSummary.self, forKey: .conversation)
+    limitations = try container.decodeIfPresent([String].self, forKey: .limitations) ?? []
+  }
+}
+
+struct ServerAgentThreadListResponse: Decodable {
+  let sessionId: String
+  let revision: UInt64
+  let threads: [ServerAgentThreadSummary]
+
+  enum CodingKeys: String, CodingKey {
+    case sessionId = "session_id"
+    case revision
+    case threads
+  }
+}
+
+struct ServerAgentThreadConversationPage: Decodable {
+  let sessionId: String
+  let threadId: String
+  let rows: [ServerConversationRowEntry]
+  let totalRowCount: UInt64
+  let hasMoreBefore: Bool
+  let oldestSequence: UInt64?
+  let newestSequence: UInt64?
+  let freshness: ServerAgentThreadTranscriptFreshness
+
+  enum CodingKeys: String, CodingKey {
+    case sessionId = "session_id"
+    case threadId = "thread_id"
+    case rows
+    case totalRowCount = "total_row_count"
+    case hasMoreBefore = "has_more_before"
+    case oldestSequence = "oldest_sequence"
+    case newestSequence = "newest_sequence"
+    case freshness
+  }
+}
+
+struct ServerAgentThreadMessageResponse: Decodable {
+  let accepted: Bool
+  let threadId: String
+  let interjectionMode: ServerAgentThreadInterjectionMode
+  let row: ServerConversationRowEntry
+  let sessionDetailSnapshot: ServerSessionDetailSnapshotPayload?
+
+  enum CodingKeys: String, CodingKey {
+    case accepted
+    case threadId = "thread_id"
+    case interjectionMode = "interjection_mode"
+    case row
+    case sessionDetailSnapshot = "session_detail_snapshot"
+  }
+}
+
 // MARK: - Session State
 
 struct ServerSessionState: Codable, Identifiable {

--- a/OrbitDockNative/OrbitDock/Services/Server/ServerSessionAPI.swift
+++ b/OrbitDockNative/OrbitDock/Services/Server/ServerSessionAPI.swift
@@ -104,6 +104,41 @@ final class ServerSessionAPI {
     try await clients.sessions.getSubagentMessages(sessionId: sessionId, subagentId: subagentId)
   }
 
+  func listAgentThreads() async throws -> ServerAgentThreadListResponse {
+    try await clients.sessions.listAgentThreads(sessionId: sessionId)
+  }
+
+  func fetchAgentThreadConversation(
+    threadId: String,
+    beforeSequence: UInt64? = nil,
+    limit: Int = 50
+  ) async throws -> ServerAgentThreadConversationPage {
+    try await clients.sessions.getAgentThreadConversation(
+      sessionId: sessionId,
+      threadId: threadId,
+      beforeSequence: beforeSequence,
+      limit: limit
+    )
+  }
+
+  func sendAgentThreadMessage(
+    threadId: String,
+    content: String
+  ) async throws -> ConversationMutationResult {
+    let response = try await clients.sessions.sendAgentThreadMessage(
+      sessionId: sessionId,
+      threadId: threadId,
+      content: content
+    )
+    let detailSnapshot = adoptMutationDetailSnapshot(response.sessionDetailSnapshot)
+    transport.emitConversationRows(.init(upserted: [response.row], removedIds: []))
+    transport.invalidate([.conversation, .detail])
+    return ConversationMutationResult(
+      row: response.row,
+      sessionDetailSnapshot: detailSnapshot
+    )
+  }
+
   func removeWorktree(
     worktreeId: String,
     force: Bool,

--- a/OrbitDockNative/OrbitDock/Views/Conversation/ConversationViewModel.swift
+++ b/OrbitDockNative/OrbitDock/Views/Conversation/ConversationViewModel.swift
@@ -6,6 +6,8 @@ import SwiftUI
 final class ConversationViewModel {
   var hasShownContent = false
   var currentSessionId: String?
+  var currentRouteKey: String?
+  var currentAgentThreadId: String?
   var currentSession: ServerSessionContext
   var currentViewMode: ChatViewMode = .focused
   var hasTimeline = false
@@ -38,6 +40,7 @@ final class ConversationViewModel {
     viewMode: ChatViewMode
   ) {
     currentSessionId = sessionId
+    currentRouteKey = sessionId
     currentSession = session
     currentViewMode = viewMode
   }

--- a/OrbitDockNative/OrbitDock/Views/Conversation/ViewModel/ConversationPresentationModels.swift
+++ b/OrbitDockNative/OrbitDock/Views/Conversation/ViewModel/ConversationPresentationModels.swift
@@ -63,6 +63,17 @@ enum ConversationHistoryPaging {
     )
   }
 
+  static func mergeOlderPage(
+    existingRows: [ServerConversationRowEntry],
+    page: ServerAgentThreadConversationPage
+  ) -> MergeResult {
+    MergeResult(
+      rows: normalizedRows(page.rows + existingRows),
+      hasMoreBefore: page.hasMoreBefore,
+      totalRowCount: page.totalRowCount
+    )
+  }
+
   private static func normalizedRows(
     _ rows: [ServerConversationRowEntry]
   ) -> [ServerConversationRowEntry] {

--- a/OrbitDockNative/OrbitDock/Views/Conversation/ViewModel/ConversationViewModel+Lifecycle.swift
+++ b/OrbitDockNative/OrbitDock/Views/Conversation/ViewModel/ConversationViewModel+Lifecycle.swift
@@ -1,12 +1,24 @@
 import SwiftUI
 
 extension ConversationViewModel {
-  func bind(sessionId: String?, session: ServerSessionContext, viewMode: ChatViewMode) {
-    let didChange = currentSessionId != sessionId || currentSession !== session
+  func bind(
+    sessionId: String?,
+    session: ServerSessionContext,
+    viewMode: ChatViewMode,
+    routeKey: String? = nil,
+    agentThreadId: String? = nil
+  ) {
+    let nextRouteKey = routeKey ?? sessionId
+    let didChange =
+      currentRouteKey != nextRouteKey
+        || currentSession !== session
+        || currentAgentThreadId != agentThreadId
     currentSessionId = sessionId
+    currentRouteKey = nextRouteKey
+    currentAgentThreadId = agentThreadId
     currentSession = session
     currentViewMode = viewMode
-    timelineViewModel.bind(sessionId: sessionId)
+    timelineViewModel.bind(sessionId: nextRouteKey)
 
     if didChange {
       followState = .initial

--- a/OrbitDockNative/OrbitDock/Views/Conversation/ViewModel/ConversationViewModel+Presentation.swift
+++ b/OrbitDockNative/OrbitDock/Views/Conversation/ViewModel/ConversationViewModel+Presentation.swift
@@ -37,6 +37,29 @@ extension ConversationViewModel {
     }
   }
 
+  func applyAgentThreadPage(_ page: ServerAgentThreadConversationPage) {
+    let mergedPage = ConversationHistoryPaging.mergeBootstrap(
+      existingRows: rowEntries,
+      existingHasMoreBefore: hasMoreBefore,
+      existingTotalRowCount: totalRowCount,
+      bootstrapRows: page.rows,
+      bootstrapHasMoreBefore: page.hasMoreBefore,
+      bootstrapTotalRowCount: page.totalRowCount
+    )
+    rowEntries = mergedPage.rows
+    hasMoreBefore = mergedPage.hasMoreBefore
+    totalRowCount = mergedPage.totalRowCount
+    conversationLoaded = true
+    forkOrigin = nil
+    structureRevision += 1
+    contentRevision += 1
+    rebuildPresentation(
+      changedEntries: page.rows,
+      appendedEntryCount: 0,
+      visibilityEventRowID: nil
+    )
+  }
+
   func applyDelta(_ delta: ServerSessionTransport.ConversationRowDelta) {
     conversationLoaded = true
 

--- a/OrbitDockNative/OrbitDock/Views/Conversation/ViewModel/ConversationViewModel+Refresh.swift
+++ b/OrbitDockNative/OrbitDock/Views/Conversation/ViewModel/ConversationViewModel+Refresh.swift
@@ -27,26 +27,55 @@ extension ConversationViewModel {
     guard let oldestSequence = rowEntries.first?.sequence else { return }
     isLoadingOlder = true
     let session = currentSession
+    let routeKey = currentRouteKey
+    let agentThreadId = currentAgentThreadId
 
     Task {
       defer { isLoadingOlder = false }
       do {
-        let page = try await session.api.fetchConversationHistory(
-          beforeSequence: oldestSequence,
-          limit: pageSize
-        )
-        guard self.currentSessionId == currentSessionId, self.currentSession === session else { return }
-        let mergedPage = ConversationHistoryPaging.mergeOlderPage(
-          existingRows: rowEntries,
-          page: page
-        )
+        let pageRows: [ServerConversationRowEntry]
+        let mergedPage: ConversationHistoryPaging.MergeResult
+        if let agentThreadId {
+          let page = try await session.api.fetchAgentThreadConversation(
+            threadId: agentThreadId,
+            beforeSequence: oldestSequence,
+            limit: pageSize
+          )
+          guard
+            self.currentSessionId == currentSessionId,
+            self.currentRouteKey == routeKey,
+            self.currentAgentThreadId == agentThreadId,
+            self.currentSession === session
+          else { return }
+          pageRows = page.rows
+          mergedPage = ConversationHistoryPaging.mergeOlderPage(
+            existingRows: rowEntries,
+            page: page
+          )
+        } else {
+          let page = try await session.api.fetchConversationHistory(
+            beforeSequence: oldestSequence,
+            limit: pageSize
+          )
+          guard
+            self.currentSessionId == currentSessionId,
+            self.currentRouteKey == routeKey,
+            self.currentAgentThreadId == nil,
+            self.currentSession === session
+          else { return }
+          pageRows = page.rows
+          mergedPage = ConversationHistoryPaging.mergeOlderPage(
+            existingRows: rowEntries,
+            page: page
+          )
+        }
         hasMoreBefore = mergedPage.hasMoreBefore
         totalRowCount = mergedPage.totalRowCount
         rowEntries = mergedPage.rows
         structureRevision += 1
         contentRevision += 1
         rebuildPresentation(
-          changedEntries: page.rows,
+          changedEntries: pageRows,
           appendedEntryCount: 0,
           visibilityEventRowID: nil
         )
@@ -69,6 +98,15 @@ extension ConversationViewModel {
 
   func performRefreshCycle() async {
     guard let sessionId = currentSessionId, !sessionId.isEmpty else { return }
+    if let agentThreadId = currentAgentThreadId {
+      await performAgentThreadRefreshCycle(
+        sessionId: sessionId,
+        routeKey: currentRouteKey,
+        agentThreadId: agentThreadId
+      )
+      return
+    }
+
     let requestedForcedResyncRevision = pendingForcedResyncRevision
     let isUnversionedForcedResync = pendingForceHTTPResync && requestedForcedResyncRevision == nil
     let shouldForceHTTPResync = shouldRunForcedResync(
@@ -134,6 +172,63 @@ extension ConversationViewModel {
             sid: sessionId,
             data: ["error": error.localizedDescription]
           )
+        }
+      }
+    }
+  }
+
+  private func performAgentThreadRefreshCycle(
+    sessionId: String,
+    routeKey: String?,
+    agentThreadId: String
+  ) async {
+    let shouldForceHTTPResync = pendingForceHTTPResync
+    pendingForceHTTPResync = false
+    pendingForcedResyncRevision = nil
+
+    let session = currentSession
+    let needsInitialBootstrap = !conversationLoaded && rowEntries.isEmpty
+    guard needsInitialBootstrap || shouldForceHTTPResync else { return }
+
+    isRefreshInFlight = true
+    defer {
+      isRefreshInFlight = false
+    }
+
+    do {
+      let page = try await session.api.fetchAgentThreadConversation(
+        threadId: agentThreadId,
+        limit: pageSize
+      )
+      guard
+        currentSessionId == sessionId,
+        currentRouteKey == routeKey,
+        currentAgentThreadId == agentThreadId,
+        currentSession === session
+      else { return }
+      applyAgentThreadPage(page)
+    } catch {
+      netLog(
+        .error,
+        cat: .conv,
+        "Agent thread conversation fetch failed during refresh",
+        sid: sessionId,
+        data: [
+          "threadId": agentThreadId,
+          "initialBootstrap": needsInitialBootstrap ? "true" : "false",
+          "error": error.localizedDescription,
+        ]
+      )
+
+      if needsInitialBootstrap {
+        guard
+          currentSessionId == sessionId,
+          currentRouteKey == routeKey,
+          currentAgentThreadId == agentThreadId
+        else { return }
+        if rowEntries.isEmpty {
+          conversationLoaded = true
+          rebuildPresentation(changedEntries: [])
         }
       }
     }

--- a/OrbitDockNative/OrbitDock/Views/SessionDetail/SessionDetailContentSections.swift
+++ b/OrbitDockNative/OrbitDock/Views/SessionDetail/SessionDetailContentSections.swift
@@ -10,6 +10,7 @@ struct SessionDetailConversationSection: View {
   let currentTool: String?
   let showsOrbitStatusIndicator: Bool
   let chatViewMode: ChatViewMode
+  var routeIdentitySuffix: String? = nil
   let openFileInReview: ((String) -> Void)?
   let focusWorkerInDeck: ((String) -> Void)?
   @Binding var scrollCommand: ConversationScrollCommand?
@@ -17,7 +18,7 @@ struct SessionDetailConversationSection: View {
   let onFollowStateChanged: (ConversationFollowState) -> Void
 
   private var routeIdentity: String {
-    "\(endpointId.uuidString):\(sessionId)"
+    "\(endpointId.uuidString):\(sessionId):\(routeIdentitySuffix ?? "main")"
   }
 
   var body: some View {

--- a/OrbitDockNative/OrbitDock/Views/SessionDetail/SessionDetailSceneModels.swift
+++ b/OrbitDockNative/OrbitDock/Views/SessionDetail/SessionDetailSceneModels.swift
@@ -82,9 +82,24 @@ final class SessionDetailWorkerModel {
   var state = SessionDetailWorkerState.empty
   var rosterPresentation: SessionWorkerRosterPresentation?
   var detailPresentation: SessionWorkerDetailPresentation?
+  var threadConversationViewModel = ConversationViewModel()
+  var threadScrollCommand: ConversationScrollCommand?
 
   @ObservationIgnored private var detailLoadTask: Task<Void, Never>?
   @ObservationIgnored private var detailLoadRequestID = 0
+  @ObservationIgnored private var threadScrollCommandNonce = 0
+
+  var hasAgentThreadRoster: Bool {
+    !state.agentThreads.isEmpty
+  }
+
+  var openedAgentThreadID: String? {
+    guard
+      let selectedWorkerId,
+      state.agentThreads.contains(where: { $0.id == selectedWorkerId })
+    else { return nil }
+    return selectedWorkerId
+  }
 
   func reset() {
     cancelDetailLoad()
@@ -94,10 +109,13 @@ final class SessionDetailWorkerModel {
     state = .empty
     rosterPresentation = nil
     detailPresentation = nil
+    threadConversationViewModel = ConversationViewModel()
+    threadScrollCommand = nil
+    threadScrollCommandNonce = 0
   }
 
   func apply(snapshotState: SessionDetailWorkerState, layoutConfig: LayoutConfiguration) {
-    let visibleWorkerIDs = Set(snapshotState.subagents.map(\.id))
+    let visibleWorkerIDs = Set(snapshotState.subagents.map(\.id)).union(state.agentThreads.map(\.id))
     let preservedTools = state.subagentTools.filter { visibleWorkerIDs.contains($0.key) }
     let preservedMessages = state.subagentMessages.filter { visibleWorkerIDs.contains($0.key) }
     let preservedThreads = state.agentThreads.filter { visibleWorkerIDs.contains($0.id) }
@@ -124,6 +142,7 @@ final class SessionDetailWorkerModel {
     sessionId: String,
     session: ServerSessionContext,
     layoutConfig: LayoutConfiguration,
+    chatViewMode: ChatViewMode = .focused,
     for workerId: String? = nil
   ) {
     guard let workerId = workerId ?? selectedWorkerId else { return }
@@ -156,6 +175,17 @@ final class SessionDetailWorkerModel {
       if let conversation {
         state.agentThreadPages[workerId] = conversation
       }
+      if !state.agentThreads.isEmpty {
+        bindAgentThreadConversation(
+          sessionId: sessionId,
+          session: session,
+          chatViewMode: chatViewMode,
+          threadId: workerId
+        )
+        if let conversation {
+          threadConversationViewModel.applyAgentThreadPage(conversation)
+        }
+      }
       syncDetailPresentation(layoutConfig: layoutConfig)
     }
   }
@@ -164,15 +194,28 @@ final class SessionDetailWorkerModel {
     workerId: String,
     sessionId: String,
     session: ServerSessionContext,
-    layoutConfig: LayoutConfiguration
+    layoutConfig: LayoutConfiguration,
+    chatViewMode: ChatViewMode = .focused
   ) {
     guard !workerId.isEmpty else { return }
     selectedWorkerId = workerId
+    if state.agentThreads.contains(where: { $0.id == workerId }) {
+      bindAgentThreadConversation(
+        sessionId: sessionId,
+        session: session,
+        chatViewMode: chatViewMode,
+        threadId: workerId
+      )
+      if let page = state.agentThreadPages[workerId] {
+        threadConversationViewModel.applyAgentThreadPage(page)
+      }
+    }
     syncDetailPresentation(layoutConfig: layoutConfig)
     loadDetails(
       sessionId: sessionId,
       session: session,
       layoutConfig: layoutConfig,
+      chatViewMode: chatViewMode,
       for: workerId
     )
   }
@@ -181,14 +224,40 @@ final class SessionDetailWorkerModel {
     workerId: String,
     sessionId: String,
     session: ServerSessionContext,
-    layoutConfig: LayoutConfiguration
+    layoutConfig: LayoutConfiguration,
+    chatViewMode: ChatViewMode = .focused
   ) {
     select(
       workerId: workerId,
       sessionId: sessionId,
       session: session,
-      layoutConfig: layoutConfig
+      layoutConfig: layoutConfig,
+      chatViewMode: chatViewMode
     )
+  }
+
+  func bindAgentThreadConversation(
+    sessionId: String,
+    session: ServerSessionContext,
+    chatViewMode: ChatViewMode,
+    threadId: String
+  ) {
+    threadConversationViewModel.bind(
+      sessionId: sessionId,
+      session: session,
+      viewMode: chatViewMode,
+      routeKey: agentThreadConversationRouteKey(sessionId: sessionId, threadId: threadId),
+      agentThreadId: threadId
+    )
+  }
+
+  func jumpThreadConversationToLatest() {
+    threadScrollCommandNonce += 1
+    threadScrollCommand = .jumpToLatest(nonce: threadScrollCommandNonce)
+  }
+
+  func handleThreadConversationFollowStateChanged(_ state: ConversationFollowState) {
+    threadConversationViewModel.applyFollowState(state)
   }
 
   func cancelDetailLoad() {
@@ -256,6 +325,10 @@ final class SessionDetailWorkerModel {
       return SessionWorkerRosterPlanner.presentation(agentThreads: state.agentThreads)
     }
     return SessionWorkerRosterPlanner.presentation(subagents: state.subagents)
+  }
+
+  private func agentThreadConversationRouteKey(sessionId: String, threadId: String) -> String {
+    "\(sessionId):agent-thread:\(threadId)"
   }
 }
 

--- a/OrbitDockNative/OrbitDock/Views/SessionDetail/SessionDetailSceneModels.swift
+++ b/OrbitDockNative/OrbitDock/Views/SessionDetail/SessionDetailSceneModels.swift
@@ -77,6 +77,8 @@ final class SessionDetailTerminalModel {
 @Observable
 final class SessionDetailWorkerModel {
   var selectedWorkerId: String?
+  var messageDraft = ""
+  var isSendingMessage = false
   var state = SessionDetailWorkerState.empty
   var rosterPresentation: SessionWorkerRosterPresentation?
   var detailPresentation: SessionWorkerDetailPresentation?
@@ -87,6 +89,8 @@ final class SessionDetailWorkerModel {
   func reset() {
     cancelDetailLoad()
     selectedWorkerId = nil
+    messageDraft = ""
+    isSendingMessage = false
     state = .empty
     rosterPresentation = nil
     detailPresentation = nil
@@ -96,15 +100,19 @@ final class SessionDetailWorkerModel {
     let visibleWorkerIDs = Set(snapshotState.subagents.map(\.id))
     let preservedTools = state.subagentTools.filter { visibleWorkerIDs.contains($0.key) }
     let preservedMessages = state.subagentMessages.filter { visibleWorkerIDs.contains($0.key) }
+    let preservedThreads = state.agentThreads.filter { visibleWorkerIDs.contains($0.id) }
+    let preservedPages = state.agentThreadPages.filter { visibleWorkerIDs.contains($0.key) }
 
     state = SessionDetailWorkerState(
       subagents: snapshotState.subagents,
       subagentTools: preservedTools,
       subagentMessages: preservedMessages,
+      agentThreads: preservedThreads,
+      agentThreadPages: preservedPages,
       timelineRevision: snapshotState.timelineRevision
     )
 
-    rosterPresentation = SessionWorkerRosterPlanner.presentation(subagents: state.subagents)
+    rosterPresentation = rosterPresentation(for: state)
     syncSelectedWorker(layoutConfig: layoutConfig)
   }
 
@@ -131,18 +139,23 @@ final class SessionDetailWorkerModel {
         }
       }
 
-      async let toolsRequest = try? session.api.fetchSubagentTools(subagentId: workerId)
-      async let messagesRequest = try? session.api.fetchSubagentMessages(subagentId: workerId)
+      async let threadsRequest = try? session.api.listAgentThreads()
+      async let conversationRequest = try? session.api.fetchAgentThreadConversation(threadId: workerId)
 
-      let tools = await toolsRequest
-      let messages = await messagesRequest
+      let threads = await threadsRequest
+      let conversation = await conversationRequest
 
       guard !Task.isCancelled else { return }
       guard requestID == detailLoadRequestID else { return }
       guard selectedWorkerId == workerId else { return }
 
-      state.subagentTools[workerId] = tools ?? []
-      state.subagentMessages[workerId] = messages ?? []
+      if let threads {
+        state.agentThreads = threads.threads
+        rosterPresentation = SessionWorkerRosterPlanner.presentation(agentThreads: threads.threads)
+      }
+      if let conversation {
+        state.agentThreadPages[workerId] = conversation
+      }
       syncDetailPresentation(layoutConfig: layoutConfig)
     }
   }
@@ -185,10 +198,17 @@ final class SessionDetailWorkerModel {
   }
 
   private func syncSelectedWorker(layoutConfig: LayoutConfiguration) {
-    let nextSelectedWorkerId = SessionWorkerRosterPlanner.preferredSelectedWorkerID(
-      currentSelectionID: selectedWorkerId,
-      subagents: state.subagents
-    )
+    let nextSelectedWorkerId: String? = if !state.agentThreads.isEmpty {
+      SessionWorkerRosterPlanner.preferredSelectedWorkerID(
+        currentSelectionID: selectedWorkerId,
+        agentThreads: state.agentThreads
+      )
+    } else {
+      SessionWorkerRosterPlanner.preferredSelectedWorkerID(
+        currentSelectionID: selectedWorkerId,
+        subagents: state.subagents
+      )
+    }
 
     if selectedWorkerId != nextSelectedWorkerId {
       selectedWorkerId = nextSelectedWorkerId
@@ -204,21 +224,38 @@ final class SessionDetailWorkerModel {
     }
 
     let hasLoadedWorkerPayload =
-      state.subagentTools[selectedWorkerId] != nil
-      || state.subagentMessages[selectedWorkerId] != nil
+      state.agentThreadPages[selectedWorkerId] != nil
+        || state.subagentTools[selectedWorkerId] != nil
+        || state.subagentMessages[selectedWorkerId] != nil
 
     guard hasLoadedWorkerPayload else {
       detailPresentation = nil
       return
     }
 
-    detailPresentation = SessionWorkerRosterPlanner.detailPresentation(
-      subagents: state.subagents,
-      selectedWorkerID: selectedWorkerId,
-      toolsByWorker: state.subagentTools,
-      messagesByWorker: state.subagentMessages,
-      timelineEntries: []
-    )
+    if !state.agentThreads.isEmpty {
+      detailPresentation = SessionWorkerRosterPlanner.detailPresentation(
+        agentThreads: state.agentThreads,
+        selectedWorkerID: selectedWorkerId,
+        pageByThread: state.agentThreadPages,
+        subagents: state.subagents
+      )
+    } else {
+      detailPresentation = SessionWorkerRosterPlanner.detailPresentation(
+        subagents: state.subagents,
+        selectedWorkerID: selectedWorkerId,
+        toolsByWorker: state.subagentTools,
+        messagesByWorker: state.subagentMessages,
+        timelineEntries: []
+      )
+    }
+  }
+
+  private func rosterPresentation(for state: SessionDetailWorkerState) -> SessionWorkerRosterPresentation? {
+    if !state.agentThreads.isEmpty {
+      return SessionWorkerRosterPlanner.presentation(agentThreads: state.agentThreads)
+    }
+    return SessionWorkerRosterPlanner.presentation(subagents: state.subagents)
   }
 }
 

--- a/OrbitDockNative/OrbitDock/Views/SessionDetail/SessionDetailSnapshot.swift
+++ b/OrbitDockNative/OrbitDock/Views/SessionDetail/SessionDetailSnapshot.swift
@@ -203,12 +203,16 @@ struct SessionDetailWorkerState {
   let subagents: [ServerSubagentInfo]
   var subagentTools: [String: [ServerSubagentTool]]
   var subagentMessages: [String: [ServerConversationRowEntry]]
+  var agentThreads: [ServerAgentThreadSummary]
+  var agentThreadPages: [String: ServerAgentThreadConversationPage]
   let timelineRevision: Int
 
   static let empty = SessionDetailWorkerState(
     subagents: [],
     subagentTools: [:],
     subagentMessages: [:],
+    agentThreads: [],
+    agentThreadPages: [:],
     timelineRevision: 0
   )
 }

--- a/OrbitDockNative/OrbitDock/Views/SessionDetail/SessionDetailSnapshotBuilder.swift
+++ b/OrbitDockNative/OrbitDock/Views/SessionDetail/SessionDetailSnapshotBuilder.swift
@@ -79,6 +79,8 @@ enum SessionDetailSnapshotBuilder {
         subagents: SessionWorkerRosterPlanner.visibleSubagents(subagents: session.subagents),
         subagentTools: [:],
         subagentMessages: [:],
+        agentThreads: [],
+        agentThreadPages: [:],
         timelineRevision: 0
       ),
       currentTool: session.pendingToolName,

--- a/OrbitDockNative/OrbitDock/Views/SessionDetail/SessionDetailView+Lifecycle.swift
+++ b/OrbitDockNative/OrbitDock/Views/SessionDetail/SessionDetailView+Lifecycle.swift
@@ -15,7 +15,8 @@ extension SessionDetailView {
       workerId: workerId,
       sessionId: sessionId,
       session: scopedSession,
-      layoutConfig: viewModel.layoutConfig
+      layoutConfig: viewModel.layoutConfig,
+      chatViewMode: chatViewMode
     )
   }
 
@@ -26,7 +27,8 @@ extension SessionDetailView {
       workerId: workerId,
       sessionId: sessionId,
       session: scopedSession,
-      layoutConfig: viewModel.layoutConfig
+      layoutConfig: viewModel.layoutConfig,
+      chatViewMode: chatViewMode
     )
   }
 
@@ -57,6 +59,7 @@ extension SessionDetailView {
           sessionId: sessionId,
           session: scopedSession,
           layoutConfig: viewModel.layoutConfig,
+          chatViewMode: chatViewMode,
           for: workerId
         )
       } catch {

--- a/OrbitDockNative/OrbitDock/Views/SessionDetail/SessionDetailView+Lifecycle.swift
+++ b/OrbitDockNative/OrbitDock/Views/SessionDetail/SessionDetailView+Lifecycle.swift
@@ -29,4 +29,39 @@ extension SessionDetailView {
       layoutConfig: viewModel.layoutConfig
     )
   }
+
+  func sendAgentThreadMessage() {
+    guard let workerId = viewModel.worker.selectedWorkerId else { return }
+    let content = viewModel.worker.messageDraft.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !content.isEmpty, !viewModel.worker.isSendingMessage else { return }
+
+    viewModel.worker.isSendingMessage = true
+    viewModel.interaction.lastError = nil
+
+    Task {
+      defer {
+        viewModel.worker.isSendingMessage = false
+      }
+
+      do {
+        let result = try await scopedSession.api.sendAgentThreadMessage(
+          threadId: workerId,
+          content: content
+        )
+        viewModel.worker.messageDraft = ""
+        viewModel.applyConversationMutationRow(result.row)
+        if let snapshot = result.sessionDetailSnapshot {
+          viewModel.applyDetailPayload(snapshot)
+        }
+        viewModel.worker.loadDetails(
+          sessionId: sessionId,
+          session: scopedSession,
+          layoutConfig: viewModel.layoutConfig,
+          for: workerId
+        )
+      } catch {
+        viewModel.interaction.lastError = String(describing: error)
+      }
+    }
+  }
 }

--- a/OrbitDockNative/OrbitDock/Views/SessionDetail/SessionDetailView+Sections.swift
+++ b/OrbitDockNative/OrbitDock/Views/SessionDetail/SessionDetailView+Sections.swift
@@ -20,14 +20,7 @@ extension SessionDetailView {
           rosterPresentation: workerRosterPresentation,
           detailPresentation: workerDetailPresentation,
           selectedWorkerID: viewModel.worker.selectedWorkerId,
-          messageDraft: Binding(
-            get: { viewModel.worker.messageDraft },
-            set: { viewModel.worker.messageDraft = $0 }
-          ),
-          isSendingMessage: viewModel.worker.isSendingMessage,
-          sessionId: sessionId,
-          endpointId: endpointId,
-          clients: scopedSession.clients,
+          showsDetail: !viewModel.worker.hasAgentThreadRoster,
           onSelectWorker: { workerId in
             selectWorkerInPanel(workerId)
           },
@@ -35,9 +28,6 @@ extension SessionDetailView {
             withAnimation(Motion.gentle) {
               viewModel.revealWorkerConversationEvent(messageId)
             }
-          },
-          onSendMessage: {
-            sendAgentThreadMessage()
           }
         )
       }
@@ -107,6 +97,29 @@ extension SessionDetailView {
 
   var conversationContent: some View {
     let presentation = viewModel.conversationPresentation
+    if let threadId = viewModel.worker.openedAgentThreadID {
+      return SessionDetailConversationSection(
+        sessionId: sessionId,
+        session: scopedSession,
+        viewModel: viewModel.worker.threadConversationViewModel,
+        endpointId: endpointId,
+        isSessionActive: presentation.isSessionActive,
+        displayStatus: presentation.displayStatus,
+        currentTool: presentation.currentTool,
+        showsOrbitStatusIndicator: false,
+        chatViewMode: chatViewMode,
+        routeIdentitySuffix: "agent-thread:\(threadId)",
+        openFileInReview: presentation.canOpenFileInReview ? { filePath in
+          withAnimation(Motion.gentle) {
+            viewModel.openFileInReview(projectPath: presentation.projectPath, filePath: filePath)
+          }
+        } : nil,
+        focusWorkerInDeck: nil,
+        scrollCommand: $viewModel.worker.threadScrollCommand,
+        onJumpToLatest: viewModel.worker.jumpThreadConversationToLatest,
+        onFollowStateChanged: viewModel.worker.handleThreadConversationFollowStateChanged
+      )
+    }
 
     return SessionDetailConversationSection(
       sessionId: sessionId,
@@ -201,7 +214,10 @@ extension SessionDetailView {
   }
 
   var footerMode: SessionDetailFooterMode {
-    viewModel.footerMode
+    if viewModel.worker.openedAgentThreadID != nil {
+      return .passive
+    }
+    return viewModel.footerMode
   }
 
   var sessionDetailWorktreeCleanupState: SessionDetailWorktreeCleanupBannerState? {

--- a/OrbitDockNative/OrbitDock/Views/SessionDetail/SessionDetailView+Sections.swift
+++ b/OrbitDockNative/OrbitDock/Views/SessionDetail/SessionDetailView+Sections.swift
@@ -20,6 +20,14 @@ extension SessionDetailView {
           rosterPresentation: workerRosterPresentation,
           detailPresentation: workerDetailPresentation,
           selectedWorkerID: viewModel.worker.selectedWorkerId,
+          messageDraft: Binding(
+            get: { viewModel.worker.messageDraft },
+            set: { viewModel.worker.messageDraft = $0 }
+          ),
+          isSendingMessage: viewModel.worker.isSendingMessage,
+          sessionId: sessionId,
+          endpointId: endpointId,
+          clients: scopedSession.clients,
           onSelectWorker: { workerId in
             selectWorkerInPanel(workerId)
           },
@@ -27,6 +35,9 @@ extension SessionDetailView {
             withAnimation(Motion.gentle) {
               viewModel.revealWorkerConversationEvent(messageId)
             }
+          },
+          onSendMessage: {
+            sendAgentThreadMessage()
           }
         )
       }

--- a/OrbitDockNative/OrbitDock/Views/SessionDetail/SessionWorkerCompanionPanel.swift
+++ b/OrbitDockNative/OrbitDock/Views/SessionDetail/SessionWorkerCompanionPanel.swift
@@ -4,8 +4,14 @@ struct SessionWorkerCompanionPanel: View {
   let rosterPresentation: SessionWorkerRosterPresentation
   let detailPresentation: SessionWorkerDetailPresentation?
   let selectedWorkerID: String?
+  @Binding var messageDraft: String
+  let isSendingMessage: Bool
+  let sessionId: String
+  let endpointId: UUID?
+  let clients: ServerClients?
   let onSelectWorker: (String) -> Void
   let onRevealConversationEvent: (String) -> Void
+  let onSendMessage: () -> Void
 
   var body: some View {
     ScrollView(showsIndicators: false) {
@@ -23,8 +29,14 @@ struct SessionWorkerCompanionPanel: View {
           if let detailPresentation {
             SessionWorkerDetailView(
               presentation: detailPresentation,
+              messageDraft: $messageDraft,
+              isSendingMessage: isSendingMessage,
+              sessionId: sessionId,
+              endpointId: endpointId,
+              clients: clients,
               onSelectWorker: onSelectWorker,
-              onRevealConversationEvent: onRevealConversationEvent
+              onRevealConversationEvent: onRevealConversationEvent,
+              onSendMessage: onSendMessage
             )
           } else {
             SessionWorkerEmptyState()
@@ -38,8 +50,14 @@ struct SessionWorkerCompanionPanel: View {
 
 struct SessionWorkerDetailView: View {
   let presentation: SessionWorkerDetailPresentation
+  @Binding var messageDraft: String
+  let isSendingMessage: Bool
+  let sessionId: String
+  let endpointId: UUID?
+  let clients: ServerClients?
   let onSelectWorker: (String) -> Void
   let onRevealConversationEvent: (String) -> Void
+  let onSendMessage: () -> Void
 
   var body: some View {
     VStack(alignment: .leading, spacing: Spacing.md) {
@@ -51,6 +69,16 @@ struct SessionWorkerDetailView: View {
 
       if !presentation.detailLines.isEmpty {
         workerFactsGrid
+      }
+
+      if !presentation.capabilities.isEmpty {
+        capabilityGrid
+      }
+
+      if hasAgentThreadEnvelope {
+        agentThreadComposer
+
+        agentConversationSection
       }
 
       missionBriefing
@@ -92,58 +120,6 @@ struct SessionWorkerDetailView: View {
               .padding(.vertical, Spacing.sm)
               .background(
                 Color.backgroundSecondary.opacity(0.72),
-                in: RoundedRectangle(cornerRadius: Radius.md, style: .continuous)
-              )
-            }
-          }
-        }
-      }
-
-      activitySection(
-        title: "Thread Feed",
-        eyebrow: "Sub-thread",
-        icon: "text.bubble.fill",
-        accent: Color.statusReply
-      ) {
-        if presentation.threadEntries.isEmpty {
-          Text("Open worker transcript updates will land here as this worker talks through the run.")
-            .font(.system(size: TypeScale.meta))
-            .foregroundStyle(Color.textSecondary)
-        } else {
-          VStack(spacing: Spacing.sm) {
-            ForEach(presentation.threadEntries) { entry in
-              HStack(alignment: .top, spacing: Spacing.sm) {
-                Image(systemName: entry.iconName)
-                  .font(.system(size: TypeScale.mini, weight: .semibold))
-                  .foregroundStyle(entry.tint)
-                  .frame(width: 14, height: 14)
-                  .padding(.top, 2)
-
-                VStack(alignment: .leading, spacing: Spacing.xxs) {
-                  HStack(spacing: Spacing.xs) {
-                    Text(entry.title)
-                      .font(.system(size: TypeScale.meta, weight: .semibold))
-                      .foregroundStyle(Color.textPrimary)
-
-                    if let timestampLabel = entry.timestampLabel {
-                      Text(timestampLabel)
-                        .font(.system(size: TypeScale.mini))
-                        .foregroundStyle(Color.textQuaternary)
-                    }
-                  }
-
-                  Text(entry.body)
-                    .font(.system(size: TypeScale.meta))
-                    .foregroundStyle(Color.textSecondary)
-                    .fixedSize(horizontal: false, vertical: true)
-                    .textSelection(.enabled)
-                }
-              }
-              .frame(maxWidth: .infinity, alignment: .leading)
-              .padding(.horizontal, Spacing.md)
-              .padding(.vertical, Spacing.sm)
-              .background(
-                Color.backgroundSecondary.opacity(0.62),
                 in: RoundedRectangle(cornerRadius: Radius.md, style: .continuous)
               )
             }
@@ -350,6 +326,140 @@ struct SessionWorkerDetailView: View {
       Spacer(minLength: 0)
     }
     .padding(.horizontal, Spacing.xs)
+  }
+
+  private var hasAgentThreadEnvelope: Bool {
+    !presentation.capabilities.isEmpty
+      || !presentation.limitations.isEmpty
+      || !presentation.conversationRows.isEmpty
+      || presentation.messageModeLabel != nil
+  }
+
+  private var capabilityGrid: some View {
+    LazyVGrid(
+      columns: [
+        GridItem(.adaptive(minimum: 128), alignment: .leading),
+      ],
+      alignment: .leading,
+      spacing: Spacing.sm
+    ) {
+      ForEach(presentation.capabilities) { capability in
+        VStack(alignment: .leading, spacing: Spacing.xxs) {
+          Text(capability.label.uppercased())
+            .font(.system(size: TypeScale.mini, weight: .bold, design: .rounded))
+            .foregroundStyle(Color.textQuaternary)
+
+          HStack(spacing: Spacing.xs) {
+            Circle()
+              .fill(capability.color)
+              .frame(width: 6, height: 6)
+
+            Text(capability.value)
+              .font(.system(size: TypeScale.meta, weight: .semibold))
+              .foregroundStyle(Color.textPrimary)
+              .lineLimit(2)
+          }
+        }
+        .frame(maxWidth: .infinity, minHeight: 54, alignment: .leading)
+        .padding(.horizontal, Spacing.md)
+        .padding(.vertical, Spacing.sm)
+        .background(
+          Color.backgroundTertiary.opacity(0.62),
+          in: RoundedRectangle(cornerRadius: Radius.md, style: .continuous)
+        )
+      }
+    }
+  }
+
+  private var agentThreadComposer: some View {
+    activitySection(
+      title: "Interject",
+      eyebrow: presentation.messageModeLabel ?? "Provider capability",
+      icon: "arrow.up.message.fill",
+      accent: presentation.canSendMessage ? Color.statusReply : Color.textTertiary
+    ) {
+      VStack(alignment: .leading, spacing: Spacing.sm) {
+        if presentation.canSendMessage {
+          TextField("Message this agent", text: $messageDraft, axis: .vertical)
+            .textFieldStyle(.plain)
+            .font(.system(size: TypeScale.body))
+            .foregroundStyle(Color.textPrimary)
+            .lineLimit(2 ... 5)
+            .padding(.horizontal, Spacing.md)
+            .padding(.vertical, Spacing.sm)
+            .background(
+              Color.backgroundSecondary.opacity(0.78),
+              in: RoundedRectangle(cornerRadius: Radius.md, style: .continuous)
+            )
+
+          HStack(spacing: Spacing.sm) {
+            Spacer(minLength: 0)
+
+            Button {
+              onSendMessage()
+            } label: {
+              Label(isSendingMessage ? "Sending" : "Send", systemImage: "arrow.up.circle.fill")
+                .font(.system(size: TypeScale.meta, weight: .semibold))
+            }
+            .buttonStyle(.borderedProminent)
+            .tint(.statusReply)
+            .disabled(isSendingMessage || messageDraft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+          }
+        } else if presentation.limitations.isEmpty {
+          Text("This provider exposes this thread as observe-only right now.")
+            .font(.system(size: TypeScale.meta))
+            .foregroundStyle(Color.textSecondary)
+        } else {
+          VStack(alignment: .leading, spacing: Spacing.xs) {
+            ForEach(presentation.limitations, id: \.self) { limitation in
+              HStack(alignment: .top, spacing: Spacing.xs) {
+                Image(systemName: "info.circle.fill")
+                  .font(.system(size: TypeScale.mini, weight: .semibold))
+                  .foregroundStyle(Color.textTertiary)
+                  .padding(.top, 2)
+
+                Text(limitation)
+                  .font(.system(size: TypeScale.meta))
+                  .foregroundStyle(Color.textSecondary)
+                  .fixedSize(horizontal: false, vertical: true)
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  private var agentConversationSection: some View {
+    activitySection(
+      title: "Conversation",
+      eyebrow: presentation.transcriptStatusLabel,
+      icon: "text.bubble.fill",
+      accent: Color.statusReply
+    ) {
+      if presentation.conversationRows.isEmpty {
+        Text("No transcript rows captured yet.")
+          .font(.system(size: TypeScale.meta))
+          .foregroundStyle(Color.textSecondary)
+      } else {
+        VStack(spacing: Spacing.sm) {
+          ForEach(presentation.conversationRows) { row in
+            TimelineRowContent(
+              entry: row,
+              isExpanded: false,
+              sessionId: sessionId,
+              endpointId: endpointId,
+              clients: clients
+            )
+            .padding(.vertical, Spacing.xs)
+            .background(
+              Color.backgroundSecondary.opacity(0.54),
+              in: RoundedRectangle(cornerRadius: Radius.md, style: .continuous)
+            )
+          }
+        }
+      }
+    }
   }
 
   private var missionBriefing: some View {

--- a/OrbitDockNative/OrbitDock/Views/SessionDetail/SessionWorkerCompanionPanel.swift
+++ b/OrbitDockNative/OrbitDock/Views/SessionDetail/SessionWorkerCompanionPanel.swift
@@ -4,14 +4,9 @@ struct SessionWorkerCompanionPanel: View {
   let rosterPresentation: SessionWorkerRosterPresentation
   let detailPresentation: SessionWorkerDetailPresentation?
   let selectedWorkerID: String?
-  @Binding var messageDraft: String
-  let isSendingMessage: Bool
-  let sessionId: String
-  let endpointId: UUID?
-  let clients: ServerClients?
+  let showsDetail: Bool
   let onSelectWorker: (String) -> Void
   let onRevealConversationEvent: (String) -> Void
-  let onSendMessage: () -> Void
 
   var body: some View {
     ScrollView(showsIndicators: false) {
@@ -22,27 +17,23 @@ struct SessionWorkerCompanionPanel: View {
           onSelectWorker: onSelectWorker
         )
 
-        Divider()
-          .foregroundStyle(Color.panelBorder.opacity(0.6))
+        if showsDetail {
+          Divider()
+            .foregroundStyle(Color.panelBorder.opacity(0.6))
 
-        VStack(alignment: .leading, spacing: Spacing.md) {
-          if let detailPresentation {
-            SessionWorkerDetailView(
-              presentation: detailPresentation,
-              messageDraft: $messageDraft,
-              isSendingMessage: isSendingMessage,
-              sessionId: sessionId,
-              endpointId: endpointId,
-              clients: clients,
-              onSelectWorker: onSelectWorker,
-              onRevealConversationEvent: onRevealConversationEvent,
-              onSendMessage: onSendMessage
-            )
-          } else {
-            SessionWorkerEmptyState()
+          VStack(alignment: .leading, spacing: Spacing.md) {
+            if let detailPresentation {
+              SessionWorkerDetailView(
+                presentation: detailPresentation,
+                onSelectWorker: onSelectWorker,
+                onRevealConversationEvent: onRevealConversationEvent
+              )
+            } else {
+              SessionWorkerEmptyState()
+            }
           }
+          .padding(.vertical, Spacing.md)
         }
-        .padding(.vertical, Spacing.md)
       }
     }
   }
@@ -50,14 +41,8 @@ struct SessionWorkerCompanionPanel: View {
 
 struct SessionWorkerDetailView: View {
   let presentation: SessionWorkerDetailPresentation
-  @Binding var messageDraft: String
-  let isSendingMessage: Bool
-  let sessionId: String
-  let endpointId: UUID?
-  let clients: ServerClients?
   let onSelectWorker: (String) -> Void
   let onRevealConversationEvent: (String) -> Void
-  let onSendMessage: () -> Void
 
   var body: some View {
     VStack(alignment: .leading, spacing: Spacing.md) {
@@ -69,16 +54,6 @@ struct SessionWorkerDetailView: View {
 
       if !presentation.detailLines.isEmpty {
         workerFactsGrid
-      }
-
-      if !presentation.capabilities.isEmpty {
-        capabilityGrid
-      }
-
-      if hasAgentThreadEnvelope {
-        agentThreadComposer
-
-        agentConversationSection
       }
 
       missionBriefing
@@ -326,140 +301,6 @@ struct SessionWorkerDetailView: View {
       Spacer(minLength: 0)
     }
     .padding(.horizontal, Spacing.xs)
-  }
-
-  private var hasAgentThreadEnvelope: Bool {
-    !presentation.capabilities.isEmpty
-      || !presentation.limitations.isEmpty
-      || !presentation.conversationRows.isEmpty
-      || presentation.messageModeLabel != nil
-  }
-
-  private var capabilityGrid: some View {
-    LazyVGrid(
-      columns: [
-        GridItem(.adaptive(minimum: 128), alignment: .leading),
-      ],
-      alignment: .leading,
-      spacing: Spacing.sm
-    ) {
-      ForEach(presentation.capabilities) { capability in
-        VStack(alignment: .leading, spacing: Spacing.xxs) {
-          Text(capability.label.uppercased())
-            .font(.system(size: TypeScale.mini, weight: .bold, design: .rounded))
-            .foregroundStyle(Color.textQuaternary)
-
-          HStack(spacing: Spacing.xs) {
-            Circle()
-              .fill(capability.color)
-              .frame(width: 6, height: 6)
-
-            Text(capability.value)
-              .font(.system(size: TypeScale.meta, weight: .semibold))
-              .foregroundStyle(Color.textPrimary)
-              .lineLimit(2)
-          }
-        }
-        .frame(maxWidth: .infinity, minHeight: 54, alignment: .leading)
-        .padding(.horizontal, Spacing.md)
-        .padding(.vertical, Spacing.sm)
-        .background(
-          Color.backgroundTertiary.opacity(0.62),
-          in: RoundedRectangle(cornerRadius: Radius.md, style: .continuous)
-        )
-      }
-    }
-  }
-
-  private var agentThreadComposer: some View {
-    activitySection(
-      title: "Interject",
-      eyebrow: presentation.messageModeLabel ?? "Provider capability",
-      icon: "arrow.up.message.fill",
-      accent: presentation.canSendMessage ? Color.statusReply : Color.textTertiary
-    ) {
-      VStack(alignment: .leading, spacing: Spacing.sm) {
-        if presentation.canSendMessage {
-          TextField("Message this agent", text: $messageDraft, axis: .vertical)
-            .textFieldStyle(.plain)
-            .font(.system(size: TypeScale.body))
-            .foregroundStyle(Color.textPrimary)
-            .lineLimit(2 ... 5)
-            .padding(.horizontal, Spacing.md)
-            .padding(.vertical, Spacing.sm)
-            .background(
-              Color.backgroundSecondary.opacity(0.78),
-              in: RoundedRectangle(cornerRadius: Radius.md, style: .continuous)
-            )
-
-          HStack(spacing: Spacing.sm) {
-            Spacer(minLength: 0)
-
-            Button {
-              onSendMessage()
-            } label: {
-              Label(isSendingMessage ? "Sending" : "Send", systemImage: "arrow.up.circle.fill")
-                .font(.system(size: TypeScale.meta, weight: .semibold))
-            }
-            .buttonStyle(.borderedProminent)
-            .tint(.statusReply)
-            .disabled(isSendingMessage || messageDraft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
-          }
-        } else if presentation.limitations.isEmpty {
-          Text("This provider exposes this thread as observe-only right now.")
-            .font(.system(size: TypeScale.meta))
-            .foregroundStyle(Color.textSecondary)
-        } else {
-          VStack(alignment: .leading, spacing: Spacing.xs) {
-            ForEach(presentation.limitations, id: \.self) { limitation in
-              HStack(alignment: .top, spacing: Spacing.xs) {
-                Image(systemName: "info.circle.fill")
-                  .font(.system(size: TypeScale.mini, weight: .semibold))
-                  .foregroundStyle(Color.textTertiary)
-                  .padding(.top, 2)
-
-                Text(limitation)
-                  .font(.system(size: TypeScale.meta))
-                  .foregroundStyle(Color.textSecondary)
-                  .fixedSize(horizontal: false, vertical: true)
-              }
-            }
-          }
-        }
-      }
-    }
-  }
-
-  private var agentConversationSection: some View {
-    activitySection(
-      title: "Conversation",
-      eyebrow: presentation.transcriptStatusLabel,
-      icon: "text.bubble.fill",
-      accent: Color.statusReply
-    ) {
-      if presentation.conversationRows.isEmpty {
-        Text("No transcript rows captured yet.")
-          .font(.system(size: TypeScale.meta))
-          .foregroundStyle(Color.textSecondary)
-      } else {
-        VStack(spacing: Spacing.sm) {
-          ForEach(presentation.conversationRows) { row in
-            TimelineRowContent(
-              entry: row,
-              isExpanded: false,
-              sessionId: sessionId,
-              endpointId: endpointId,
-              clients: clients
-            )
-            .padding(.vertical, Spacing.xs)
-            .background(
-              Color.backgroundSecondary.opacity(0.54),
-              in: RoundedRectangle(cornerRadius: Radius.md, style: .continuous)
-            )
-          }
-        }
-      }
-    }
   }
 
   private var missionBriefing: some View {

--- a/OrbitDockNative/OrbitDock/Views/SessionDetail/SessionWorkerPresentations.swift
+++ b/OrbitDockNative/OrbitDock/Views/SessionDetail/SessionWorkerPresentations.swift
@@ -61,6 +61,13 @@ struct SessionWorkerDetailPresentation {
     let tint: Color
   }
 
+  struct Capability: Identifiable {
+    let id: String
+    let label: String
+    let value: String
+    let color: Color
+  }
+
   let id: String
   let title: String
   let subtitle: String?
@@ -77,5 +84,10 @@ struct SessionWorkerDetailPresentation {
   let conversationEvents: [ConversationEvent]
   let relatedWorkers: [RelatedWorker]
   let latestConversationEventID: String?
+  let capabilities: [Capability]
+  let limitations: [String]
+  let conversationRows: [ServerConversationRowEntry]
+  let transcriptStatusLabel: String
+  let canSendMessage: Bool
+  let messageModeLabel: String?
 }
-

--- a/OrbitDockNative/OrbitDock/Views/SessionDetail/SessionWorkerRosterPlanner.swift
+++ b/OrbitDockNative/OrbitDock/Views/SessionDetail/SessionWorkerRosterPlanner.swift
@@ -54,6 +54,32 @@ enum SessionWorkerRosterPlanner {
     )
   }
 
+  static func presentation(agentThreads: [ServerAgentThreadSummary]) -> SessionWorkerRosterPresentation? {
+    let threads = visibleAgentThreads(agentThreads)
+    let workers = threads.map(workerPresentation)
+
+    guard !workers.isEmpty else { return nil }
+
+    let activeCount = agentThreads.filter { isActive($0.status) }.count
+    let completedCount = agentThreads.filter { $0.status == .completed }.count
+    let stalledCount = agentThreads.count - activeCount - completedCount
+    let archivedCount = max(agentThreads.count - threads.count, 0)
+
+    return SessionWorkerRosterPresentation(
+      title: "Agent Threads",
+      summary: workerSummary(
+        activeCount: activeCount,
+        completedCount: completedCount,
+        stalledCount: stalledCount,
+        archivedCount: archivedCount
+      ),
+      detailPrompt: activeCount > 0
+        ? "Watch live child conversations while the parent session stays in view."
+        : "Revisit finished child conversations without losing the main thread.",
+      workers: workers
+    )
+  }
+
   static func preferredSelectedWorkerID(
     currentSelectionID: String?,
     subagents: [ServerSubagentInfo]
@@ -67,6 +93,21 @@ enum SessionWorkerRosterPlanner {
     }
 
     return visibleSubagents(subagents: subagents).first?.id
+  }
+
+  static func preferredSelectedWorkerID(
+    currentSelectionID: String?,
+    agentThreads: [ServerAgentThreadSummary]
+  ) -> String? {
+    let visibleWorkerIDs = Set(visibleAgentThreads(agentThreads).map(\.id))
+
+    if let currentSelectionID,
+       visibleWorkerIDs.contains(currentSelectionID)
+    {
+      return currentSelectionID
+    }
+
+    return visibleAgentThreads(agentThreads).first?.id
   }
 
   static func detailPresentation(
@@ -112,7 +153,57 @@ enum SessionWorkerRosterPlanner {
       threadEntries: threadEntries,
       conversationEvents: timelineSummary.conversationEvents,
       relatedWorkers: relatedWorkers,
-      latestConversationEventID: timelineSummary.conversationEvents.last?.id
+      latestConversationEventID: timelineSummary.conversationEvents.last?.id,
+      capabilities: [],
+      limitations: [],
+      conversationRows: messagesByWorker[subagent.id] ?? [],
+      transcriptStatusLabel: "Transcript",
+      canSendMessage: false,
+      messageModeLabel: nil
+    )
+  }
+
+  static func detailPresentation(
+    agentThreads: [ServerAgentThreadSummary],
+    selectedWorkerID: String?,
+    pageByThread: [String: ServerAgentThreadConversationPage],
+    subagents: [ServerSubagentInfo]
+  ) -> SessionWorkerDetailPresentation? {
+    guard let selectedWorkerID,
+          let thread = agentThreads.first(where: { $0.id == selectedWorkerID })
+    else {
+      return nil
+    }
+
+    let status = statusPresentation(thread.status)
+    let visuals = visuals(for: thread.agentType)
+    let page = pageByThread[thread.id]
+    let rows = page?.rows ?? []
+    let legacySubagent = subagents.first(where: { $0.id == thread.id }) ?? subagentInfo(from: thread)
+
+    return SessionWorkerDetailPresentation(
+      id: thread.id,
+      title: thread.label ?? visuals.label,
+      subtitle: workerSubtitle(thread),
+      statusLabel: status.label,
+      statusColor: status.color,
+      iconName: visuals.iconName,
+      isActive: status.isActive,
+      statusNarrative: status.narrative,
+      assignmentPreview: thread.taskSummary,
+      reportPreview: thread.resultSummary ?? thread.errorSummary,
+      detailLines: detailLines(for: thread),
+      tools: rows.compactMap(toolActivityFromRow).suffix(8).map { $0 },
+      threadEntries: threadEntries(for: rows),
+      conversationEvents: rows.map(conversationEventPresentation),
+      relatedWorkers: relatedWorkers(for: legacySubagent, among: subagents),
+      latestConversationEventID: rows.last?.id,
+      capabilities: capabilities(for: thread),
+      limitations: thread.limitations,
+      conversationRows: rows,
+      transcriptStatusLabel: transcriptStatusLabel(thread.conversation.freshness),
+      canSendMessage: thread.capabilities.acceptsUserInput,
+      messageModeLabel: messageModeLabel(thread.capabilities.interjectionMode)
     )
   }
 
@@ -129,12 +220,47 @@ enum SessionWorkerRosterPlanner {
       .map(\.subagent)
   }
 
+  private static func visibleAgentThreads(_ threads: [ServerAgentThreadSummary]) -> [ServerAgentThreadSummary] {
+    let ranked = sortedAgentThreads(threads)
+    let activeWorkers = ranked.filter { isActive($0.status) }
+    let inactiveWorkers = ranked.filter { !isActive($0.status) }
+
+    return activeWorkers + inactiveWorkers.prefix(maxRecentInactiveWorkers)
+  }
+
+  private static func sortedAgentThreads(_ threads: [ServerAgentThreadSummary]) -> [ServerAgentThreadSummary] {
+    threads.sorted { lhs, rhs in
+      let lhsActive = isActive(lhs.status)
+      let rhsActive = isActive(rhs.status)
+      if lhsActive != rhsActive {
+        return lhsActive && !rhsActive
+      }
+
+      return sortDate(for: lhs) > sortDate(for: rhs)
+    }
+  }
+
   private static func rankedWorkerSort(lhs: RankedWorker, rhs: RankedWorker) -> Bool {
     if lhs.isActive != rhs.isActive {
       return lhs.isActive && !rhs.isActive
     }
 
     return lhs.sortDate > rhs.sortDate
+  }
+
+  private static func workerPresentation(thread: ServerAgentThreadSummary) -> SessionWorkerRosterPresentation.Worker {
+    let status = statusPresentation(thread.status)
+    let visuals = visuals(for: thread.agentType)
+
+    return SessionWorkerRosterPresentation.Worker(
+      id: thread.id,
+      title: thread.label ?? visuals.label,
+      subtitle: workerSubtitle(thread),
+      statusLabel: status.label,
+      statusColor: status.color,
+      isActive: status.isActive,
+      iconName: visuals.iconName
+    )
   }
 
   private static func workerPresentation(subagent: ServerSubagentInfo) -> SessionWorkerRosterPresentation.Worker {
@@ -185,6 +311,48 @@ enum SessionWorkerRosterPlanner {
     .compactMap { $0 }
   }
 
+  private static func detailLines(for thread: ServerAgentThreadSummary)
+    -> [SessionWorkerDetailPresentation.DetailLine]
+  {
+    [
+      detailLine(id: "type", label: "Role", value: visuals(for: thread.agentType).label),
+      detailLine(id: "provider", label: "Provider", value: thread.provider.rawValue.capitalized),
+      detailLine(id: "model", label: "Model", value: thread.model),
+      detailLine(id: "started", label: "Started", value: formattedDate(thread.startedAt)),
+      detailLine(id: "last", label: "Last active", value: formattedDate(thread.lastActivityAt)),
+      detailLine(id: "ended", label: "Ended", value: formattedDate(thread.endedAt)),
+      detailLine(id: "parent", label: "Parent thread", value: thread.parentThreadId),
+    ]
+    .compactMap { $0 }
+  }
+
+  private static func capabilities(
+    for thread: ServerAgentThreadSummary
+  ) -> [SessionWorkerDetailPresentation.Capability] {
+    [
+      .init(
+        id: "transcript",
+        label: "Transcript",
+        value: thread.capabilities.canViewTranscript
+          ? transcriptStatusLabel(thread.conversation.freshness)
+          : "Unavailable",
+        color: thread.capabilities.canViewTranscript ? .statusReply : .textSecondary
+      ),
+      .init(
+        id: "input",
+        label: "Input",
+        value: messageModeLabel(thread.capabilities.interjectionMode) ?? "Observe only",
+        color: thread.capabilities.acceptsUserInput ? .composerSteer : .textSecondary
+      ),
+      .init(
+        id: "updates",
+        label: "Updates",
+        value: thread.capabilities.hasLiveUpdates ? "Live" : "On refresh",
+        color: thread.capabilities.hasLiveUpdates ? .statusWorking : .textSecondary
+      ),
+    ]
+  }
+
   private static func detailLine(
     id: String,
     label: String,
@@ -201,6 +369,18 @@ enum SessionWorkerRosterPlanner {
       subagent.taskSummary,
       subagent.resultSummary,
       subagent.errorSummary,
+    ]
+    .compactMap {
+      $0?.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty
+    }
+    .first
+  }
+
+  private static func workerSubtitle(_ thread: ServerAgentThreadSummary) -> String? {
+    [
+      thread.taskSummary,
+      thread.resultSummary,
+      thread.errorSummary,
     ]
     .compactMap {
       $0?.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty
@@ -243,6 +423,13 @@ enum SessionWorkerRosterPlanner {
       ?? .distantPast
   }
 
+  private static func sortDate(for thread: ServerAgentThreadSummary) -> Date {
+    parseDate(thread.lastActivityAt)
+      ?? parseDate(thread.startedAt)
+      ?? parseDate(thread.endedAt)
+      ?? .distantPast
+  }
+
   private static func parseDate(_ value: String?) -> Date? {
     guard let value else { return nil }
     return iso8601Formatter.date(from: value)
@@ -251,6 +438,48 @@ enum SessionWorkerRosterPlanner {
   private static func formattedDate(_ value: String?) -> String? {
     guard let date = parseDate(value) else { return nil }
     return date.formatted(date: .abbreviated, time: .shortened)
+  }
+
+  private static func transcriptStatusLabel(_ freshness: ServerAgentThreadTranscriptFreshness) -> String {
+    switch freshness {
+      case .live:
+        "Live"
+      case .pollable:
+        "Refreshable"
+      case .finalOnly:
+        "Final transcript"
+      case .unavailable:
+        "Unavailable"
+    }
+  }
+
+  private static func messageModeLabel(_ mode: ServerAgentThreadInterjectionMode) -> String? {
+    switch mode {
+      case .direct:
+        "Message worker"
+      case .parentMediated:
+        "Ask parent to redirect"
+      case .none:
+        nil
+    }
+  }
+
+  private static func subagentInfo(from thread: ServerAgentThreadSummary) -> ServerSubagentInfo {
+    ServerSubagentInfo(
+      id: thread.id,
+      agentType: thread.agentType,
+      startedAt: thread.startedAt,
+      endedAt: thread.endedAt,
+      provider: thread.provider,
+      label: thread.label,
+      status: thread.status,
+      taskSummary: thread.taskSummary,
+      resultSummary: thread.resultSummary,
+      errorSummary: thread.errorSummary,
+      parentSubagentId: thread.parentThreadId,
+      model: thread.model,
+      lastActivityAt: thread.lastActivityAt
+    )
   }
 
   private static func visuals(for agentType: String) -> (label: String, iconName: String) {
@@ -281,6 +510,21 @@ enum SessionWorkerRosterPlanner {
       summary: tool.summary,
       statusLabel: tool.isInProgress ? "Running" : "Done",
       statusColor: statusColor
+    )
+  }
+
+  private static func toolActivityFromRow(
+    _ row: ServerConversationRowEntry
+  ) -> SessionWorkerDetailPresentation.ToolActivity? {
+    guard case let .tool(tool) = row.row else { return nil }
+    let isRunning = tool.status == .running || tool.status == .pending
+    return .init(
+      id: tool.id,
+      iconName: ToolCardStyle.icon(for: tool.title),
+      toolName: tool.title,
+      summary: tool.summary ?? tool.toolDisplay.outputPreview ?? tool.subtitle ?? "Tool activity",
+      statusLabel: isRunning ? "Running" : tool.status.rawValue.capitalized,
+      statusColor: isRunning ? .statusWorking : tool.status == .failed ? .feedbackNegative : .feedbackPositive
     )
   }
 
@@ -871,7 +1115,7 @@ enum SessionWorkerRosterPlanner {
   private static func reportPreview(for child: ServerConversationActivityGroupChild) -> String? {
     switch child {
       case let .tool(tool):
-        return reportPreview(for: tool)
+        reportPreview(for: tool)
     }
   }
 

--- a/OrbitDockNative/OrbitDockTests/Conversation/ConversationViewModelTests.swift
+++ b/OrbitDockNative/OrbitDockTests/Conversation/ConversationViewModelTests.swift
@@ -50,4 +50,79 @@ struct ConversationViewModelTests {
 
     #expect(viewModel.followState == followState)
   }
+
+  @Test func agentThreadPagesPopulateNormalConversationTimeline() {
+    let session = ServerSessionContext.preview()
+    let viewModel = ConversationViewModel(
+      sessionId: "parent-session",
+      session: session,
+      viewMode: .focused
+    )
+
+    viewModel.bind(
+      sessionId: "parent-session",
+      session: session,
+      viewMode: .focused,
+      routeKey: "parent-session:agent-thread:thread-1",
+      agentThreadId: "thread-1"
+    )
+
+    viewModel.applyAgentThreadPage(
+      makeAgentThreadPage(
+        rows: [
+          makeRow(id: "assistant-2", sequence: 2, content: "I found the coordinator."),
+          makeRow(id: "assistant-4", sequence: 4, content: "The patch is ready."),
+        ],
+        totalRowCount: 4,
+        hasMoreBefore: true
+      )
+    )
+
+    #expect(viewModel.loadState == .ready)
+    #expect(viewModel.hasTimeline)
+    #expect(viewModel.rowEntries.map(\.sequence) == [2, 4])
+    #expect(viewModel.currentAgentThreadId == "thread-1")
+
+    let mergedOlderPage = ConversationHistoryPaging.mergeOlderPage(
+      existingRows: viewModel.rowEntries,
+      page: makeAgentThreadPage(
+        rows: [
+          makeRow(id: "user-1", sequence: 1, content: "Please inspect auth."),
+          makeRow(id: "assistant-2", sequence: 2, content: "I found the coordinator."),
+        ],
+        totalRowCount: 4,
+        hasMoreBefore: false
+      )
+    )
+
+    #expect(mergedOlderPage.rows.map(\.sequence) == [1, 2, 4])
+    #expect(!mergedOlderPage.hasMoreBefore)
+    #expect(mergedOlderPage.totalRowCount == 4)
+  }
+
+  private func makeAgentThreadPage(
+    rows: [ServerConversationRowEntry],
+    totalRowCount: UInt64,
+    hasMoreBefore: Bool
+  ) -> ServerAgentThreadConversationPage {
+    ServerAgentThreadConversationPage(
+      sessionId: "parent-session",
+      threadId: "thread-1",
+      rows: rows,
+      totalRowCount: totalRowCount,
+      hasMoreBefore: hasMoreBefore,
+      oldestSequence: rows.first?.sequence,
+      newestSequence: rows.last?.sequence,
+      freshness: .pollable
+    )
+  }
+
+  private func makeRow(id: String, sequence: UInt64, content: String) -> ServerConversationRowEntry {
+    ServerConversationRowEntry(
+      sessionId: "thread-1",
+      sequence: sequence,
+      turnId: nil,
+      row: .assistant(ServerConversationMessageRow(id: id, content: content))
+    )
+  }
 }

--- a/OrbitDockNative/OrbitDockTests/SessionDetail/SessionWorkerRosterPlannerTests.swift
+++ b/OrbitDockNative/OrbitDockTests/SessionDetail/SessionWorkerRosterPlannerTests.swift
@@ -282,6 +282,92 @@ struct SessionWorkerRosterPlannerTests {
       .contains("The runtime coordinator owns the auth refresh path.") == true)
   }
 
+  @Test func agentThreadPresentationOrdersActiveThreadsFirst() throws {
+    let running = makeAgentThread(
+      id: "thread-running",
+      label: "Scout",
+      status: "running",
+      taskSummary: "Inspect the auth flow",
+      resultSummary: nil,
+      freshness: "pollable",
+      acceptsUserInput: true,
+      interjectionMode: "parent_mediated",
+      lastActivityAt: "2026-03-10T12:00:00Z"
+    )
+    let completed = makeAgentThread(
+      id: "thread-complete",
+      label: "Finisher",
+      status: "completed",
+      taskSummary: nil,
+      resultSummary: "Returned findings",
+      freshness: "final_only",
+      acceptsUserInput: false,
+      interjectionMode: "none",
+      lastActivityAt: "2026-03-10T11:00:00Z"
+    )
+
+    let presentation = try #require(SessionWorkerRosterPlanner.presentation(agentThreads: [completed, running]))
+
+    #expect(presentation.title == "Agent Threads")
+    #expect(presentation.summary == "1 active · 1 complete")
+    #expect(presentation.workers.map(\.id) == ["thread-running", "thread-complete"])
+    #expect(presentation.workers.first?.subtitle == "Inspect the auth flow")
+  }
+
+  @Test func agentThreadDetailSurfacesTranscriptAndInputCapability() throws {
+    let thread = makeAgentThread(
+      id: "thread-running",
+      label: "Scout",
+      status: "running",
+      taskSummary: "Inspect the auth flow",
+      resultSummary: nil,
+      freshness: "pollable",
+      acceptsUserInput: true,
+      interjectionMode: "parent_mediated",
+      lastActivityAt: "2026-03-10T12:00:00Z"
+    )
+    let rows = [
+      makeRowEntry(
+        id: "thread-user",
+        sessionId: "session-1",
+        sequence: 1,
+        rowType: .user,
+        content: "Inspect the auth flow"
+      ),
+      makeRowEntry(
+        id: "thread-assistant",
+        sessionId: "session-1",
+        sequence: 2,
+        rowType: .assistant,
+        content: "The runtime coordinator owns the auth refresh path."
+      ),
+    ]
+    let page = ServerAgentThreadConversationPage(
+      sessionId: "session-1",
+      threadId: thread.id,
+      rows: rows,
+      totalRowCount: UInt64(rows.count),
+      hasMoreBefore: false,
+      oldestSequence: rows.first?.sequence,
+      newestSequence: rows.last?.sequence,
+      freshness: .pollable
+    )
+
+    let presentation = try #require(SessionWorkerRosterPlanner.detailPresentation(
+      agentThreads: [thread],
+      selectedWorkerID: thread.id,
+      pageByThread: [thread.id: page],
+      subagents: []
+    ))
+
+    #expect(presentation.title == "Scout")
+    #expect(presentation.transcriptStatusLabel == "Refreshable")
+    #expect(presentation.canSendMessage)
+    #expect(presentation.messageModeLabel == "Ask parent to redirect")
+    #expect(presentation.conversationRows.map(\.id) == ["thread-user", "thread-assistant"])
+    #expect(presentation.capabilities.contains(where: { $0.label == "Input" && $0.value == "Ask parent to redirect" }))
+  }
+
   @Test func detailPresentationBuildsConversationTrailFromWorkerLinkedMessages() {
     let worker = makeWorker(
       id: "worker-running",
@@ -403,16 +489,16 @@ struct SessionWorkerRosterPlannerTests {
       toolsByWorker: [:],
       messagesByWorker: [
         worker.id: [
-        makeShellCommandEntry(
-          id: "shell-1",
-          sessionId: worker.id,
-          sequence: 1,
-          title: "Run migration check",
-          command: "orbitdock migrate --check",
-          stdout: "stdout-1\nstdout-2",
-          stderr: "stderr-1",
-          outputPreview: "stdout-1\nstderr-1\nstdout-2"
-        ),
+          makeShellCommandEntry(
+            id: "shell-1",
+            sessionId: worker.id,
+            sequence: 1,
+            title: "Run migration check",
+            command: "orbitdock migrate --check",
+            stdout: "stdout-1\nstdout-2",
+            stderr: "stderr-1",
+            outputPreview: "stdout-1\nstderr-1\nstdout-2"
+          ),
         ],
       ],
       timelineEntries: []
@@ -619,6 +705,64 @@ struct SessionWorkerRosterPlannerTests {
       model: nil,
       lastActivityAt: lastActivityAt
     )
+  }
+
+  private func makeAgentThread(
+    id: String,
+    label: String?,
+    status: String,
+    taskSummary: String?,
+    resultSummary: String?,
+    freshness: String,
+    acceptsUserInput: Bool,
+    interjectionMode: String,
+    lastActivityAt: String?
+  ) -> ServerAgentThreadSummary {
+    let labelJSON = jsonString(label)
+    let taskSummaryJSON = jsonString(taskSummary)
+    let resultSummaryJSON = jsonString(resultSummary)
+    let lastActivityAtJSON = jsonString(lastActivityAt)
+    let json = """
+    {
+      "id": "\(id)",
+      "provider": "codex",
+      "agent_type": "general-purpose",
+      "label": \(labelJSON),
+      "status": "\(status)",
+      "task_summary": \(taskSummaryJSON),
+      "result_summary": \(resultSummaryJSON),
+      "error_summary": null,
+      "parent_thread_id": null,
+      "model": "gpt-5.4",
+      "started_at": "2026-03-10T09:00:00Z",
+      "last_activity_at": \(lastActivityAtJSON),
+      "ended_at": null,
+      "capabilities": {
+        "can_view_transcript": true,
+        "has_live_updates": false,
+        "accepts_user_input": \(acceptsUserInput),
+        "can_interrupt": false,
+        "can_resume": false,
+        "can_close": false,
+        "interjection_mode": "\(interjectionMode)"
+      },
+      "conversation": {
+        "freshness": "\(freshness)",
+        "has_transcript": true,
+        "total_row_count": 2,
+        "oldest_sequence": 1,
+        "newest_sequence": 2
+      },
+      "limitations": []
+    }
+    """
+    return try! JSONDecoder().decode(ServerAgentThreadSummary.self, from: Data(json.utf8))
+  }
+
+  private func jsonString(_ value: String?) -> String {
+    guard let value else { return "null" }
+    let data = try! JSONEncoder().encode(value)
+    return String(data: data, encoding: .utf8)!
   }
 
   private enum RowEntryType {

--- a/orbitdock-server/crates/protocol/src/types.rs
+++ b/orbitdock-server/crates/protocol/src/types.rs
@@ -1097,6 +1097,97 @@ pub struct SubagentTool {
   pub is_in_progress: bool,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AgentThreadInterjectionMode {
+  Direct,
+  ParentMediated,
+  None,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AgentThreadTranscriptFreshness {
+  Live,
+  Pollable,
+  FinalOnly,
+  Unavailable,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AgentThreadCapabilities {
+  pub can_view_transcript: bool,
+  pub has_live_updates: bool,
+  pub accepts_user_input: bool,
+  pub can_interrupt: bool,
+  pub can_resume: bool,
+  pub can_close: bool,
+  pub interjection_mode: AgentThreadInterjectionMode,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AgentThreadConversationSummary {
+  pub freshness: AgentThreadTranscriptFreshness,
+  pub has_transcript: bool,
+  #[serde(default, skip_serializing_if = "Option::is_none")]
+  pub total_row_count: Option<u64>,
+  #[serde(default, skip_serializing_if = "Option::is_none")]
+  pub oldest_sequence: Option<u64>,
+  #[serde(default, skip_serializing_if = "Option::is_none")]
+  pub newest_sequence: Option<u64>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct AgentThreadSummary {
+  pub id: String,
+  pub provider: Provider,
+  pub agent_type: AgentType,
+  #[serde(default, skip_serializing_if = "Option::is_none")]
+  pub label: Option<String>,
+  pub status: SubagentStatus,
+  #[serde(default, skip_serializing_if = "Option::is_none")]
+  pub task_summary: Option<String>,
+  #[serde(default, skip_serializing_if = "Option::is_none")]
+  pub result_summary: Option<String>,
+  #[serde(default, skip_serializing_if = "Option::is_none")]
+  pub error_summary: Option<String>,
+  #[serde(default, skip_serializing_if = "Option::is_none")]
+  pub parent_thread_id: Option<String>,
+  #[serde(default, skip_serializing_if = "Option::is_none")]
+  pub model: Option<String>,
+  pub started_at: String,
+  #[serde(default, skip_serializing_if = "Option::is_none")]
+  pub last_activity_at: Option<String>,
+  #[serde(default, skip_serializing_if = "Option::is_none")]
+  pub ended_at: Option<String>,
+  pub capabilities: AgentThreadCapabilities,
+  pub conversation: AgentThreadConversationSummary,
+  #[serde(default, skip_serializing_if = "Vec::is_empty")]
+  pub limitations: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct AgentThreadListResponse {
+  pub session_id: String,
+  pub revision: u64,
+  pub threads: Vec<AgentThreadSummary>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct AgentThreadConversationPage {
+  pub session_id: String,
+  pub thread_id: String,
+  #[serde(default, skip_serializing_if = "Vec::is_empty")]
+  pub rows: Vec<crate::conversation_contracts::RowEntrySummary>,
+  pub total_row_count: u64,
+  pub has_more_before: bool,
+  #[serde(default, skip_serializing_if = "Option::is_none")]
+  pub oldest_sequence: Option<u64>,
+  #[serde(default, skip_serializing_if = "Option::is_none")]
+  pub newest_sequence: Option<u64>,
+  pub freshness: AgentThreadTranscriptFreshness,
+}
+
 /// Full session state
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SessionState {

--- a/orbitdock-server/crates/server/src/domain/agent_threads.rs
+++ b/orbitdock-server/crates/server/src/domain/agent_threads.rs
@@ -1,0 +1,314 @@
+use orbitdock_protocol::{
+  AgentThreadCapabilities, AgentThreadConversationSummary, AgentThreadInterjectionMode,
+  AgentThreadSummary, AgentThreadTranscriptFreshness, Provider, SessionState, SubagentInfo,
+  SubagentStatus,
+};
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct AgentThreadTranscriptState {
+  pub has_transcript: bool,
+  pub total_row_count: Option<u64>,
+  pub oldest_sequence: Option<u64>,
+  pub newest_sequence: Option<u64>,
+}
+
+pub(crate) fn summarize_agent_thread(
+  session: &SessionState,
+  thread: &SubagentInfo,
+  transcript: AgentThreadTranscriptState,
+) -> AgentThreadSummary {
+  let provider = thread.provider.unwrap_or(session.provider);
+  let freshness = transcript_freshness(thread.status, transcript.has_transcript);
+  let interjection_mode = interjection_mode_for(session, thread);
+  let capabilities = AgentThreadCapabilities {
+    can_view_transcript: transcript.has_transcript,
+    has_live_updates: false,
+    accepts_user_input: interjection_mode != AgentThreadInterjectionMode::None,
+    can_interrupt: false,
+    can_resume: false,
+    can_close: false,
+    interjection_mode,
+  };
+
+  AgentThreadSummary {
+    id: thread.id.clone(),
+    provider,
+    agent_type: thread.agent_type.clone(),
+    label: thread.label.clone(),
+    status: thread.status,
+    task_summary: thread.task_summary.clone(),
+    result_summary: thread.result_summary.clone(),
+    error_summary: thread.error_summary.clone(),
+    parent_thread_id: thread.parent_subagent_id.clone(),
+    model: thread.model.clone(),
+    started_at: thread.started_at.clone(),
+    last_activity_at: thread.last_activity_at.clone(),
+    ended_at: thread.ended_at.clone(),
+    capabilities,
+    conversation: AgentThreadConversationSummary {
+      freshness,
+      has_transcript: transcript.has_transcript,
+      total_row_count: transcript.total_row_count,
+      oldest_sequence: transcript.oldest_sequence,
+      newest_sequence: transcript.newest_sequence,
+    },
+    limitations: limitations_for(session, thread, provider, transcript.has_transcript),
+  }
+}
+
+pub(crate) fn parent_mediated_message(thread: &AgentThreadSummary, content: &str) -> String {
+  let label = thread.label.as_deref().unwrap_or(thread.id.as_str());
+  format!(
+    "Interjection for agent thread {label} ({id}):\n\n{content}",
+    id = thread.id,
+    content = content.trim()
+  )
+}
+
+fn transcript_freshness(
+  status: SubagentStatus,
+  has_transcript: bool,
+) -> AgentThreadTranscriptFreshness {
+  if !has_transcript {
+    return AgentThreadTranscriptFreshness::Unavailable;
+  }
+
+  if is_active_status(status) {
+    AgentThreadTranscriptFreshness::Pollable
+  } else {
+    AgentThreadTranscriptFreshness::FinalOnly
+  }
+}
+
+fn interjection_mode_for(
+  session: &SessionState,
+  thread: &SubagentInfo,
+) -> AgentThreadInterjectionMode {
+  if session.steerable && is_active_status(thread.status) {
+    AgentThreadInterjectionMode::ParentMediated
+  } else {
+    AgentThreadInterjectionMode::None
+  }
+}
+
+fn limitations_for(
+  session: &SessionState,
+  thread: &SubagentInfo,
+  provider: Provider,
+  has_transcript: bool,
+) -> Vec<String> {
+  let mut limitations = Vec::new();
+
+  if !has_transcript {
+    limitations.push("No readable agent transcript is available yet.".to_string());
+  }
+
+  if provider == Provider::Claude {
+    limitations.push(
+      "Claude subagent control is exposed through the parent session, not a direct child input channel."
+        .to_string(),
+    );
+  }
+
+  if provider == Provider::Codex {
+    limitations.push(
+      "Codex child-thread input is mediated through the parent session until OrbitDock owns a live child runtime handle."
+        .to_string(),
+    );
+  }
+
+  if !session.steerable || !is_active_status(thread.status) {
+    limitations.push("This thread is observe-only in its current state.".to_string());
+  }
+
+  limitations
+}
+
+fn is_active_status(status: SubagentStatus) -> bool {
+  matches!(
+    status,
+    SubagentStatus::Pending | SubagentStatus::Running | SubagentStatus::Interrupted
+  )
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use orbitdock_protocol::domain_events::AgentType;
+  use orbitdock_protocol::{
+    ClaudeIntegrationMode, CodexIntegrationMode, SessionControlMode, SessionLifecycleState,
+    SessionStatus, WorkStatus,
+  };
+
+  fn session(provider: Provider, steerable: bool) -> SessionState {
+    SessionState {
+      id: "session-1".to_string(),
+      provider,
+      project_path: "/tmp/project".to_string(),
+      transcript_path: None,
+      project_name: None,
+      model: None,
+      custom_name: None,
+      summary: None,
+      first_prompt: None,
+      last_message: None,
+      status: SessionStatus::Active,
+      work_status: if steerable {
+        WorkStatus::Working
+      } else {
+        WorkStatus::Waiting
+      },
+      control_mode: SessionControlMode::Direct,
+      lifecycle_state: SessionLifecycleState::Open,
+      accepts_user_input: steerable,
+      steerable,
+      pending_approval: None,
+      connector_attached: true,
+      can_interrupt: steerable,
+      permission_mode: None,
+      allow_bypass_permissions: false,
+      collaboration_mode: None,
+      multi_agent: None,
+      personality: None,
+      service_tier: None,
+      developer_instructions: None,
+      codex_config_mode: None,
+      codex_config_profile: None,
+      codex_model_provider: None,
+      codex_config_source: None,
+      codex_config_overrides: None,
+      pending_tool_name: None,
+      pending_tool_input: None,
+      pending_question: None,
+      pending_approval_id: None,
+      token_usage: Default::default(),
+      token_usage_snapshot_kind: Default::default(),
+      current_diff: None,
+      cumulative_diff: None,
+      current_plan: None,
+      codex_integration_mode: Some(CodexIntegrationMode::Direct),
+      claude_integration_mode: Some(ClaudeIntegrationMode::Direct),
+      approval_policy: None,
+      approval_policy_details: None,
+      sandbox_mode: None,
+      sandbox_policy_details: None,
+      started_at: None,
+      last_activity_at: None,
+      last_progress_at: None,
+      forked_from_session_id: None,
+      revision: Some(7),
+      current_turn_id: None,
+      turn_count: 0,
+      turn_diffs: vec![],
+      git_branch: None,
+      git_sha: None,
+      current_cwd: None,
+      subagents: vec![],
+      effort: None,
+      terminal_session_id: None,
+      terminal_app: None,
+      approval_version: None,
+      repository_root: None,
+      is_worktree: false,
+      worktree_id: None,
+      unread_count: 0,
+      mission_id: None,
+      issue_identifier: None,
+      rows: vec![],
+      total_row_count: 0,
+      has_more_before: false,
+      oldest_sequence: None,
+      newest_sequence: None,
+    }
+  }
+
+  fn thread(provider: Provider, status: SubagentStatus) -> SubagentInfo {
+    SubagentInfo {
+      id: "thread-1".to_string(),
+      agent_type: AgentType::GeneralPurpose,
+      started_at: "2026-04-23T00:00:00Z".to_string(),
+      ended_at: None,
+      provider: Some(provider),
+      label: Some("Worker".to_string()),
+      status,
+      task_summary: Some("Check the flow".to_string()),
+      result_summary: None,
+      error_summary: None,
+      parent_subagent_id: Some("parent-thread".to_string()),
+      model: None,
+      last_activity_at: None,
+    }
+  }
+
+  #[test]
+  fn active_thread_uses_parent_mediated_interjection_when_session_is_steerable() {
+    let summary = summarize_agent_thread(
+      &session(Provider::Codex, true),
+      &thread(Provider::Codex, SubagentStatus::Running),
+      AgentThreadTranscriptState {
+        has_transcript: true,
+        total_row_count: Some(3),
+        oldest_sequence: Some(0),
+        newest_sequence: Some(2),
+      },
+    );
+
+    assert_eq!(
+      summary.capabilities.interjection_mode,
+      AgentThreadInterjectionMode::ParentMediated
+    );
+    assert!(summary.capabilities.accepts_user_input);
+    assert_eq!(
+      summary.conversation.freshness,
+      AgentThreadTranscriptFreshness::Pollable
+    );
+  }
+
+  #[test]
+  fn completed_thread_is_observe_only() {
+    let summary = summarize_agent_thread(
+      &session(Provider::Claude, true),
+      &thread(Provider::Claude, SubagentStatus::Completed),
+      AgentThreadTranscriptState {
+        has_transcript: true,
+        total_row_count: None,
+        oldest_sequence: None,
+        newest_sequence: None,
+      },
+    );
+
+    assert_eq!(
+      summary.capabilities.interjection_mode,
+      AgentThreadInterjectionMode::None
+    );
+    assert!(!summary.capabilities.accepts_user_input);
+    assert_eq!(
+      summary.conversation.freshness,
+      AgentThreadTranscriptFreshness::FinalOnly
+    );
+  }
+
+  #[test]
+  fn missing_transcript_is_explicitly_unavailable() {
+    let summary = summarize_agent_thread(
+      &session(Provider::Codex, false),
+      &thread(Provider::Codex, SubagentStatus::Running),
+      AgentThreadTranscriptState {
+        has_transcript: false,
+        total_row_count: None,
+        oldest_sequence: None,
+        newest_sequence: None,
+      },
+    );
+
+    assert!(!summary.capabilities.can_view_transcript);
+    assert_eq!(
+      summary.conversation.freshness,
+      AgentThreadTranscriptFreshness::Unavailable
+    );
+    assert!(summary
+      .limitations
+      .iter()
+      .any(|item| item.contains("No readable agent transcript")));
+  }
+}

--- a/orbitdock-server/crates/server/src/domain/mod.rs
+++ b/orbitdock-server/crates/server/src/domain/mod.rs
@@ -1,3 +1,4 @@
+pub(crate) mod agent_threads;
 pub(crate) mod codex_tools;
 pub(crate) mod conversation_semantics;
 pub(crate) mod git;

--- a/orbitdock-server/crates/server/src/transport/http/agent_threads.rs
+++ b/orbitdock-server/crates/server/src/transport/http/agent_threads.rs
@@ -1,0 +1,351 @@
+use std::sync::Arc;
+
+use axum::{
+  extract::{Path, Query, State},
+  http::StatusCode,
+  Json,
+};
+use serde::Deserialize;
+
+use orbitdock_protocol::{
+  AgentThreadConversationPage, AgentThreadListResponse, AgentThreadTranscriptFreshness,
+};
+
+use super::{messaging_dispatch_error_response, session_load_error, ApiErrorResponse, ApiResult};
+use crate::{
+  domain::agent_threads::{
+    parent_mediated_message, summarize_agent_thread, AgentThreadTranscriptState,
+  },
+  infrastructure::persistence::PersistCommand,
+  runtime::{
+    message_dispatch, session_queries::load_light_session_state, session_registry::SessionRegistry,
+  },
+};
+
+const DEFAULT_AGENT_THREAD_PAGE_SIZE: usize = 50;
+const MAX_AGENT_THREAD_PAGE_SIZE: usize = 200;
+
+#[derive(Debug, Deserialize, Default)]
+pub struct AgentThreadConversationQuery {
+  #[serde(default)]
+  pub before_sequence: Option<u64>,
+  #[serde(default)]
+  pub limit: Option<usize>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct AgentThreadMessageRequest {
+  pub content: String,
+}
+
+#[derive(Debug, serde::Serialize)]
+pub struct AgentThreadMessageResponse {
+  pub accepted: bool,
+  pub thread_id: String,
+  pub interjection_mode: orbitdock_protocol::AgentThreadInterjectionMode,
+  pub row: orbitdock_protocol::conversation_contracts::RowEntrySummary,
+  #[serde(skip_serializing_if = "Option::is_none")]
+  pub session_detail_snapshot: Option<orbitdock_protocol::SessionDetailSnapshot>,
+}
+
+pub async fn list_agent_threads(
+  Path(session_id): Path<String>,
+  State(state): State<Arc<SessionRegistry>>,
+) -> ApiResult<AgentThreadListResponse> {
+  let session = load_light_session_state(&state, &session_id)
+    .await
+    .map_err(|error| session_load_error(&session_id, error))?;
+
+  let mut threads = Vec::with_capacity(session.subagents.len());
+  for thread in &session.subagents {
+    let has_transcript = super::files::resolve_subagent_transcript_path(&thread.id)
+      .await
+      .is_some();
+    threads.push(summarize_agent_thread(
+      &session,
+      thread,
+      AgentThreadTranscriptState {
+        has_transcript,
+        total_row_count: None,
+        oldest_sequence: None,
+        newest_sequence: None,
+      },
+    ));
+  }
+
+  Ok(Json(AgentThreadListResponse {
+    session_id,
+    revision: session.revision.unwrap_or_default(),
+    threads,
+  }))
+}
+
+pub async fn get_agent_thread_conversation(
+  Path((session_id, thread_id)): Path<(String, String)>,
+  Query(query): Query<AgentThreadConversationQuery>,
+  State(state): State<Arc<SessionRegistry>>,
+) -> ApiResult<AgentThreadConversationPage> {
+  let session = load_light_session_state(&state, &session_id)
+    .await
+    .map_err(|error| session_load_error(&session_id, error))?;
+  let thread = session
+    .subagents
+    .iter()
+    .find(|thread| thread.id == thread_id)
+    .ok_or_else(|| thread_not_found(&thread_id))?;
+
+  let transcript_path = super::files::resolve_subagent_transcript_path(&thread_id).await;
+  let Some(_) = transcript_path else {
+    return Ok(Json(AgentThreadConversationPage {
+      session_id,
+      thread_id,
+      rows: vec![],
+      total_row_count: 0,
+      has_more_before: false,
+      oldest_sequence: None,
+      newest_sequence: None,
+      freshness: AgentThreadTranscriptFreshness::Unavailable,
+    }));
+  };
+
+  let mut rows = super::files::load_subagent_rows(&thread_id).await;
+  for row in &mut rows {
+    row.session_id = session_id.clone();
+  }
+  let page = page_rows(rows, query.before_sequence, clamp_limit(query.limit));
+  let summary = summarize_agent_thread(
+    &session,
+    thread,
+    AgentThreadTranscriptState {
+      has_transcript: true,
+      total_row_count: Some(page.total_row_count),
+      oldest_sequence: page.oldest_sequence,
+      newest_sequence: page.newest_sequence,
+    },
+  );
+
+  Ok(Json(AgentThreadConversationPage {
+    session_id,
+    thread_id,
+    rows: page.rows,
+    total_row_count: page.total_row_count,
+    has_more_before: page.has_more_before,
+    oldest_sequence: page.oldest_sequence,
+    newest_sequence: page.newest_sequence,
+    freshness: summary.conversation.freshness,
+  }))
+}
+
+pub async fn post_agent_thread_message(
+  Path((session_id, thread_id)): Path<(String, String)>,
+  State(state): State<Arc<SessionRegistry>>,
+  Json(body): Json<AgentThreadMessageRequest>,
+) -> Result<(StatusCode, Json<AgentThreadMessageResponse>), (StatusCode, Json<ApiErrorResponse>)> {
+  let content = body.content.trim();
+  if content.is_empty() {
+    return Err((
+      StatusCode::BAD_REQUEST,
+      Json(ApiErrorResponse {
+        code: "invalid_request",
+        error: "Provide content to interject into an agent thread".to_string(),
+      }),
+    ));
+  }
+
+  let session = load_light_session_state(&state, &session_id)
+    .await
+    .map_err(|error| session_load_error(&session_id, error))?;
+  let thread = session
+    .subagents
+    .iter()
+    .find(|thread| thread.id == thread_id)
+    .ok_or_else(|| thread_not_found(&thread_id))?;
+  let summary = summarize_agent_thread(
+    &session,
+    thread,
+    AgentThreadTranscriptState {
+      has_transcript: super::files::resolve_subagent_transcript_path(&thread_id)
+        .await
+        .is_some(),
+      total_row_count: None,
+      oldest_sequence: None,
+      newest_sequence: None,
+    },
+  );
+
+  if !summary.capabilities.accepts_user_input {
+    return Err((
+      StatusCode::CONFLICT,
+      Json(ApiErrorResponse {
+        code: "agent_thread_observe_only",
+        error: summary
+          .limitations
+          .first()
+          .cloned()
+          .unwrap_or_else(|| "This agent thread is observe-only right now.".to_string()),
+      }),
+    ));
+  }
+
+  let row = message_dispatch::dispatch_steer_turn(
+    &state,
+    session_id.clone(),
+    parent_mediated_message(&summary, content),
+    vec![],
+    vec![],
+    format!("agent-thread-steer-{}", orbitdock_protocol::new_id()),
+  )
+  .await
+  .map_err(|error| messaging_dispatch_error_response(error, &session_id))?;
+
+  flush_persistence(&state).await;
+  let session_detail_snapshot =
+    crate::runtime::session_queries::load_full_session_state(&state, &session_id, false, false)
+      .await
+      .map(|session| orbitdock_protocol::SessionDetailSnapshot {
+        revision: session.revision.unwrap_or_default(),
+        session,
+      })
+      .map_err(|error| session_load_error(&session_id, error))?;
+
+  Ok((
+    StatusCode::ACCEPTED,
+    Json(AgentThreadMessageResponse {
+      accepted: true,
+      thread_id,
+      interjection_mode: summary.capabilities.interjection_mode,
+      row: row.to_transport_summary(),
+      session_detail_snapshot: Some(session_detail_snapshot),
+    }),
+  ))
+}
+
+async fn flush_persistence(state: &Arc<SessionRegistry>) {
+  let (ack_tx, ack_rx) = tokio::sync::oneshot::channel();
+  if state
+    .persist()
+    .send(PersistCommand::Flush { ack: ack_tx })
+    .await
+    .is_ok()
+  {
+    let _ = ack_rx.await;
+  }
+}
+
+fn clamp_limit(limit: Option<usize>) -> usize {
+  limit
+    .unwrap_or(DEFAULT_AGENT_THREAD_PAGE_SIZE)
+    .clamp(1, MAX_AGENT_THREAD_PAGE_SIZE)
+}
+
+fn page_rows(
+  rows: Vec<orbitdock_protocol::conversation_contracts::ConversationRowEntry>,
+  before_sequence: Option<u64>,
+  limit: usize,
+) -> orbitdock_protocol::conversation_contracts::RowPageSummary {
+  let total_row_count = rows.len() as u64;
+  let mut candidates: Vec<_> = rows
+    .into_iter()
+    .filter(|row| {
+      before_sequence
+        .map(|before| row.sequence < before)
+        .unwrap_or(true)
+    })
+    .collect();
+  let has_more_before = candidates.len() > limit;
+  let start = candidates.len().saturating_sub(limit);
+  if start > 0 {
+    candidates.drain(0..start);
+  }
+
+  let rows = candidates
+    .iter()
+    .map(|entry| entry.to_transport_summary())
+    .collect::<Vec<_>>();
+
+  orbitdock_protocol::conversation_contracts::RowPageSummary {
+    total_row_count,
+    has_more_before,
+    oldest_sequence: rows.first().map(|entry| entry.sequence),
+    newest_sequence: rows.last().map(|entry| entry.sequence),
+    rows,
+  }
+}
+
+fn thread_not_found(thread_id: &str) -> (StatusCode, Json<ApiErrorResponse>) {
+  (
+    StatusCode::NOT_FOUND,
+    Json(ApiErrorResponse {
+      code: "agent_thread_not_found",
+      error: format!("Agent thread {thread_id} not found"),
+    }),
+  )
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use orbitdock_protocol::conversation_contracts::{
+    ConversationRow, ConversationRowEntry, MessageRowContent, TurnStatus,
+  };
+
+  #[test]
+  fn page_rows_returns_bounded_latest_rows_with_total_count() {
+    let page = page_rows((0..5).map(row).collect(), None, 2);
+
+    assert_eq!(page.total_row_count, 5);
+    assert!(page.has_more_before);
+    assert_eq!(page.oldest_sequence, Some(3));
+    assert_eq!(page.newest_sequence, Some(4));
+    assert_eq!(
+      page
+        .rows
+        .iter()
+        .map(|entry| entry.sequence)
+        .collect::<Vec<_>>(),
+      vec![3, 4]
+    );
+  }
+
+  #[test]
+  fn page_rows_honors_before_sequence() {
+    let page = page_rows((0..5).map(row).collect(), Some(4), 2);
+
+    assert_eq!(page.total_row_count, 5);
+    assert!(page.has_more_before);
+    assert_eq!(
+      page
+        .rows
+        .iter()
+        .map(|entry| entry.sequence)
+        .collect::<Vec<_>>(),
+      vec![2, 3]
+    );
+  }
+
+  #[test]
+  fn clamp_limit_keeps_agent_thread_pages_in_bounds() {
+    assert_eq!(clamp_limit(None), DEFAULT_AGENT_THREAD_PAGE_SIZE);
+    assert_eq!(clamp_limit(Some(0)), 1);
+    assert_eq!(clamp_limit(Some(500)), MAX_AGENT_THREAD_PAGE_SIZE);
+  }
+
+  fn row(sequence: u64) -> ConversationRowEntry {
+    ConversationRowEntry {
+      session_id: "child-thread".to_string(),
+      sequence,
+      turn_id: None,
+      turn_status: TurnStatus::Active,
+      row: ConversationRow::Assistant(MessageRowContent {
+        id: format!("row-{sequence}"),
+        content: format!("message {sequence}"),
+        turn_id: None,
+        timestamp: None,
+        is_streaming: false,
+        images: vec![],
+        memory_citation: None,
+        delivery_status: None,
+      }),
+    }
+  }
+}

--- a/orbitdock-server/crates/server/src/transport/http/files.rs
+++ b/orbitdock-server/crates/server/src/transport/http/files.rs
@@ -183,7 +183,7 @@ fn read_directory_entries(target: &PathBuf) -> Result<Vec<DirectoryEntry>, std::
   Ok(listing)
 }
 
-async fn load_subagent_tools(subagent_id: &str) -> Vec<SubagentTool> {
+pub(crate) async fn load_subagent_tools(subagent_id: &str) -> Vec<SubagentTool> {
   match resolve_subagent_transcript_path(subagent_id).await {
     Some(path) => {
       let parse_path = path.clone();
@@ -197,7 +197,7 @@ async fn load_subagent_tools(subagent_id: &str) -> Vec<SubagentTool> {
   }
 }
 
-async fn load_subagent_rows(subagent_id: &str) -> Vec<ConversationRowEntry> {
+pub(crate) async fn load_subagent_rows(subagent_id: &str) -> Vec<ConversationRowEntry> {
   let Some(path) = resolve_subagent_transcript_path(subagent_id).await else {
     return vec![];
   };
@@ -207,7 +207,7 @@ async fn load_subagent_rows(subagent_id: &str) -> Vec<ConversationRowEntry> {
     .unwrap_or_default()
 }
 
-async fn resolve_subagent_transcript_path(subagent_id: &str) -> Option<String> {
+pub(crate) async fn resolve_subagent_transcript_path(subagent_id: &str) -> Option<String> {
   // Check persisted path first
   if let Ok(Some(path)) = load_subagent_transcript_path(subagent_id).await {
     return Some(path);

--- a/orbitdock-server/crates/server/src/transport/http/mod.rs
+++ b/orbitdock-server/crates/server/src/transport/http/mod.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+mod agent_threads;
 mod approvals;
 mod capabilities;
 mod codex_auth;
@@ -31,6 +32,9 @@ use axum::{
 };
 use serde::{Deserialize, Serialize};
 
+pub use agent_threads::{
+  get_agent_thread_conversation, list_agent_threads, post_agent_thread_message,
+};
 pub use approvals::{
   answer_question, approve_tool, delete_approval_endpoint, list_approvals_endpoint,
   respond_to_permission_request,

--- a/orbitdock-server/crates/server/src/transport/http/router.rs
+++ b/orbitdock-server/crates/server/src/transport/http/router.rs
@@ -192,6 +192,18 @@ fn session_attachment_routes() -> Router<Arc<SessionRegistry>> {
 fn session_support_routes() -> Router<Arc<SessionRegistry>> {
   Router::new()
     .route(
+      "/api/sessions/{session_id}/agent-threads",
+      get(super::list_agent_threads),
+    )
+    .route(
+      "/api/sessions/{session_id}/agent-threads/{thread_id}/conversation",
+      get(super::get_agent_thread_conversation),
+    )
+    .route(
+      "/api/sessions/{session_id}/agent-threads/{thread_id}/message",
+      post(super::post_agent_thread_message),
+    )
+    .route(
       "/api/sessions/{session_id}/subagents/{subagent_id}/tools",
       get(super::list_subagent_tools_endpoint),
     )

--- a/plans/agent-threads.md
+++ b/plans/agent-threads.md
@@ -52,16 +52,19 @@ For this first production pass:
 
 ## UI
 
-Replace the detail-heavy worker inspector with an Agent Threads sidecar:
+Use the worker sidecar as the entry point, then open the selected child thread
+in OrbitDock's normal conversation surface:
 
 - native roster remains compact and scannable
-- selected worker shows a mini conversation timeline using existing row
-  renderers where possible
-- explicit capability strip explains what OrbitDock can do for the selected
-  provider/thread
-- composer appears only when the server reports an input capability
-- parent-mediated interjection is labeled as such
-- graph/related workers stay visible but secondary
+- selected agent thread routes the main pane to `ConversationView`
+- agent-thread pages reuse normal conversation paging, row rendering, follow
+  state, and jump-to-latest behavior
+- the bespoke worker detail inspector remains for legacy subagent payloads, but
+  agent-thread rows do not open a special transcript panel
+- the direct parent composer is suppressed while a child thread is open so input
+  is not accidentally sent to the wrong conversation
+- provider capabilities stay on the server contract so a future normal-composer
+  interjection path can be added without Swift guessing provider behavior
 
 ## Testing
 
@@ -82,7 +85,7 @@ Use the testing philosophy:
 - [x] Add Swift protocol/API client types
 - [x] Add session API methods
 - [x] Update worker scene model to load agent-thread details
-- [x] Build conversation-first Agent Threads UI
+- [x] Build conversation-first Agent Threads routing
 - [x] Add Rust tests
 - [x] Add Swift tests
 - [x] Run Rust checks/tests

--- a/plans/agent-threads.md
+++ b/plans/agent-threads.md
@@ -1,0 +1,90 @@
+# Agent Threads
+
+## Goal
+
+Make Codex and Claude workers feel like real child conversations in OrbitDock:
+visible, inspectable, provider-honest, and steerable only when the server can
+prove the provider/thread supports it.
+
+The current worker sidecar is useful, but it flattens real agent work into
+summary cards. This plan turns that sidecar into a first-class `agent-threads`
+surface without overloading WebSocket or pushing provider inference into Swift.
+
+## Invariants
+
+- The Rust server owns agent-thread capabilities and transcript availability.
+- HTTP owns agent-thread bootstrap, transcript reads, pagination, and mutations.
+- WebSocket remains light: existing session/detail invalidations plus future
+  targeted child-row deltas/refetch hints.
+- Swift renders server truth and does not infer steerability from provider names,
+  transcript presence, or worker status alone.
+- Provider differences are product facts, not bugs. Codex can expose richer
+  child-thread control than Claude; Claude can still provide a strong observer
+  and transcript experience when transcript paths exist.
+
+## Contract
+
+Add a session-scoped resource:
+
+- `GET /api/sessions/{session_id}/agent-threads`
+- `GET /api/sessions/{session_id}/agent-threads/{thread_id}/conversation?limit=...&before_sequence=...`
+- `POST /api/sessions/{session_id}/agent-threads/{thread_id}/message`
+
+Summary rows include:
+
+- thread identity and parent id
+- provider, role, label, status, model, timestamps
+- task/result/error summaries
+- `conversation`: row counts, newest/oldest sequence, availability/freshness
+- `capabilities`: `can_view_transcript`, `has_live_updates`, `accepts_user_input`,
+  `can_interrupt`, `can_resume`, `can_close`, `interjection_mode`
+- `limitations`: short provider-honest explanation when actions are disabled
+
+For this first production pass:
+
+- Codex direct child conversation viewing is supported through rollout transcript
+  lookup.
+- Codex child-thread input is parent-mediated while OrbitDock does not own a
+  supported live child runtime handle.
+- Claude transcript viewing is supported when a transcript path can be resolved.
+- Claude interjection is parent-mediated because the current hook/CLI path does
+  not expose a supported direct child input channel.
+
+## UI
+
+Replace the detail-heavy worker inspector with an Agent Threads sidecar:
+
+- native roster remains compact and scannable
+- selected worker shows a mini conversation timeline using existing row
+  renderers where possible
+- explicit capability strip explains what OrbitDock can do for the selected
+  provider/thread
+- composer appears only when the server reports an input capability
+- parent-mediated interjection is labeled as such
+- graph/related workers stay visible but secondary
+
+## Testing
+
+Use the testing philosophy:
+
+- test pure capability planning without provider mocks
+- test HTTP outcomes for users: summaries expose correct capabilities and
+  conversation pages return bounded rows
+- test Swift presentation planning from protocol values rather than view internals
+- avoid sleeps/polling; async tests wait on real returned values/events
+
+## Checklist
+
+- [x] Add typed protocol contracts for agent threads
+- [x] Add server planner for provider capabilities and transcript metrics
+- [x] Add HTTP endpoints and routing
+- [x] Reuse existing subagent transcript parsing behind the new surface
+- [x] Add Swift protocol/API client types
+- [x] Add session API methods
+- [x] Update worker scene model to load agent-thread details
+- [x] Build conversation-first Agent Threads UI
+- [x] Add Rust tests
+- [x] Add Swift tests
+- [x] Run Rust checks/tests
+- [x] Run macOS build/tests
+- [ ] Commit and open PR


### PR DESCRIPTION
## What changed

- Added a server-owned `agent-threads` HTTP surface for listing child threads, reading bounded transcript pages, and sending provider-honest parent-mediated interjections.
- Added typed Rust and Swift protocol contracts for capabilities, transcript freshness, limitations, conversation pages, and message responses.
- Kept the worker sidecar as the compact thread roster, then routes the selected agent thread through OrbitDock's normal `ConversationView` with shared row rendering, paging, follow state, and jump-to-latest behavior.
- Removed the bespoke agent-thread transcript/composer detail panel so child threads behave like normal conversations instead of a special inspector surface.
- Added a source-of-truth implementation plan in `plans/agent-threads.md`.

## Verification

- `make rust-fmt-check`
- `make rust-check`
- `make rust-test`
- `make build`
- `make test-unit XCODEBUILD_ARGS='-only-testing:OrbitDockTests/ConversationViewModelTests -only-testing:OrbitDockTests/SessionWorkerRosterPlannerTests'`
- `make test-unit`
